### PR TITLE
refactor: store only the id of the active wallet

### DIFF
--- a/src/renderer/components/Wallet/WalletHeading/WalletHeading.vue
+++ b/src/renderer/components/Wallet/WalletHeading/WalletHeading.vue
@@ -22,7 +22,7 @@ export default {
   },
 
   data: () => ({
-    activeWallet: null
+    activeWalletId: null
   }),
 
   computed: {
@@ -39,7 +39,7 @@ export default {
 
   watch: {
     currentWallet () {
-      if (this.activeWallet && this.activeWallet.id !== this.currentWallet.id) {
+      if (this.activeWalletId !== this.currentWallet.id) {
         this.resetHeading()
       }
     }
@@ -51,7 +51,7 @@ export default {
 
   methods: {
     resetHeading () {
-      this.activeWallet = this.currentWallet
+      this.activeWalletId = this.currentWallet.id
       this.$store.dispatch('wallet/setSecondaryButtonsVisible', false)
     }
   }


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

As originally done in #780, storing the whole wallet object is unnecessary since only the ID is used for the comparison check. This also aligns with the same check introduced in #787.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes