### PR TITLE
fix: show contacts in sidebar if wallet is contact

### DIFF
--- a/src/renderer/components/Wallet/WalletSidebar/WalletSidebar.vue
+++ b/src/renderer/components/Wallet/WalletSidebar/WalletSidebar.vue
@@ -133,12 +133,22 @@ export default {
 
   computed: {
     wallets () {
+      if (this.currentWallet.isContact) {
+        const contacts = this.$store.getters['wallet/contactsByProfileId'](this.session_profile.id)
+        const prop = 'name'
+        return contacts.slice().sort(sortByProp(prop))
+      }
+
       const prop = 'name'
       return this.$store.getters['wallet/byProfileId'](this.session_profile.id).slice().sort(sortByProp(prop))
     },
 
     activeWallet () {
       return this.wallet_fromRoute || {}
+    },
+
+    currentWallet () {
+      return this.wallet_fromRoute
     },
 
     isLoadingLedger () {


### PR DESCRIPTION
## Proposed changes

When you opened a contact, it would only show wallets in the sidebar and when changing to one it would not show the additional tabs that a wallet has. This PR changes the sidebar to show contacts when the wallet is a contact, and wallets when it's a wallet. This indirectly fixes #756 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
