### PR TITLE
fix: check if currentwallet is defined before checking for contact

### DIFF
--- a/src/renderer/components/Wallet/WalletSidebar/WalletSidebar.vue
+++ b/src/renderer/components/Wallet/WalletSidebar/WalletSidebar.vue
@@ -133,7 +133,7 @@ export default {
 
   computed: {
     wallets () {
-      if (this.currentWallet.isContact) {
+      if (this.currentWallet && this.currentWallet.isContact) {
         const contacts = this.$store.getters['wallet/contactsByProfileId'](this.session_profile.id)
         const prop = 'name'
         return contacts.slice().sort(sortByProp(prop))


### PR DESCRIPTION
## Proposed changes

`this.currentWallet` was not defined when the `WalletSidebar` was used in the dashboard, which resulted in a js error and the wallets no longer loading in that sidebar.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
