### PR TITLE
fix: comment out whole search menu icon div

### DIFF
--- a/src/renderer/components/App/AppSidemenu/AppSidemenu.vue
+++ b/src/renderer/components/App/AppSidemenu/AppSidemenu.vue
@@ -63,17 +63,17 @@
           />
         </div>
 
-        <div class="flexify">
-          <!-- Search -->
-          <!-- <MenuNavigationItem
+        <!-- <div class="flexify">
+          <!- - Search - ->
+          <MenuNavigationItem
             id="search"
             :class="isHorizontal ? 'w-16' : 'h-16'"
             :is-horizontal="isHorizontal"
             view-box="0 0 20 20"
             icon="search"
             @click="redirect($event)"
-          /> -->
-        </div>
+          />
+        </div> -->
 
         <div class="flexify">
           <AppSidemenuSettings


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

While having a height of 0px, the `flexify` div wrapping for the search icon is still regarded when positioning the other flex items, causing the notification icon to be off center.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Temporary Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes