### PR TITLE
fix: use sender instead of recipient for sender links

### DIFF
--- a/src/renderer/components/Transaction/TransactionShow.vue
+++ b/src/renderer/components/Transaction/TransactionShow.vue
@@ -67,7 +67,7 @@
             content: `${$t('TRANSACTION.OPEN_IN_EXPLORER')}`,
             trigger: 'hover'
           }"
-          @click="openAddress(transaction.recipient)"
+          @click="openAddress(transaction.sender)"
         >
           <SvgIcon
             name="open-external"


### PR DESCRIPTION
## Proposed changes

Sender incorrectly pointed to recipient in explorer, fixes #657 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes

