### PR TITLE
fix: ledger wallet rename saving old name

### DIFF
--- a/src/renderer/components/Wallet/WalletRenameModal.vue
+++ b/src/renderer/components/Wallet/WalletRenameModal.vue
@@ -70,18 +70,19 @@ export default {
 
   methods: {
     renameWallet () {
+      const newName = this.schema.name
       if (this.wallet.isLedger) {
         try {
           this.$store.dispatch('wallet/setLedgerName', {
             address: this.wallet.address,
-            name: this.wallet.name
+            name: newName
           })
+          this.wallet.name = newName
         } catch (error) {
           this.$error(this.$t('WALLET_RENAME.ERROR_LEDGER', { error }))
         }
-        this.wallet.name = this.schema.name
       } else {
-        this.wallet.name = this.schema.name
+        this.wallet.name = newName
         this.$store.dispatch('wallet/update', this.wallet)
       }
       this.emitRenamed()


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

When changing the name of a ledger wallet, it was saving the name of the wallet before the name was updated. E.g. renaming a wallet from "Ledger 1" to "Business Ledger" would save "Ledger 1". This is the wrong order.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
