### PR TITLE
fix: fading out of wallet / contact

### DIFF
--- a/src/renderer/pages/Contact/ContactAll.vue
+++ b/src/renderer/pages/Contact/ContactAll.vue
@@ -126,6 +126,9 @@ export default {
   transition: 0.5s;
   opacity: 0.5;
 }
+.ContactAll__grid__contact .identicon {
+  transition: 0.5s;
+}
 @screen lg {
   .ContactAll__grid__contact {
     @apply .p-4

--- a/src/renderer/pages/Wallet/WalletAll.vue
+++ b/src/renderer/pages/Wallet/WalletAll.vue
@@ -249,6 +249,9 @@ export default {
   transition: 0.5s;
   opacity: 0.5;
 }
+.WalletAll__grid__wallet .identicon {
+  transition: 0.5s;
+}
 @screen lg {
   .WalletAll__grid__wallet {
     @apply .p-4


### PR DESCRIPTION
## Proposed changes

Wallets / contacts faded when you hovered over them, but if you moved away they would immediately go back to their original which looks odd. So this PR adds a fade transition when the item is no longer hovered (don't mind the missing colors in the before gif):

Before:
![before](https://user-images.githubusercontent.com/35610748/49701218-c83a0f00-fbe9-11e8-8500-93ef4e881114.gif)

After:
![after](https://user-images.githubusercontent.com/35610748/49701221-cd975980-fbe9-11e8-87eb-29642dcd826f.gif)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
