### PR TITLE
[WIP] fix: decompose korean characters so they match the generated ones for passphrases

### DIFF
--- a/src/renderer/pages/Wallet/WalletImport.vue
+++ b/src/renderer/pages/Wallet/WalletImport.vue
@@ -217,7 +217,7 @@ export default {
      */
     step () {
       if (this.step === 2 && !this.useOnlyAddress) {
-        this.schema.address = WalletService.getAddress(this.schema.passphrase, this.session_network.version)
+        this.schema.address = WalletService.getAddress(this.schema.passphrase.normalize('NFD'), this.session_network.version)
       }
     }
   },


### PR DESCRIPTION
## Proposed changes

When you set BIP39 to korean and then copy the passphrase it generates for you, it will import a different passphrase when you pasted and copied it from slack (or other editors that didn't keep the decomposed characters) . This is because the underlying passphrase uses the decomposed characters as opposed to the combined ones that are shown in the passphrase input (so if you would write them down on paper from the 12 inputs, you won't be able to import it)

Luckily there's something called `normalize` to fix this. I've tried it on English, Korean and Chinese and those all seem to work properly. Please test this thoroughly with the different phrases before importing. Now that I think of it, I'll add some tests for this too (so WIP)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (incoming)
