### PR TITLE
chore: add a new version  (`test:e2e:build`) of the script to run E2E tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
           command: yarn test:unit --ci --maxWorkers 4
       - run:
           name: e2e tests
-          command: yarn test:e2e:build
+          command: yarn test:e2e:full
       - run:
           name: Lint
           command: yarn lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
           command: yarn test:unit --ci --maxWorkers 4
       - run:
           name: e2e tests
-          command: yarn test:e2e
+          command: yarn test:e2e:build
       - run:
           name: Lint
           command: yarn lint

--- a/README.md
+++ b/README.md
@@ -85,8 +85,11 @@ yarn test:unit:coverage
 # Run unit tests and watch for changes to re-run the tests
 yarn test:unit:watch
 
-# Run end-to-end tests
+# Run end-to-end tests, without building the application
 yarn test:e2e
+
+# Build the application and run end-to-end tests
+yarn test:e2e:build
 ```
 
 ## Security

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ yarn test:unit:watch
 yarn test:e2e
 
 # Build the application and run end-to-end tests
-yarn test:e2e:build
+yarn test:e2e:full
 ```
 
 ## Security

--- a/package.json
+++ b/package.json
@@ -37,8 +37,9 @@
     "pack:main": "cross-env NODE_ENV=production webpack --progress --colors --config .electron-vue/webpack.main.config.js",
     "pack:renderer": "cross-env NODE_ENV=production webpack --progress --colors --config .electron-vue/webpack.renderer.config.js",
     "postinstall": "electron-builder install-app-deps",
-    "test": "npm run test:unit && npm run test:e2e",
-    "test:e2e": "npm run pack && jest --config __tests__/e2e.jest.conf.js",
+    "test": "npm run test:unit && npm run test:e2e:build",
+    "test:e2e": "jest --config __tests__/e2e.jest.conf.js",
+    "test:e2e:build": "npm run pack && npm run test:e2e",
     "test:unit": "jest --config __tests__/unit.jest.conf.js",
     "test:unit:coverage": "jest --config __tests__/unit.jest.conf.js --coverage",
     "test:unit:watch": "jest --config __tests__/unit.jest.conf.js --watch"

--- a/package.json
+++ b/package.json
@@ -38,9 +38,9 @@
     "pack:main": "cross-env NODE_ENV=production webpack --progress --colors --config .electron-vue/webpack.main.config.js",
     "pack:renderer": "cross-env NODE_ENV=production webpack --progress --colors --config .electron-vue/webpack.renderer.config.js",
     "postinstall": "electron-builder install-app-deps",
-    "test": "npm run test:unit && npm run test:e2e:build",
+    "test": "npm run test:unit && npm run test:e2e:full",
     "test:e2e": "jest --config __tests__/e2e.jest.conf.js",
-    "test:e2e:build": "npm run pack && npm run test:e2e",
+    "test:e2e:full": "npm run pack && npm run test:e2e",
     "test:unit": "jest --config __tests__/unit.jest.conf.js",
     "test:unit:coverage": "jest --config __tests__/unit.jest.conf.js --coverage",
     "test:unit:watch": "jest --config __tests__/unit.jest.conf.js --watch"


### PR DESCRIPTION
## Proposed changes
Basically, this would be useful when executing E2E tests without changing the files of `src`.

## Types of changes
- [x] Build (changes that affect the build system)

## Checklist
- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [x] I have added necessary documentation (if appropriate)