### PR TITLE
fix: set tooltip container on transaction table

### DIFF
--- a/src/renderer/components/Transaction/TransactionShow.vue
+++ b/src/renderer/components/Transaction/TransactionShow.vue
@@ -134,7 +134,7 @@
         <span
           v-show="!transaction.isExpired"
           v-tooltip="{
-            content: $t('TRANSACTION.CONFIRMATION_COUNT', [transaction.confirmations]),
+            content: $t('TRANSACTION.CONFIRMATION_COUNT', { confirmations: transaction.confirmations }),
             trigger: 'hover'
           }"
           class="ml-1"

--- a/src/renderer/components/Transaction/TransactionTable.vue
+++ b/src/renderer/components/Transaction/TransactionTable.vue
@@ -22,7 +22,8 @@
               v-tooltip="{
                 content: data.row.vendorField,
                 classes: 'text-xs',
-                trigger: 'hover'
+                trigger: 'hover',
+                container: '.TransactionTable'
               }"
               :name="data.formattedRow['vendorField'] ? 'vendorfield' : 'vendorfield-empty'"
               view-box="0 0 18 18"
@@ -33,7 +34,8 @@
               v-tooltip="{
                 content: data.row.id,
                 classes: 'text-xs',
-                trigger: 'hover'
+                trigger: 'hover',
+                container: '.TransactionTable'
               }"
               class="mr-1"
             >
@@ -58,6 +60,7 @@
               html: true,
               classes: 'leading-loose',
               trigger: 'hover',
+              container: '.TransactionTable',
               placement: 'left'
             }"
             class="font-bold mr-2 whitespace-no-wrap"
@@ -68,9 +71,10 @@
           <span
             v-if="!isWellConfirmed(data.row.confirmations)"
             v-tooltip="{
-              content: $t('TRANSACTION.CONFIRMATION_COUNT', [data.row.confirmations]),
+              content: $t('TRANSACTION.CONFIRMATION_COUNT', { confirmations: data.row.confirmations }),
               classes: 'text-xs',
-              trigger: 'hover'
+              trigger: 'hover',
+              container: '.TransactionTable'
             }"
             :class="{
               'text-theme-transaction-confirmations-sent bg-theme-transaction-sent': data.row.isSender,
@@ -88,7 +92,8 @@
             v-tooltip="{
               content: $t('TRANSACTION.WELL_CONFIRMED_COUNT', { confirmations: data.row.confirmations }),
               classes: 'text-xs',
-              trigger: 'hover'
+              trigger: 'hover',
+              container: '.TransactionTable'
             }"
             :class="{
               'text-theme-transaction-sent-arrow bg-theme-transaction-sent': data.row.isSender,
@@ -109,7 +114,10 @@
           :class="[ isDashboard ? 'dashboard-address' : 'max-w-xxs' ]"
           class="overflow-hidden truncate"
         >
-          <WalletAddress :address="data.row.sender" />
+          <WalletAddress
+            :address="data.row.sender"
+            tooltip-container=".TransactionTable"
+          />
         </div>
 
         <div
@@ -121,6 +129,7 @@
             :address="data.row.recipient"
             :type="data.row.type"
             :asset="data.row.asset"
+            tooltip-container=".TransactionTable"
           />
         </div>
 

--- a/src/renderer/components/Wallet/WalletAddress.vue
+++ b/src/renderer/components/Wallet/WalletAddress.vue
@@ -3,7 +3,10 @@
   <span>
     <span v-if="!type">
       <a
-        v-tooltip="address"
+        v-tooltip="{
+          content: address,
+          container: tooltipContainer
+        }"
         href="#"
         @click.stop="openAddress"
       >
@@ -64,6 +67,11 @@ export default {
       type: Number,
       required: false,
       default: () => 0
+    },
+    tooltipContainer: {
+      type: String,
+      required: false,
+      default: () => '#app'
     }
   },
 

--- a/src/renderer/i18n/locales/en-US.js
+++ b/src/renderer/i18n/locales/en-US.js
@@ -680,7 +680,7 @@ export default {
     },
     AMOUNT: 'Amount',
     BLOCK_ID: 'Block ID',
-    CONFIRMATION_COUNT: '{0} Confirmations',
+    CONFIRMATION_COUNT: '{confirmations} Confirmations',
     CONFIRMATIONS: 'Confirmations',
     CREATE_TRANSFER: 'Create Transfer',
     DISCARD: 'Discard',


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

Partially solves #767 and replaces #822.

This sets the tooltip container to `.TransactionTable` and adds a property to `WalletAddress`, which allows to set a custom tooltip container.

![tooltip](https://user-images.githubusercontent.com/6547002/50336919-bc1a4f80-050f-11e9-9d56-e614905b833b.gif)

@j-a-m-l & @JeremiGendron can you confirm this works for you?

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes