### PR TITLE
Bugfix : Validation after after regenerating 2nd passphrase

### DIFF
--- a/src/renderer/components/Transaction/TransactionForm/TransactionFormSecondSignature.vue
+++ b/src/renderer/components/Transaction/TransactionForm/TransactionFormSecondSignature.vue
@@ -219,6 +219,7 @@ export default {
     },
 
     generateNewPassphrase () {
+      this.reset()
       this.isGenerating = true
       setTimeout(() => {
         this.secondPassphrase = WalletService.generateSecondPassphrase(this.session_profile.bip39Language)


### PR DESCRIPTION
While registering for 2nd passphrase.

Follow these steps to reproduce the bug:
-If you generate a 2nd passphrase
-Then tap next
-Then verify the passphrase (by entering 3,6,9 th words)
-Tap Back
-Generate a new 2nd passphrase
-Tap next
-You will be able to continue without entering correct passphrase

## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

This has been fixed by using the rest function from the generateNewPassphrase function.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
