### PR TITLE
fix: do not show "Send All" in 2 lines on transfer modal

### DIFF
--- a/src/renderer/components/Input/InputSwitch.vue
+++ b/src/renderer/components/Input/InputSwitch.vue
@@ -8,13 +8,16 @@
     class="InputSwitch"
   >
     <div
-      :class="isReverse ? 'flex-row-reverse -mr-3' : 'flex-row'"
+      :class="isReverse ? 'flex-row-reverse' : 'flex-row'"
       class="w-full pt-4 pin-l transition text-theme-page-text h-10 flex items-center justify-flex-start"
     >
       <slot>
         <div
-          :class="isLarge ? 'text-lg' : 'text-base'"
-          class="mx-3 mt-1"
+          :class="[
+            isLarge ? 'text-lg' : 'text-base',
+            isReverse ? 'ml-3' : 'mr-3'
+          ]"
+          class="mt-1"
         >
           {{ text }}
         </div>

--- a/src/renderer/components/Input/InputSwitch.vue
+++ b/src/renderer/components/Input/InputSwitch.vue
@@ -8,7 +8,7 @@
     class="InputSwitch"
   >
     <div
-      :class="isReverse ? 'flex-row-reverse -mr-3' : 'flex-row -ml-3'"
+      :class="isReverse ? 'flex-row-reverse -mr-3' : 'flex-row'"
       class="w-full pt-4 pin-l transition text-theme-page-text h-10 flex items-center justify-flex-start"
     >
       <slot>

--- a/src/renderer/components/Transaction/TransactionForm/TransactionFormTransfer.vue
+++ b/src/renderer/components/Transaction/TransactionForm/TransactionFormTransfer.vue
@@ -382,3 +382,9 @@ export default {
   }
 }
 </script>
+
+<style>
+.TransactionModalTransfer .InputSwitch .ButtonSwitch {
+  @apply .flex-1
+}
+</style>

--- a/src/renderer/components/Transaction/TransactionForm/TransactionFormTransfer.vue
+++ b/src/renderer/components/Transaction/TransactionForm/TransactionFormTransfer.vue
@@ -382,9 +382,3 @@ export default {
   }
 }
 </script>
-
-<style>
-.TransactionModalTransfer .InputSwitch .ButtonSwitch {
-  @apply .flex-1
-}
-</style>


### PR DESCRIPTION
## Proposed changes
The text of "Send All" was not correctly displayed:

![sendall](https://user-images.githubusercontent.com/1161224/49890547-9b356880-fe44-11e8-9236-9749a60d5184.jpg)

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes

## Further comments
I've tried the changes on the import wallet page and the sidemenu settings, and it looks OK on both.
