### PR TITLE
Bug:Fix  loading of chart two times

### DIFF
--- a/src/renderer/components/MarketChart/MarketChart.vue
+++ b/src/renderer/components/MarketChart/MarketChart.vue
@@ -88,10 +88,6 @@ export default {
       this.renderChart()
     },
 
-    period () {
-      this.renderChart()
-    },
-
     isActive (val) {
       if (!val) return // Render the chart when open the component
 


### PR DESCRIPTION
Fix: Market Chart loading twice each time you change the period.

Whenever we changed period, renderChart() was being called twice. As a result chart appears to be rendering two times everytime you change the period.
Firstly, changePeriod function was triggering renderChart, later the watch function period triggers renderChart since period was changed.

## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
Watched property 'period' has been removed.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes

<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->

Since changePeriod will be used on whenever period is changed, therefore period watch can be safely removed.
This removes the above described bug and at the same time reduces a watched property.

