### PR TITLE
fix: apply blur also to navbar

### DIFF
--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -21,6 +21,9 @@
       <AppSidemenu
         v-if="hasAnyProfile"
         :is-horizontal="true"
+        :class="{
+          'blur': hasBlurFilter
+        }"
         class="block lg:hidden"
       />
       <section


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

On smaller resolutions the blur effect is applied only to the main section, but not to the navbar, which is a sibling element. This PR adds the blur class on both elements.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)
## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes