### PR TITLE
fix: add i18n to eslint ignore

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,6 +21,9 @@ module.exports = {
     // allow async-await
     'generator-star-spacing': 0,
     // allow debugger during development
-    'no-debugger': process.env.NODE_ENV === 'production' ? 2 : 0
+    'no-debugger': process.env.NODE_ENV === 'production' ? 2 : 0,
+    'vue/component-name-in-template-casing': ['warning', 'PascalCase', {
+      'ignores': ['i18n']
+    }]
   }
 }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,7 +22,7 @@ module.exports = {
     'generator-star-spacing': 0,
     // allow debugger during development
     'no-debugger': process.env.NODE_ENV === 'production' ? 2 : 0,
-    'vue/component-name-in-template-casing': ['warning', 'PascalCase', {
+    'vue/component-name-in-template-casing': ['warn', 'PascalCase', {
       'ignores': ['i18n']
     }]
   }

--- a/src/renderer/components/App/AppIntroScreen.vue
+++ b/src/renderer/components/App/AppIntroScreen.vue
@@ -47,7 +47,7 @@
         <div class="mt-3">
           {{ $t('INTRODUCTION.DUTY.OWNER') }}
         </div>
-        <I18n
+        <i18n
           tag="div"
           class="mt-2"
           path="INTRODUCTION.DUTY.WARNING.INFO"
@@ -58,7 +58,7 @@
           >
             {{ $t('INTRODUCTION.DUTY.WARNING.WARN') }}
           </div>
-        </I18n>
+        </i18n>
         <div class="font-bold mt-3">
           {{ $t('INTRODUCTION.DUTY.SECURITY') }}
         </div>

--- a/src/renderer/components/App/AppWelcome.vue
+++ b/src/renderer/components/App/AppWelcome.vue
@@ -17,7 +17,7 @@
             <img :src="assets_loadImage('ark-logo.png')">
           </div>
         </div>
-        <I18n
+        <i18n
           path="INTRODUCTION.WELCOME.TITLE"
           tag="span"
           class="text-5xl"
@@ -25,7 +25,7 @@
           <strong place="app">
             {{ $t('COMMON.APP_NAME') }}
           </strong>
-        </I18n>
+        </i18n>
         <div class="mt-3">
           {{ $t('INTRODUCTION.WELCOME.SAFETY_MESSAGE') }}
         </div>
@@ -58,7 +58,7 @@
           @back="moveTo(1)"
           @next="moveTo(3)"
         >
-          <I18n
+          <i18n
             slot="title"
             path="INTRODUCTION.PAGE_TITLE"
             tag="span"
@@ -66,7 +66,7 @@
             <strong place="page">
               {{ $t('INTRODUCTION.POWER.TITLE') }}
             </strong>
-          </I18n>
+          </i18n>
         </AppIntroScreen>
 
         <AppIntroScreen
@@ -75,7 +75,7 @@
           @back="moveTo(2)"
           @next="moveTo(4)"
         >
-          <I18n
+          <i18n
             slot="title"
             path="INTRODUCTION.PAGE_TITLE"
             tag="span"
@@ -83,7 +83,7 @@
             <strong place="page">
               {{ $t('INTRODUCTION.DUTY.TITLE') }}
             </strong>
-          </I18n>
+          </i18n>
         </AppIntroScreen>
 
         <AppIntroScreen
@@ -92,7 +92,7 @@
           @back="moveTo(3)"
           @next="moveTo(5)"
         >
-          <I18n
+          <i18n
             slot="title"
             path="INTRODUCTION.PAGE_TITLE"
             tag="span"
@@ -100,7 +100,7 @@
             <strong place="page">
               {{ $t('INTRODUCTION.RESPONSIBILITY.TITLE') }}
             </strong>
-          </I18n>
+          </i18n>
         </AppIntroScreen>
 
         <AppIntroScreen
@@ -110,7 +110,7 @@
           @back="moveTo(4)"
           @done="done"
         >
-          <I18n
+          <i18n
             slot="title"
             path="INTRODUCTION.PAGE_TITLE"
             tag="span"
@@ -118,7 +118,7 @@
             <strong place="page">
               {{ $t('INTRODUCTION.TURN.TITLE') }}
             </strong>
-          </I18n>
+          </i18n>
         </AppIntroScreen>
       </div>
     </div>

--- a/src/renderer/components/Wallet/WalletDetails/WalletDetails.vue
+++ b/src/renderer/components/Wallet/WalletDetails/WalletDetails.vue
@@ -42,9 +42,11 @@
             class="font-semibold pl-6 border-r border-theme-line-separator"
             path="WALLET_DELEGATES.RANK_BANNER"
           >
-            <strong place="rank">{{ votedDelegate.rank }}</strong>
-          </I18n>
-          <I18n
+            <strong place="rank">
+              {{ votedDelegate.rank }}
+            </strong>
+          </i18n>
+          <i18n
             tag="span"
             class="font-semibold pl-6"
             path="WALLET_DELEGATES.PRODUCTIVITY_BANNER"

--- a/src/renderer/components/Wallet/WalletDetails/WalletDetails.vue
+++ b/src/renderer/components/Wallet/WalletDetails/WalletDetails.vue
@@ -28,7 +28,7 @@
         class="mt-4 mb-4 py-4 px-6 rounded-l text-theme-voting-banner-text bg-theme-voting-banner-background w-full flex"
       >
         <div class="flex flex-row">
-          <I18n
+          <i18n
             tag="span"
             class="font-semibold pr-6 border-r border-theme-line-separator"
             path="WALLET_DELEGATES.VOTED_FOR"
@@ -36,8 +36,8 @@
             <strong place="delegate">
               {{ votedDelegate.username }}
             </strong>
-          </I18n>
-          <I18n
+          </i18n>
+          <i18n
             tag="span"
             class="font-semibold pl-6"
             path="WALLET_DELEGATES.PRODUCTIVITY_BANNER"
@@ -45,7 +45,7 @@
             <strong place="productivity">
               {{ getProductivity() }}
             </strong>
-          </I18n>
+          </i18n>
         </div>
       </div>
       <div


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

The `<i18n>` does not work when written in PascalCase (`<I18n>`) as required by the current lint rules. This PR adds the i18n tag to the eslint ignore rules.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes