### PR TITLE
fix: get ledger wallet first from route

### DIFF
--- a/src/renderer/mixins/wallet.js
+++ b/src/renderer/mixins/wallet.js
@@ -10,16 +10,14 @@ export default {
       }
 
       const address = params.address
-      let wallet = this.$store.getters['wallet/byAddress'](address)
-
-      if (this.$store.getters['ledger/isConnected'] && !wallet) {
+      if (this.$store.getters['ledger/isConnected']) {
         const ledgerWallet = this.$store.getters['ledger/wallet'](address)
         if (ledgerWallet) {
-          wallet = ledgerWallet
+          return ledgerWallet
         }
       }
 
-      return wallet
+      return this.$store.getters['wallet/byAddress'](address)
     }
   },
 


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

This fixes an issue where it checked for a ledger wallet only if the local database didn't have a record. This caused issues if the ledger wallet was added as a contact, for example. Meaning when a ledger wallet was plugged in and viewed, the wallet thought it was a contact, resulting in the inability to send transactions.

Resolves #634 

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
