### PR TITLE
fix: do not throw an Error when closing `TransactionShow`

### DIFF
--- a/src/renderer/components/Button/ButtonClipboard.vue
+++ b/src/renderer/components/Button/ButtonClipboard.vue
@@ -46,7 +46,13 @@ export default {
   }),
 
   mounted () {
-    this.copyText = this.$t('BUTTON_CLIPBOARD.COPY_TO_CLIPBOARD')
+    // When opening the `TransactionShow` modal the clipboard buttons have i18n,
+    // but, when closing, its value has been lost. This problem is produced only
+    // when using portals. Probably is this bug:
+    // https://github.com/LinusBorg/portal-vue/issues/159
+    if (this.$i18n) {
+      this.copyText = this.$t('BUTTON_CLIPBOARD.COPY_TO_CLIPBOARD')
+    }
   },
 
   methods: {

--- a/src/renderer/components/Transaction/TransactionTable.vue
+++ b/src/renderer/components/Transaction/TransactionTable.vue
@@ -153,7 +153,6 @@ export default {
   },
 
   data: () => ({
-    showModal: false,
     selected: null
   }),
 


### PR DESCRIPTION
## Proposed changes
As I've explained in a comment, this is probably related to https://github.com/LinusBorg/portal-vue/issues/159. I'll be watching that issue to provide a definitive solution.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
