### PR TITLE
fix: show unconfirmed tx for type > 0

### DIFF
--- a/src/renderer/components/Transaction/TransactionModal.vue
+++ b/src/renderer/components/Transaction/TransactionModal.vue
@@ -160,7 +160,7 @@ export default {
         timestamp,
         vendorField,
         confirmations: 0,
-        recipient: transaction.recipientId,
+        recipient: transaction.recipientId || transaction.sender,
         profileId: this.session_profile.id,
         raw: transaction
       })


### PR DESCRIPTION
## Proposed changes

Resolves #774 

Transactions that were not a transfer did not have a recipientId, which resulted in the `storeTransaction` function setting a property to undefined which made the unconfirmed transaction not appear. This PR sets the sender as recipient if recipientId is undefined, which makes the unconfirmed tx show up again:

<img width="871" alt="schermafbeelding 2018-12-20 om 22 28 43" src="https://user-images.githubusercontent.com/35610748/50311774-a45ab100-04a6-11e9-9da8-85ef9bd61d53.png">


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
