### PR TITLE
feat: make it possible to remove the set name of a wallet

### DIFF
--- a/src/renderer/components/Wallet/WalletRenameModal.vue
+++ b/src/renderer/components/Wallet/WalletRenameModal.vue
@@ -90,7 +90,9 @@ export default {
     schema: {
       name: {
         doesNotExists (value) {
-          return value === this.wallet.name || !this.$store.getters['wallet/byName'](value)
+          return value === '' ||
+            value === this.wallet.name ||
+            !this.$store.getters['wallet/byName'](value)
         }
       }
     }


### PR DESCRIPTION
## Proposed changes

It wasn't possible to remove the name of a wallet, as you would get an error saying that `''` was already taken as a wallet name. This PR makes it possible to rename a wallet to `''` again so it reverts to the original address (or delegate / contact name).

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
