### PR TITLE
feat: show public key of newly created address in wallet

### DIFF
--- a/src/renderer/pages/Wallet/WalletImport.vue
+++ b/src/renderer/pages/Wallet/WalletImport.vue
@@ -263,6 +263,9 @@ export default {
         ...this.schema,
         profileId: this.session_profile.id
       }
+      if (!this.useOnlyAddress) {
+        this.wallet.publicKey = WalletService.getPublicKeyFromPassphrase(this.wallet.passphrase)
+      }
 
       if (!this.useOnlyAddress && this.walletPassword && this.walletPassword.length) {
         this.showEncryptLoader = true

--- a/src/renderer/pages/Wallet/WalletNew.vue
+++ b/src/renderer/pages/Wallet/WalletNew.vue
@@ -378,6 +378,7 @@ export default {
         ...this.schema,
         profileId: this.session_profile.id
       }
+      this.wallet.publicKey = WalletService.getPublicKeyFromPassphrase(this.wallet.passphrase)
 
       if (this.walletPassword && this.walletPassword.length) {
         this.showEncryptLoader = true

--- a/src/renderer/services/wallet.js
+++ b/src/renderer/services/wallet.js
@@ -41,6 +41,11 @@ export default class WalletService {
     return crypto.getAddress(publicKey, pubKeyHash)
   }
 
+  /**
+   * Generates the public key belonging to the given passphrase
+   * @param {String} passphrase
+   * @return {String}
+   */
   static getPublicKeyFromPassphrase (passphrase) {
     return crypto.getKeys(passphrase).publicKey
   }

--- a/src/renderer/services/wallet.js
+++ b/src/renderer/services/wallet.js
@@ -41,6 +41,10 @@ export default class WalletService {
     return crypto.getAddress(publicKey, pubKeyHash)
   }
 
+  static getPublicKeyFromPassphrase (passphrase) {
+    return crypto.getKeys(passphrase).publicKey
+  }
+
   /**
    * Check if a specific address contain data in the NEO Blockchain
    * @param {String} address


### PR DESCRIPTION
## Proposed changes

Show the public key also for wallets that are not on the blockchain yet, fixes #648 

This only works for importing an address by passphrase, or when generating a new one. In case of just an address we cannot determine the public key, so that one will be updated automatically when the wallets sends its first transaction.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
