### PR TITLE
fix: also decompose passphrases for tx and signing

### DIFF
--- a/__tests__/unit/services/wallet.spec.js
+++ b/__tests__/unit/services/wallet.spec.js
@@ -8,20 +8,8 @@ describe('Services > Wallet', () => {
       expect(WalletService.getAddress(passphrase, 30)).toEqual(address)
     })
 
-    it('should work in English after decomposing', () => {
-      const passphrase = 'one video jaguar gap soldier ill hobby motor bundle couple trophy smoke'.normalize('NFD')
-      const address = 'DAy2xDNZLRQsgiJCnF3x4WDxGsBrmsKCsV'
-      expect(WalletService.getAddress(passphrase, 30)).toEqual(address)
-    })
-
     it('should work in Chinese (Traditional)', () => {
       const passphrase = '苗 雛 陸 桿 用 腐 爐 詞 鬼 雨 爾 然'
-      const address = 'DS6hPMzbgRkKCZa6fJSmQrG2M7toJAtd5B'
-      expect(WalletService.getAddress(passphrase, 30)).toEqual(address)
-    })
-
-    it('should work in Chinese (Traditional) after decomposing', () => {
-      const passphrase = '苗 雛 陸 桿 用 腐 爐 詞 鬼 雨 爾 然'.normalize('NFD')
       const address = 'DS6hPMzbgRkKCZa6fJSmQrG2M7toJAtd5B'
       expect(WalletService.getAddress(passphrase, 30)).toEqual(address)
     })
@@ -32,20 +20,8 @@ describe('Services > Wallet', () => {
       expect(WalletService.getAddress(passphrase, 30)).toEqual(address)
     })
 
-    it('should work in French after decomposing', () => {
-      const passphrase = 'galerie notoire prudence mortier soupape cerise argent neurone pommade géranium potager émouvoir'.normalize('NFD')
-      const address = 'DUFdRiUNXt1PiLVakbq4ADo1Ttsx3kH1AT'
-      expect(WalletService.getAddress(passphrase, 30)).toEqual(address)
-    })
-
     it('should work in Italian', () => {
       const passphrase = 'mucca comodo imbevuto talismano sconforto cavillo obelisco quota recupero malinteso gergo bipede'
-      const address = 'D8nAGdSCCRMsLPsM4GgzRtgbiTn16rHW6J'
-      expect(WalletService.getAddress(passphrase, 30)).toEqual(address)
-    })
-
-    it('should work in Italian after decomposing', () => {
-      const passphrase = 'mucca comodo imbevuto talismano sconforto cavillo obelisco quota recupero malinteso gergo bipede'.normalize('NFD')
       const address = 'D8nAGdSCCRMsLPsM4GgzRtgbiTn16rHW6J'
       expect(WalletService.getAddress(passphrase, 30)).toEqual(address)
     })
@@ -56,38 +32,20 @@ describe('Services > Wallet', () => {
       expect(WalletService.getAddress(passphrase, 30)).toEqual(address)
     })
 
-    it('should work in Japanese after decomposing', () => {
-      const passphrase = 'うかべる　くすりゆび　ひさしぶり　たそがれ　そっこう　ちけいず　ひさしぶり　ていか　しゃちょう　けおりもの　ちぬり　りきせつ'.normalize('NFD')
-      const address = 'DQquFjRfgA26cut7A8wFC4Bbo4TawWArWr'
-      expect(WalletService.getAddress(passphrase, 30)).toEqual(address)
-    })
-
     it('should work in Korean with initially decomposed characters', () => {
       const passphrase = '변명 박수 사건 실컷 목적 비용 가능 시골 수동적 청춘 식량 도망'
       const address = 'D5FvjRH136fbw8j4thcmKiFiJjfbYHT3zY'
       expect(WalletService.getAddress(passphrase, 30)).toEqual(address)
     })
 
-    it('should not work in Korean without decomposing', () => {
+    it('should work in Korean without decomposing', () => {
       const passphrase = '변명 박수 사건 실컷 목적 비용 가능 시골 수동적 청춘 식량 도망'
-      const address = 'D5FvjRH136fbw8j4thcmKiFiJjfbYHT3zY'
-      expect(WalletService.getAddress(passphrase, 30)).not.toEqual(address)
-    })
-
-    it('should work in Korean after decomposing', () => {
-      const passphrase = '변명 박수 사건 실컷 목적 비용 가능 시골 수동적 청춘 식량 도망'.normalize('NFD')
       const address = 'D5FvjRH136fbw8j4thcmKiFiJjfbYHT3zY'
       expect(WalletService.getAddress(passphrase, 30)).toEqual(address)
     })
 
     it('should work in Spanish', () => {
       const passphrase = 'cadena cadáver malla etapa vista alambre burbuja vejez aéreo taco rebaño tauro'
-      const address = 'DNZSrNt7SQ1VBrzx7C17gbPv9FDAxnaor3'
-      expect(WalletService.getAddress(passphrase, 30)).toEqual(address)
-    })
-
-    it('should work in Spanish after decomposing', () => {
-      const passphrase = 'cadena cadáver malla etapa vista alambre burbuja vejez aéreo taco rebaño tauro'.normalize('NFD')
       const address = 'DNZSrNt7SQ1VBrzx7C17gbPv9FDAxnaor3'
       expect(WalletService.getAddress(passphrase, 30)).toEqual(address)
     })

--- a/src/renderer/pages/Wallet/WalletImport.vue
+++ b/src/renderer/pages/Wallet/WalletImport.vue
@@ -229,7 +229,7 @@ export default {
       if (this.step === 2 && !this.useOnlyAddress) {
         // Important: .normalize('NFD') is needed to properly work with Korean bip39 words
         // It alters the passphrase string, so no need to normalize again in the importWallet function
-        this.schema.address = WalletService.getAddress(this.schema.passphrase.normalize('NFD'), this.session_network.version)
+        this.schema.address = WalletService.getAddress(this.schema.passphrase, this.session_network.version)
       }
     }
   },

--- a/src/renderer/services/client.js
+++ b/src/renderer/services/client.js
@@ -8,6 +8,16 @@ import store from '@/store'
 import eventBus from '@/plugins/event-bus'
 
 export default class ClientService {
+  /*
+   * Normalizes the passphrase by decomposing any characters (if applicable)
+   * This is mainly used for the korean language where characters are combined while the passphrase was based on the decomposed consonants
+  */
+  normalizePassphrase (passphrase) {
+    if (passphrase) {
+      return passphrase.normalize('NFD')
+    }
+  }
+
   /**
    * Fetch the network configuration according to the version.
    * Create a new client to isolate the main client.
@@ -390,6 +400,9 @@ export default class ClientService {
       .votesAsset(votes)
       .fee(fee)
 
+    passphrase = this.normalizePassphrase(passphrase)
+    secondPassphrase = this.normalizePassphrase(secondPassphrase)
+
     return this.__signTransaction({
       transaction,
       passphrase,
@@ -418,6 +431,9 @@ export default class ClientService {
       .delegateRegistration()
       .usernameAsset(username)
       .fee(fee)
+
+    passphrase = this.normalizePassphrase(passphrase)
+    secondPassphrase = this.normalizePassphrase(secondPassphrase)
 
     return this.__signTransaction({
       transaction,
@@ -453,6 +469,9 @@ export default class ClientService {
       .recipientId(recipientId)
       .vendorField(vendorField)
 
+    passphrase = this.normalizePassphrase(passphrase)
+    secondPassphrase = this.normalizePassphrase(secondPassphrase)
+
     return this.__signTransaction({
       transaction,
       passphrase,
@@ -481,6 +500,8 @@ export default class ClientService {
       .signatureAsset(secondPassphrase)
       .fee(fee)
 
+    passphrase = this.normalizePassphrase(passphrase)
+
     return this.__signTransaction({
       transaction,
       passphrase,
@@ -504,13 +525,13 @@ export default class ClientService {
     })
 
     if (passphrase) {
-      transaction = transaction.sign(passphrase)
+      transaction = transaction.sign(this.normalizePassphrase(passphrase))
     } else if (wif) {
       transaction = transaction.signWithWif(wif)
     }
 
     if (secondPassphrase) {
-      transaction = transaction.secondSign(secondPassphrase)
+      transaction = transaction.secondSign(this.normalizePassphrase(secondPassphrase))
     }
 
     return returnObject ? transaction : transaction.getStruct()

--- a/src/renderer/services/wallet.js
+++ b/src/renderer/services/wallet.js
@@ -5,6 +5,14 @@ import axios from 'axios'
 
 export default class WalletService {
   /*
+   * Normalizes the passphrase by decomposing any characters (if applicable)
+   * This is mainly used for the korean language where characters are combined while the passphrase was based on the decomposed consonants
+  */
+  static normalizePassphrase (passphrase) {
+    return passphrase.normalize('NFD')
+  }
+
+  /*
    * Generate a wallet.
    * It does not check if the wallet is new (no transactions on the blockchain)
    * @param {Number} pubKeyHash - also known as address or network version
@@ -12,7 +20,7 @@ export default class WalletService {
    */
   static generate (pubKeyHash, language) {
     const passphrase = bip39.generateMnemonic(null, null, bip39.wordlists[language])
-    const publicKey = crypto.getKeys(passphrase).publicKey
+    const publicKey = crypto.getKeys(this.normalizePassphrase(passphrase)).publicKey
     return {
       address: crypto.getAddress(publicKey, pubKeyHash),
       passphrase
@@ -33,7 +41,7 @@ export default class WalletService {
    * @return {String}
    */
   static getAddress (passphrase, pubKeyHash) {
-    const publicKey = crypto.getKeys(passphrase).publicKey
+    const publicKey = crypto.getKeys(this.normalizePassphrase(passphrase)).publicKey
     return crypto.getAddress(publicKey, pubKeyHash)
   }
 
@@ -47,7 +55,7 @@ export default class WalletService {
    * @return {String}
    */
   static getPublicKeyFromPassphrase (passphrase) {
-    return crypto.getKeys(passphrase).publicKey
+    return crypto.getKeys(this.normalizePassphrase(passphrase)).publicKey
   }
 
   /**
@@ -72,7 +80,7 @@ export default class WalletService {
    * @return {String}
    */
   static signMessage (message, passphrase) {
-    return Message.sign(message, passphrase)
+    return Message.sign(message, this.normalizePassphrase(passphrase))
   }
 
   /**
@@ -113,7 +121,7 @@ export default class WalletService {
    * @return {Boolean}
    */
   static validatePassphrase (passphrase, pubKeyHash) {
-    const publicKey = crypto.getKeys(passphrase).publicKey
+    const publicKey = crypto.getKeys(this.normalizePassphrase(passphrase)).publicKey
     return crypto.validatePublicKey(publicKey, pubKeyHash)
   }
 
@@ -124,7 +132,7 @@ export default class WalletService {
    * @return {Boolean}
    */
   static isBip39Passphrase (passphrase, language) {
-    return bip39.validateMnemonic(passphrase, bip39.wordlists[language])
+    return bip39.validateMnemonic(this.normalizePassphrase(passphrase), bip39.wordlists[language])
   }
 
   /**
@@ -146,6 +154,6 @@ export default class WalletService {
    * @return {Boolean}
    */
   static verifyPassphrase (address, passphrase, pubKeyHash) {
-    return address === WalletService.getAddress(passphrase, pubKeyHash)
+    return address === WalletService.getAddress(this.normalizePassphrase(passphrase), pubKeyHash)
   }
 }


### PR DESCRIPTION
## Proposed changes

Also fix the issue with Korean passphrases when sending transactions / signing messages.
Please test again by trying to send some transactions, including one with a second signature. Don't forget to set your bip39 language to Korean when creating a new wallet to test it

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
