### PR TITLE
fix: get signed messages of current wallet

### DIFF
--- a/src/renderer/components/Wallet/WalletSignVerify/WalletSignVerify.vue
+++ b/src/renderer/components/Wallet/WalletSignVerify/WalletSignVerify.vue
@@ -111,12 +111,21 @@ export default {
 
   data: () => ({
     signedMessages: [],
-    showTimestamp: null
+    showTimestamp: null,
+    activeWalletId: null
   }),
 
   computed: {
     currentWallet () {
       return this.wallet_fromRoute
+    }
+  },
+
+  watch: {
+    currentWallet () {
+      if (this.activeWalletId !== this.currentWallet.id) {
+        this.updateSignedMessages()
+      }
     }
   },
 
@@ -131,22 +140,29 @@ export default {
       }
       return value
     },
+
     copyMessage (value) {
       var message = clone(value, false)
       delete message['timestamp']
       delete message['address']
       return JSON.stringify(message)
     },
+
     deleteMessage (value) {
       var message = clone(value, false)
       this.$store.dispatch('wallet/deleteSignedMessage', message)
     },
-    updateSignedMessages () {
+
+    updateSignedMessages (setWalletId = true) {
+      if (setWalletId) {
+        this.activeWalletId = this.currentWallet.id
+      }
       this.signedMessages = this.$store.getters['wallet/signedMessages'](this.currentWallet.address)
     },
+
     onSigned (toggle) {
       toggle()
-      this.updateSignedMessages()
+      this.updateSignedMessages(false)
     }
   }
 }


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

While on the sign/verify tab, switching wallets would not update the list of signed messages.

![signed](https://user-images.githubusercontent.com/6547002/50184463-7e51d700-0315-11e9-8d38-2147da632b5a.gif)

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes