### PR TITLE
fix: version notification tooltip boundaries

### DIFF
--- a/src/renderer/components/App/AppSidemenu/AppSidemenuImportantNotification.vue
+++ b/src/renderer/components/App/AppSidemenu/AppSidemenuImportantNotification.vue
@@ -3,7 +3,8 @@
     <button
       v-tooltip="{
         content: tooltipText,
-        placement: isHorizontal ? 'bottom' : 'right'
+        placement: isHorizontal ? 'bottom' : 'right',
+        boundariesElement: 'body'
       }"
       class="AppSidemenuImportantNotification relative cursor-pointer flex items-center justify-center h-8 w-8"
       @click="openNotification"


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
The version notification tooltip is not displayed correctly.

![tooltip](https://user-images.githubusercontent.com/6547002/49902731-10b13100-fe65-11e8-9d32-d4981f6b5c28.gif)

Setting the `boundariesElement` of the tooltip to `body` fixes this issue.

![image](https://user-images.githubusercontent.com/6547002/49902625-c039d380-fe64-11e8-8c45-568bd9e52792.png)


## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes