### PR TITLE
fix: add workaround to have camera stream loaded before closing

### DIFF
--- a/src/renderer/components/Modal/ModalQrCodeScanner.vue
+++ b/src/renderer/components/Modal/ModalQrCodeScanner.vue
@@ -1,6 +1,7 @@
 <template>
   <ModalWindow
     :title="title"
+    :allow-close="!isLoading"
     portal-target="qr-scan"
     @close="emitClose"
   >
@@ -62,7 +63,6 @@ export default {
         }
       }
     },
-
     title () {
       return this.$t('MODAL_QR_SCANNER.TITLE')
     }
@@ -88,7 +88,7 @@ export default {
           this.errorMessage = this.$t('MODAL_QR_SCANNER.ERROR.STREAM')
         }
       } finally {
-        this.isLoading = false
+        setTimeout(() => { this.isLoading = false }, 1000)
       }
     },
 


### PR DESCRIPTION
## Proposed changes

Adds a workaround to have the camera stream loaded before closing the component, which could result in the camera staying on as it was unable to properly close the stream. I've opened an issue in the repo of the QR scanner component we use, but so far the workaround proposed there did not solve it.

Testing it can be done as follows:

- Without the fix: go to the send screen and press the QR code and immediately close the modal (e.g. by clicking outside of it). The camera should turn (you can see this if you have a camera light indicator) on slightly after the modal is closed, but won't turn off unless you reload the wallet.
- With fix: go to the send screen and press the QR code and immediately start clicking outside (keep clicking) to close the modal as soon as the `isLoading` property is set to false. This _should_ result in the camera being properly closed after the modal is closed.

Fixes #637

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklistt

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
