### PR TITLE
fix: disable reload button while refreshing

### DIFF
--- a/src/renderer/components/Button/ButtonReload.vue
+++ b/src/renderer/components/Button/ButtonReload.vue
@@ -1,10 +1,11 @@
 <template>
   <button
-    v-tooltip="{ content: title, trigger:'hover' }"
+    v-tooltip="{ content: title, trigger: 'hover' }"
     :class="[
       withoutBackground ? 'hover:bg-transparent' : `py-2 px-4 rounded ${colorClass ? colorClass : 'bg-theme-button-light text-theme-button-light-text'}`
     ]"
     class="ButtonReload cursor-pointer flex items-center self-stretch"
+    :disabled="isRefreshing"
     @click="emitClick"
   >
     <SvgIcon


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

Disables the reload button when `isRefreshing` is `true`.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
