### PR TITLE
fix: make it possible to input small numbers into the input field

### DIFF
--- a/src/renderer/components/Input/InputCurrency.vue
+++ b/src/renderer/components/Input/InputCurrency.vue
@@ -272,7 +272,10 @@ export default {
     updateInputValue (value) {
       // Ignore empty and not valid values
       if (value && this.checkAmount(value)) {
-        this.inputValue = value.toString().replace(',', '.')
+        let number = Number(value.toString().replace(',', '.'))
+        number.toString().includes('-')
+          ? this.inputValue = number.toFixed(number.toString().split('-')[1]) // Small numbers will be like 1e-7 so we use the number after '-' for toFixed()
+          : this.inputValue = value.toString().replace(',', '.')
         // Inform Vuelidate that the value changed
         this.$v.model.$touch()
         return true


### PR DESCRIPTION
## Proposed changes

You couldn't input 0.0000001 as it would be turned into 1e-7:

<img width="374" alt="schermafbeelding 2018-12-04 om 20 26 58" src="https://user-images.githubusercontent.com/35610748/49469654-5f791e00-f808-11e8-9be6-176ec41f1a97.png">

Now it's fixed and possible to input the correct amount:

<img width="335" alt="schermafbeelding 2018-12-04 om 21 01 43" src="https://user-images.githubusercontent.com/35610748/49469663-67d15900-f808-11e8-925c-5f2340bcefa8.png">


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
