### PR TITLE
fix: go to wallet list on ledger disconnect

### DIFF
--- a/src/renderer/pages/Wallet/WalletShow.vue
+++ b/src/renderer/pages/Wallet/WalletShow.vue
@@ -36,6 +36,14 @@ export default {
     }
   },
 
+  watch: {
+    wallet () {
+      if (!this.wallet) {
+        this.$router.push({ name: 'wallets' })
+      }
+    }
+  },
+
   methods: {
     loadWalletData () {
       this.$refs.WalletDetails.fetchWalletVote()


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

If viewing a wallet on the ledger and the ledger disconnects, the wallet page disappears. This fix takes the user to the wallet list in this scenario.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
