### PR TITLE
Warn about NEO addresses only when they have transactions

### DIFF
--- a/client/app/src/services/neo-api.service.js
+++ b/client/app/src/services/neo-api.service.js
@@ -1,40 +1,33 @@
 ;(function () {
   'use strict'
 
+  /**
+   * Example of NEO address with transactions: AYJXuFBfUyELoTe3wXEzPkq5RcsHsF58uW
+   */
   angular.module('arkclient.services')
     .service('neoApiService', ['$q', '$http', NeoApiService])
 
   function NeoApiService ($q, $http) {
-    const ark = require(require('path').resolve(__dirname, '../node_modules/arkjs'))
     const baseUrl = 'https://neoscan.io/api/main_net/v1'
 
-    /*
-      returns {"unclaimed": <value>, "address":"<address>"}
-    */
-    function getUnClaimed (address) {
-      const deferred = $q.defer()
-      $http.get(baseUrl + '/get_unclaimed/' + address)
-        .then(r => r.status === 200 && r.data ? deferred.resolve(r.data) : deferred.reject('Error'))
-        .catch(err => deferred.reject(err))
-      return deferred.promise
+    function getTxs (address) {
+      return new Promise((resolve, reject) => {
+        $http.get(`${baseUrl}/get_last_transactions_by_address/${address}`)
+          .then(({ data }) => {
+            Array.isArray(data) && data.length ? resolve() : reject(new Error('Empty NEO address'))
+          })
+          .catch(reject)
+      })
     }
 
     function doesAddressExist (address) {
-      // we use the getunclaimed call, because it's fast, if the address exists (i.e. has any transactions), the address is returned
-      // we check if it's a real address (and not "not found") and return the result
-      return getUnClaimed(address)
-        .then(r => isValidAddress(r.address))
+      return getTxs(address)
+        .then(_ => true)
         .catch(() => false)
     }
 
-    function isValidAddress (address) {
-      // since NEO addresses are the same as ARK addresses, we can use the ark validateAddress method ;)
-      // however we have to "hardcode the version", since it's not "network dependant" (e.g. devNet has another version)
-      return ark.crypto.validateAddress(address, 0x17)
-    }
-
     return {
-      doesAddressExist: doesAddressExist
+      doesAddressExist
     }
   }
 })()

--- a/client/app/src/services/transaction-sender.service.js
+++ b/client/app/src/services/transaction-sender.service.js
@@ -205,6 +205,7 @@
         }
 
         const currentCycle = ++receiverValidationCycle
+
         accountService.getTransactions(input, 0, 1).then(txs => {
           // if this check is not true it means that the address has already been changed in the meantime and we can
           // ignore the result, also if a failType is already set, we return, because we don't want to overwrite a warning or error


### PR DESCRIPTION
On the send transaction dialog, it's more common than expected that addresses are flagged as NEO.

The problem was that our current implementation was expecting that the NEO API endpoint returned a different response when NEO addresses have transactions. Instead it was asking about the unclaimed GAS.