### PR TITLE
refactor: separate logo in the sidebar

### DIFF
--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -21,7 +21,7 @@
       <AppSidemenu
         v-if="hasAnyProfile"
         :is-horizontal="true"
-        class="flex lg:hidden"
+        class="block lg:hidden"
       />
       <section
         :style="background ? `backgroundImage: url('${assets_loadImage(background)}')` : ''"
@@ -36,7 +36,7 @@
         >
           <AppSidemenu
             v-if="hasAnyProfile"
-            class="hidden lg:flex"
+            class="hidden lg:block"
           />
           <RouterView class="flex-1 overflow-y-auto" />
         </div>

--- a/src/renderer/components/App/AppSidemenu/AppSidemenu.vue
+++ b/src/renderer/components/App/AppSidemenu/AppSidemenu.vue
@@ -1,125 +1,130 @@
 <template>
   <MenuNavigation
     v-model="activeItem"
-    :class="isHorizontal ? 'h-18 flex-row' : 'w-22 mx-6 rounded-lg flex-col'"
-    class="AppSidemenu justify-between relative"
+    :class="{
+      'AppSidemenu--horizontal': isHorizontal,
+      'AppSidemenu--vertical': !isHorizontal
+    }"
+    class="AppSidemenu relative bg-transparent"
   >
-    <div :class="{'flex flex-row h-18' : isHorizontal}">
+    <div
+      class="AppSidemenu__container flexify w-full h-full justify-between"
+    >
       <!-- ARK logo -->
       <RouterLink
         :title="$t('APP_SIDEMENU.DASHBOARD')"
         :to="{ name: 'dashboard' }"
-        :class="isHorizontal ? 'py-3 px-4 flex-row w-22' : 'px-3 py-4 rounded-t-lg'"
         class="AppSidemenu__logo bg-red hover:opacity-85 flex justify-center items-center"
       >
-        <img
-          :class="isHorizontal ? 'h-12' : 'w-18'"
-          src="@/assets/images/ark-logo.png"
-        >
+        <img src="@/assets/images/ark-logo.png">
       </RouterLink>
 
-      <!-- Wallets -->
-      <MenuNavigationItem
-        id="wallets"
-        :title="$t('APP_SIDEMENU.WALLETS')"
-        :class="isHorizontal ? 'w-16' : 'h-16'"
-        :is-horizontal="isHorizontal"
-        icon="wallet"
-        @click="redirect($event)"
-      />
+      <div class="AppSidemenu__container__scrollable flex-1 overflow-y-auto flexify justify-between bg-theme-feature">
+        <div class="flexify">
+          <!-- Wallets -->
+          <MenuNavigationItem
+            id="wallets"
+            :title="$t('APP_SIDEMENU.WALLETS')"
+            :is-horizontal="isHorizontal"
+            class="AppSidemenu__item"
+            icon="wallet"
+            @click="redirect($event)"
+          />
 
-      <!-- Add contact -->
-      <MenuNavigationItem
-        id="contacts"
-        :title="$t('APP_SIDEMENU.CONTACTS')"
-        :class="isHorizontal ? 'w-16' : 'h-16'"
-        :is-horizontal="isHorizontal"
-        icon="contact-add"
-        @click="redirect($event)"
-      />
+          <!-- Add contact -->
+          <MenuNavigationItem
+            id="contacts"
+            :title="$t('APP_SIDEMENU.CONTACTS')"
+            :is-horizontal="isHorizontal"
+            class="AppSidemenu__item"
+            icon="contact-add"
+            @click="redirect($event)"
+          />
 
-      <!-- Announcements -->
-      <MenuNavigationItem
-        id="announcements"
-        :title="$t('APP_SIDEMENU.ANNOUNCEMENTS')"
-        :class="isHorizontal ? 'w-16' : 'h-16'"
-        :is-horizontal="isHorizontal"
-        :show-badge="showUnread"
-        icon="whitepaper"
-        @click="redirect($event)"
-      />
-    </div>
+          <!-- Announcements -->
+          <MenuNavigationItem
+            id="announcements"
+            :title="$t('APP_SIDEMENU.ANNOUNCEMENTS')"
+            class="AppSidemenu__item"
+            :is-horizontal="isHorizontal"
+            :show-badge="showUnread"
+            icon="whitepaper"
+            @click="redirect($event)"
+          />
+        </div>
 
-    <div :class="{'flex flex-row h-18' : isHorizontal}">
-      <!-- Important notification / new releases -->
-      <AppSidemenuImportantNotification
-        v-if="isImportantNotificationVisible && hasNewRelease"
-        :is-horizontal="isHorizontal"
-        :class="isHorizontal ? 'w-16' : 'h-16'"
-        @close="hideImportantNotification"
-      />
-    </div>
+        <div class="flexify">
+          <!-- Important notification / new releases -->
+          <AppSidemenuImportantNotification
+            v-if="isImportantNotificationVisible && hasNewRelease"
+            :is-horizontal="isHorizontal"
+            class="AppSidemenu__item"
+            @close="hideImportantNotification"
+          />
+        </div>
 
-    <div :class="{'flex flex-row h-18' : isHorizontal}">
-      <!-- Search -->
-      <!-- <MenuNavigationItem
-        id="search"
-        :class="isHorizontal ? 'w-16' : 'h-16'"
-        :is-horizontal="isHorizontal"
-        view-box="0 0 20 20"
-        icon="search"
-        @click="redirect($event)"
-      /> -->
-    </div>
+        <div class="flexify">
+          <!-- Search -->
+          <!-- <MenuNavigationItem
+            id="search"
+            :class="isHorizontal ? 'w-16' : 'h-16'"
+            :is-horizontal="isHorizontal"
+            view-box="0 0 20 20"
+            icon="search"
+            @click="redirect($event)"
+          /> -->
+        </div>
 
-    <div :class="{'flex flex-row h-18' : isHorizontal}">
-      <AppSidemenuSettings
-        v-if="isSettingsVisible"
-        :outside-click="true"
-        :is-horizontal="isHorizontal"
-        @close="closeShowSettings"
-      />
+        <div class="flexify">
+          <AppSidemenuSettings
+            v-if="isSettingsVisible"
+            :outside-click="true"
+            :is-horizontal="isHorizontal"
+            @close="closeShowSettings"
+          />
 
-      <!-- Settings -->
-      <MenuNavigationItem
-        id="settings"
-        :title="$t('APP_SIDEMENU.SETTINGS.TITLE')"
-        :class="isHorizontal ? 'w-16' : 'h-16'"
-        :is-horizontal="isHorizontal"
-        :can-activate="false"
-        icon="settings"
-        @click="toggleShowSettings"
-      />
+          <!-- Settings -->
+          <MenuNavigationItem
+            id="settings"
+            :title="$t('APP_SIDEMENU.SETTINGS.TITLE')"
+            :is-horizontal="isHorizontal"
+            :can-activate="false"
+            class="AppSidemenu__item"
+            icon="settings"
+            @click="toggleShowSettings"
+          />
 
-      <AppSidemenuNetworkStatus
-        v-if="isNetworkStatusVisible"
-        :is-horizontal="isHorizontal"
-        :outside-click="true"
-        @close="closeShowNetworkStatus"
-      />
-      <!-- Networks -->
-      <MenuNavigationItem
-        id="networks"
-        :title="$t('APP_SIDEMENU.NETWORK')"
-        :class="isHorizontal ? 'w-16' : 'h-16'"
-        :is-horizontal="isHorizontal"
-        :can-activate="false"
-        icon="cloud"
-        @click="toggleShowNetworkStatus"
-      />
+          <AppSidemenuNetworkStatus
+            v-if="isNetworkStatusVisible"
+            :is-horizontal="isHorizontal"
+            :outside-click="true"
+            @close="closeShowNetworkStatus"
+          />
+          <!-- Networks -->
+          <MenuNavigationItem
+            id="networks"
+            :title="$t('APP_SIDEMENU.NETWORK')"
+            :is-horizontal="isHorizontal"
+            :can-activate="false"
+            class="AppSidemenu__item"
+            icon="cloud"
+            @click="toggleShowNetworkStatus"
+          />
 
-      <!-- Profile settings -->
-      <div
-        :class="isHorizontal ? 'ml-2 mr-4 py-3' : 'mt-2 mb-4 px-3'"
-        class="cursor-pointer flex items-center"
-      >
-        <RouterLink
-          :class="isHorizontal ? 'h-12 w-12 bg-no-repeat' : 'h-18 w-18'"
-          :style="session_profile.avatar ? `backgroundImage: url('${assets_loadImage(session_profile.avatar)}')` : ''"
-          :title="$t('APP_SIDEMENU.CURRENT_PROFILE', { profileName: session_profile.name })"
-          :to="{ name: 'profiles' }"
-          class="AppSidemenu__avatar flex background-image"
-        />
+          <!-- Profile settings -->
+          <div
+            :class="isHorizontal ? 'ml-2 mr-4 py-3' : 'mt-2 mb-4 px-3'"
+            class="cursor-pointer flex items-center"
+          >
+            <RouterLink
+              :class="isHorizontal ? 'h-12 w-12 bg-no-repeat' : 'h-18 w-18'"
+              :style="session_profile.avatar ? `backgroundImage: url('${assets_loadImage(session_profile.avatar)}')` : ''"
+              :title="$t('APP_SIDEMENU.CURRENT_PROFILE', { profileName: session_profile.name })"
+              :to="{ name: 'profiles' }"
+              class="AppSidemenu__avatar flex background-image bg-center bg-no-repeat border-none hover:opacity-50"
+            />
+          </div>
+        </div>
       </div>
     </div>
   </MenuNavigation>
@@ -206,17 +211,24 @@ export default {
 }
 </script>
 
-<style scoped>
-.AppSidemenu__logo {
-  transition: opacity 0.5s;
-}
+<style lang="postcss" scoped>
+.AppSidemenu__container__scrollable .flexify { @apply flex-none }
+.AppSidemenu__logo { transition: opacity 0.5s; }
+
+.AppSidemenu--horizontal .AppSidemenu__item { @apply w-16 }
+.AppSidemenu--horizontal .AppSidemenu__logo { @apply p-4 }
+.AppSidemenu--horizontal .AppSidemenu__logo img { @apply h-12 }
+.AppSidemenu--horizontal .flexify { @apply flex flex-row }
+.AppSidemenu--horizontal { @apply h-18; }
+
+.AppSidemenu--vertical .AppSidemenu__container__scrollable { @apply rounded-lg py-2 }
+.AppSidemenu--vertical .AppSidemenu__item { @apply h-16 }
+.AppSidemenu--vertical .AppSidemenu__logo { @apply rounded-lg mb-2 px-4 py-5 }
+.AppSidemenu--vertical .AppSidemenu__logo img { @apply w-18 }
+.AppSidemenu--vertical .flexify { @apply flex flex-col }
+.AppSidemenu--vertical { @apply w-22 mx-6 rounded-lg }
+
 .AppSidemenu__avatar {
   transition: opacity 0.5s;
-  background-repeat: no-repeat;
-  background-position: center;
-  border: none;
-}
-.AppSidemenu__avatar:hover {
-  opacity: 0.5;
 }
 </style>

--- a/src/renderer/components/App/AppSidemenu/AppSidemenu.vue
+++ b/src/renderer/components/App/AppSidemenu/AppSidemenu.vue
@@ -223,7 +223,7 @@ export default {
 
 .AppSidemenu--vertical .AppSidemenu__container__scrollable { @apply rounded-lg py-2 }
 .AppSidemenu--vertical .AppSidemenu__item { @apply h-16 }
-.AppSidemenu--vertical .AppSidemenu__logo { @apply rounded-lg mb-2 px-4 py-5 }
+.AppSidemenu--vertical .AppSidemenu__logo { @apply rounded-lg mb-3 px-4 py-5 }
 .AppSidemenu--vertical .AppSidemenu__logo img { @apply w-18 }
 .AppSidemenu--vertical .flexify { @apply flex flex-col }
 .AppSidemenu--vertical { @apply w-22 mx-6 rounded-lg }

--- a/src/renderer/pages/Wallet/WalletAll.vue
+++ b/src/renderer/pages/Wallet/WalletAll.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="WalletAll rounded-lg flex flex-col overflow-y-hidden">
-    <div class="WalletAll__balance bg-theme-feature rounded-lg flex p-10 mb-4">
+    <div class="WalletAll__balance bg-theme-feature rounded-lg flex p-10 mb-3">
       <div class="flex-1 flex flex-row justify-between">
         <div class="flex flex-row items-end">
           <div


### PR DESCRIPTION
## Proposed changes

This PR separate the logo in the sidebar and also refactor to fix the overflow.

<img width="80" alt="captura de tela 2018-12-07 as 15 20 13" src="https://user-images.githubusercontent.com/4539235/49665444-9ed78280-fa33-11e8-9b18-e15dd3a63e54.png">


<img width="200" alt="49078221-30691800-f21c-11e8-87e1-9bc73e2d7325 copia" src="https://user-images.githubusercontent.com/4539235/49665266-1f49b380-fa33-11e8-9b0c-46692db59543.png">


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)