### PR TITLE
fix: set screenshot protection upon app launch instead of sidebar

### DIFF
--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -146,6 +146,8 @@ export default {
         // We only set this if the env variable is 'false', since protection defaults to true
         // Since it's not a boolean, we can't do status !== false, since that would disable protection with every env var that's not 'true'
         this.$store.dispatch('session/setContentProtection', !(status === 'false'))
+      } else {
+        remote.getCurrentWindow().setContentProtection(true)
       }
     })
 

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -139,9 +139,16 @@ export default {
       this.$synchronizer.ready()
 
       await this.loadNotEssential()
+
+      // Environments variables are strings
+      const status = process.env.ENABLE_SCREENSHOT_PROTECTION
+      if (status) {
+        // We only set this if the env variable is 'false', since protection defaults to true
+        // Since it's not a boolean, we can't do status !== false, since that would disable protection with every env var that's not 'true'
+        this.$store.dispatch('session/setContentProtection', !(status === 'false'))
+      }
     })
 
-    remote.getCurrentWindow().setContentProtection(this.hasProtection)
     this.setContextMenu()
   },
 

--- a/src/renderer/components/App/AppSidemenu/AppSidemenuSettings.vue
+++ b/src/renderer/components/App/AppSidemenu/AppSidemenuSettings.vue
@@ -180,15 +180,6 @@ export default {
     }
   },
 
-  mounted () {
-    const status = process.env.ENABLE_SCREENSHOT_PROTECTION
-    // Environments variables are strings
-    // Prevent JSON.parse from throwing an error if the variable is not a boolean
-    if (status && (status === 'true' || status === 'false')) {
-      this.setProtection(JSON.parse(status))
-    }
-  },
-
   methods: {
     setCurrency (newCurrency) {
       this.sessionCurrency = newCurrency


### PR DESCRIPTION
## Proposed changes

#671 introduced a way to disable screenshot protection on launch, but it was set in the appsidemenu. This means that it got only triggered after the sidemenu got openend, which resulted in still not being able to take screenshots in dev mode when you hadn't touched the sidemenu yet. This PR moves it towards the `App.vue` file so it gets set immediately upon launch.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
