### PR TITLE
fix: add bottom margin to wallet list

### DIFF
--- a/src/renderer/pages/Contact/ContactAll.vue
+++ b/src/renderer/pages/Contact/ContactAll.vue
@@ -3,7 +3,7 @@
     <h3>{{ $t('PAGES.CONTACT_ALL.HEADER') }}</h3>
 
     <div class="ContactAll__grid mt-10 justify-center">
-      <div class="ContactAll__grid__contact w-full overflow-hidden bg-theme-feature lg:bg-transparent rounded-lg border-theme-wallet-overview-border border-b border-r">
+      <div class="ContactAll__grid__contact w-full overflow-hidden bg-theme-feature lg:bg-transparent rounded-lg border-theme-wallet-overview-border border-b border-r mb-3">
         <div class="flex flex-row items-center">
           <router-link :to="{ name: 'contact-new' }">
             <WalletIdenticonPlaceholder
@@ -25,7 +25,7 @@
       <div
         v-for="contact in contacts"
         :key="contact.id"
-        class="ContactAll__grid__contact w-full overflow-hidden bg-theme-feature lg:bg-transparent rounded-lg border-theme-wallet-overview-border border-b border-r"
+        class="ContactAll__grid__contact w-full overflow-hidden bg-theme-feature lg:bg-transparent rounded-lg border-theme-wallet-overview-border border-b border-r mb-3"
       >
         <div class="flex flex-row items-center">
           <router-link

--- a/src/renderer/pages/Wallet/WalletAll.vue
+++ b/src/renderer/pages/Wallet/WalletAll.vue
@@ -85,7 +85,7 @@
           <div
             v-for="wallet in selectableWallets"
             :key="wallet.id"
-            class="WalletAll__grid__wallet w-full overflow-hidden bg-theme-feature lg:bg-transparent rounded-lg border-theme-wallet-overview-border border-b border-r"
+            class="WalletAll__grid__wallet w-full overflow-hidden bg-theme-feature lg:bg-transparent rounded-lg border-theme-wallet-overview-border border-b border-r mb-3"
           >
             <div class="flex flex-row items-center">
               <router-link


### PR DESCRIPTION
## Proposed changes

One of the things as suggested in #645 was to add a margin to the wallet overviews.

## Types of changes

- [x] Other... Please describe: visual

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
