### PR TITLE
feat: disable send all button when funds are too low to send all

### DIFF
--- a/src/renderer/components/Transaction/TransactionForm/TransactionFormTransfer.vue
+++ b/src/renderer/components/Transaction/TransactionForm/TransactionFormTransfer.vue
@@ -32,6 +32,7 @@
       <InputSwitch
         :text="$t('TRANSACTION.SEND_ALL')"
         :is-active="isSendAllActive"
+        :is-disabled="!canSendAll()"
         @change="onSendAll"
       />
     </div>
@@ -226,8 +227,12 @@ export default {
       this.ensureAvailableAmount()
     },
 
+    canSendAll () {
+      return this.maximumAvailableAmount > 0
+    },
+
     ensureAvailableAmount () {
-      if (this.isSendAllActive) {
+      if (this.isSendAllActive && this.canSendAll()) {
         this.$set(this.form, 'amount', this.maximumAvailableAmount)
       }
     },


### PR DESCRIPTION
## Proposed changes

Disables the "Send all" toggle when there are not enough funds available to cover amount + fees. Proposed by @zillion in response to #652 

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
