### PR TITLE
refactor: don't show delegate details if it has no rank

### DIFF
--- a/src/renderer/components/Wallet/WalletDetails/WalletDetails.vue
+++ b/src/renderer/components/Wallet/WalletDetails/WalletDetails.vue
@@ -30,31 +30,36 @@
         <div class="flex flex-row">
           <i18n
             tag="span"
-            class="font-semibold pr-6 border-r border-theme-line-separator"
+            :class="{
+              'border-r border-theme-line-separator' : votedDelegate.rank
+            }"
+            class="font-semibold pr-6"
             path="WALLET_DELEGATES.VOTED_FOR"
           >
             <strong place="delegate">
               {{ votedDelegate.username }}
             </strong>
           </i18n>
-          <i18n
-            tag="span"
-            class="font-semibold pl-6 border-r border-theme-line-separator"
-            path="WALLET_DELEGATES.RANK_BANNER"
-          >
-            <strong place="rank">
-              {{ votedDelegate.rank }}
-            </strong>
-          </i18n>
-          <i18n
-            tag="span"
-            class="font-semibold pl-6"
-            path="WALLET_DELEGATES.PRODUCTIVITY_BANNER"
-          >
-            <strong place="productivity">
-              {{ getProductivity() }}
-            </strong>
-          </i18n>
+          <template v-if="votedDelegate.rank">
+            <i18n
+              tag="span"
+              class="font-semibold px-6 border-r border-theme-line-separator"
+              path="WALLET_DELEGATES.RANK_BANNER"
+            >
+              <strong place="rank">
+                {{ votedDelegate.rank }}
+              </strong>
+            </i18n>
+            <i18n
+              tag="span"
+              class="font-semibold pl-6"
+              path="WALLET_DELEGATES.PRODUCTIVITY_BANNER"
+            >
+              <strong place="productivity">
+                {{ getProductivity() }}
+              </strong>
+            </i18n>
+          </template>
         </div>
       </div>
       <div


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

By design of the Ark Core a delegate has no rank until the round it registered in is over. If voted for said delegate, this PR hides the respective delegate details (rank/productivity) if that is the case.

Also fixes the padding of the displayed rank.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes