### PR TITLE
fix: only reset buttons when the curretWallet has changed

### DIFF
--- a/src/renderer/components/Wallet/WalletHeading/WalletHeading.vue
+++ b/src/renderer/components/Wallet/WalletHeading/WalletHeading.vue
@@ -21,6 +21,10 @@ export default {
     WalletHeadingActions
   },
 
+  data: () => ({
+    activeWallet: null
+  }),
+
   computed: {
     ...mapGetters('wallet', ['secondaryButtonsVisible']),
 
@@ -35,7 +39,9 @@ export default {
 
   watch: {
     currentWallet () {
-      this.resetHeading()
+      if (this.activeWallet && this.activeWallet.id !== this.currentWallet.id) {
+        this.resetHeading()
+      }
     }
   },
 
@@ -45,6 +51,7 @@ export default {
 
   methods: {
     resetHeading () {
+      this.activeWallet = this.currentWallet
       this.$store.dispatch('wallet/setSecondaryButtonsVisible', false)
     }
   }


### PR DESCRIPTION
## Proposed changes

#759 introduced resetting the wallet buttons when the wallet was changed, but this was done by watching the `currentWallet` property for changes. This property "changes" every x seconds due to refreshing, which would result in buttons being reset while the wallet itself did not change. As a sideeffect, this would also close the second signature or delegate registration modals if those were open, making it difficult to work with those transaction type. This PR adds a check to only reset the buttons when the wallet actually changed.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
