### PR TITLE
fix: include the Ledger wallets when computing the total balance

### DIFF
--- a/__tests__/unit/pages/Profile/ProfileAll.spec.js
+++ b/__tests__/unit/pages/Profile/ProfileAll.spec.js
@@ -14,6 +14,7 @@ describe('pages > ProfileAll', () => {
   let networks
   let profiles
   let wallets
+  let ledgerWallets
 
   const mountPage = () => {
     const networkBy = (attr, value) => networks.find(network => network[attr] === value)
@@ -26,15 +27,19 @@ describe('pages > ProfileAll', () => {
       mocks: {
         $store: {
           getters: {
+            'ledger/wallets': ledgerWallets,
             'network/byId': id => networkBy('id', id),
             'network/byToken': token => networkBy('token', token),
             'network/bySymbol': symbol => networkBy('symbol', symbol),
             'profile/all': profiles,
-            'profile/balance': _id => 13700000,
+            'profile/balanceWithLedger': _id => 13700000,
             'wallet/byProfileId': id => wallets[id]
           }
         },
-        formatter_networkCurrency: jest.fn()
+        formatter_networkCurrency: jest.fn(),
+        session_network: {
+          id: 'main'
+        }
       }
     })
   }
@@ -69,6 +74,7 @@ describe('pages > ProfileAll', () => {
         { address: 'D1', balance: 50900000 }
       ]
     }
+    ledgerWallets = []
   })
 
   it('should render component', () => {
@@ -100,6 +106,39 @@ describe('pages > ProfileAll', () => {
         })
       })
     })
+
+    describe('when the Ledger has wallets on the current network', () => {
+      beforeEach(() => {
+        ledgerWallets = [
+          { address: 'MxLedger0', balance: 9883102007 },
+          { address: 'MxLedger1', balance: 6723900701 }
+        ]
+      })
+
+      it('should include their balances', () => {
+        wrapper = mountPage()
+        expect(wrapper.vm.aggregatedBalances).toEqual({
+          main: 66622093608,
+          other: 12190000,
+          dev: 52010000
+        })
+      })
+
+      describe('when they are included as non-Ledger wallets', () => {
+        beforeEach(() => {
+          ledgerWallets[1] = wallets.p1[1]
+        })
+
+        it('should include those wallets only 1 time', () => {
+          wrapper = mountPage()
+          expect(wrapper.vm.aggregatedBalances).toEqual({
+            main: 59898192907,
+            other: 12190000,
+            dev: 52010000
+          })
+        })
+      })
+    })
   })
 
   describe('totalBalances', () => {
@@ -110,6 +149,24 @@ describe('pages > ProfileAll', () => {
         'o0.1219',
         'd0.5201'
       ])
+    })
+
+    describe('when the Ledger has wallets on the current network', () => {
+      beforeEach(() => {
+        ledgerWallets = [
+          { address: 'MxLedger0', balance: 9883102007 },
+          { address: 'MxLedger1', balance: 6723900701 }
+        ]
+      })
+
+      it('should include their balances', () => {
+        wrapper = mountPage()
+        expect(wrapper.vm.totalBalances).toEqual([
+          'm666.22093608',
+          'o0.1219',
+          'd0.5201'
+        ])
+      })
     })
   })
 

--- a/__tests__/unit/pages/Wallet/WalletAll.spec.js
+++ b/__tests__/unit/pages/Wallet/WalletAll.spec.js
@@ -30,7 +30,7 @@ describe('pages > WalletAll', () => {
           getters: {
             'ledger/isConnected': false,
             'ledger/wallets': ledgerWallets,
-            'profile/balance': jest.fn(),
+            'profile/balanceWithLedger': jest.fn(),
             'wallet/byProfileId': id => wallets
           }
         },

--- a/src/renderer/pages/Profile/ProfileAll.vue
+++ b/src/renderer/pages/Profile/ProfileAll.vue
@@ -97,7 +97,8 @@ export default {
       return 'pages/new-profile-avatar.svg'
     },
     /**
-     * Returns the sum of balances of all profile of each network
+     * Returns the sum of balances of all profile of each network and the Ledger
+     * wallets
      * @return {Object}
      */
     aggregatedBalances () {
@@ -108,6 +109,15 @@ export default {
           [profile.networkId]: (all[profile.networkId] || []).concat(wallets)
         }
       }, {})
+
+      // Add the Ledger wallets of the current network only
+      if (!walletsByNetwork[this.session_network.id]) {
+        walletsByNetwork[this.session_network.id] = []
+      }
+      walletsByNetwork[this.session_network.id] = [
+        ...walletsByNetwork[this.session_network.id],
+        ...this.$store.getters['ledger/wallets']
+      ]
 
       return mapValues(walletsByNetwork, wallets => {
         return uniqBy(wallets, 'address').reduce((total, wallet) => total + wallet.balance, 0)
@@ -158,7 +168,7 @@ export default {
     },
 
     profileBalance (profile) {
-      const balance = this.$store.getters['profile/balance'](profile.id)
+      const balance = this.$store.getters['profile/balanceWithLedger'](profile.id)
       const network = this.$store.getters['network/byId'](profile.networkId)
       const amount = this.currency_subToUnit(balance, network)
       return this.currency_format(amount, { currency: network.symbol, maximumFractionDigits: network.fractionDigits })

--- a/src/renderer/pages/Wallet/WalletAll.vue
+++ b/src/renderer/pages/Wallet/WalletAll.vue
@@ -166,7 +166,7 @@ export default {
       return this.session_network.market.enabled
     },
     totalBalance () {
-      return this.$store.getters['profile/balance'](this.session_profile.id)
+      return this.$store.getters['profile/balanceWithLedger'](this.session_profile.id)
     },
     price () {
       return this.$store.getters['market/lastPrice']

--- a/src/renderer/store/modules/profile.js
+++ b/src/renderer/store/modules/profile.js
@@ -1,4 +1,4 @@
-import { map } from 'lodash'
+import { map, uniqBy } from 'lodash'
 import crypto from 'crypto'
 import BaseModule from '../base'
 import ProfileModel from '@/models/profile'
@@ -14,6 +14,22 @@ export default new BaseModule(ProfileModel, {
     balance: (state, _, __, rootGetters) => id => {
       const wallets = rootGetters['wallet/byProfileId'](id)
       return wallets.reduce((total, wallet) => {
+        return total + wallet.balance
+      }, 0)
+    },
+    balanceWithLedger: (state, _, __, rootGetters) => id => {
+      let wallets = rootGetters['wallet/byProfileId'](id)
+
+      // Only include the wallets of the Ledger that are on the same network than the profile
+      const profile = rootGetters['profile/byId'](id)
+      if (profile.networkId === rootGetters['session/network'].id) {
+        wallets = [
+          ...wallets,
+          ...rootGetters['ledger/wallets']
+        ]
+      }
+
+      return uniqBy(wallets, 'address').reduce((total, wallet) => {
         return total + wallet.balance
       }, 0)
     }


### PR DESCRIPTION
## Proposed changes
This PR includes the balance of the Ledger wallets on the wallets page and the profiles page. On the profiles page it only includes the balance of the wallets of the current network.

Resolves https://github.com/ArkEcosystem/desktop-wallet/issues/632.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Test (adding missing tests or fixing existing tests)

## Checklist
- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works