### PR TITLE
fix: capture any error when sending transactions and warn about broadcasting

### DIFF
--- a/__tests__/unit/components/Transaction/TransactionModal.spec.js
+++ b/__tests__/unit/components/Transaction/TransactionModal.spec.js
@@ -58,8 +58,39 @@ describe('TransactionModal', () => {
         response.status = 200
       })
 
+      describe('when the response does not include errors', () => {
+        beforeEach(() => {
+          response.data.errors = null
+          response.data.data = {
+            invalid: [],
+            accept: []
+          }
+        })
+
+        it('should return `true`', () => {
+          expect(wrapper.vm.isSuccessfulResponse(response)).toBeTrue()
+        })
+      })
+
+      describe('when the response includes errors', () => {
+        beforeEach(() => {
+          response.data.errors = {
+            tx1: [{ type: 'ERR_LOW_FEE' }]
+          }
+          response.data.data = {
+            invalid: [],
+            accept: []
+          }
+        })
+
+        it('should return `false`', () => {
+          expect(wrapper.vm.isSuccessfulResponse(response)).toBeFalse()
+        })
+      })
+
       describe('when the response does not include invalid transactions', () => {
         beforeEach(() => {
+          response.data.errors = null
           response.data.data.invalid = []
         })
 
@@ -75,24 +106,8 @@ describe('TransactionModal', () => {
           }
         })
 
-        describe('when the response does not include accepted and broadcasted transactions', () => {
-          beforeEach(() => {
-            response.data.data = {
-              invalid: ['tx1'],
-              accept: [],
-              broadcast: []
-            }
-          })
-
-          it('should return `false`', () => {
-            expect(wrapper.vm.isSuccessfulResponse(response)).toBeFalse()
-          })
-        })
-
-        xdescribe('when the response includes accepted or broadcasted transactions', () => {
-          it('should return `true`', () => {
-            expect(wrapper.vm.isSuccessfulResponse(response)).toBeTrue()
-          })
+        it('should return `false`', () => {
+          expect(wrapper.vm.isSuccessfulResponse(response)).toBeFalse()
         })
       })
     })

--- a/src/renderer/components/Transaction/TransactionModal.vue
+++ b/src/renderer/components/Transaction/TransactionModal.vue
@@ -134,7 +134,7 @@ export default {
         response = await this.$client.broadcastTransaction(this.transaction)
       }
 
-      const { data } = response.data
+      const { data, errors } = response.data
 
       if (this.isSuccessfulResponse(response)) {
         this.storeTransaction(this.transaction)
@@ -145,8 +145,12 @@ export default {
           this.$success(success)
         }
       } else {
+        const anyLowFee = Object.keys(errors).some(transactionId => {
+          return errors[transactionId].some(error => error.type === 'ERR_LOW_FEE')
+        })
+
         // Be clear with the user about the error cause
-        if (data && data.accept.length === 0 && data.broadcast.length === 0) {
+        if (anyLowFee) {
           this.$error(errorLowFee)
         } else {
           this.$error(error)

--- a/src/renderer/components/Transaction/TransactionModal.vue
+++ b/src/renderer/components/Transaction/TransactionModal.vue
@@ -114,7 +114,7 @@ export default {
     async onConfirm () {
       // Produce the messages before closing the modal to avoid `$t` scope errors
       const messages = {
-        succcess: this.$t(`TRANSACTION.SUCCESS.${this.transactionKey}`),
+        success: this.$t(`TRANSACTION.SUCCESS.${this.transactionKey}`),
         error: this.$t(`TRANSACTION.ERROR.${this.transactionKey}`),
         errorLowFee: this.$t('TRANSACTION.ERROR.FEE_TOO_LOW', {
           fee: this.formatter_networkCurrency(this.transaction.fee)

--- a/src/renderer/components/Wallet/WalletSelection.vue
+++ b/src/renderer/components/Wallet/WalletSelection.vue
@@ -148,7 +148,7 @@ export default {
       const ledgerWallets = this.$store.getters['ledger/isConnected'] ? this.$store.getters['ledger/wallets'] : []
 
       const wallets = this.wallets
-      if (ledgerWallets.length && this.profile.networkId === this.session_network.id) {
+      if (ledgerWallets.length && this.profile && this.profile.networkId === this.session_network.id) {
         wallets.push(...ledgerWallets)
       }
 

--- a/src/renderer/i18n/locales/en-US.js
+++ b/src/renderer/i18n/locales/en-US.js
@@ -684,6 +684,9 @@ export default {
       VOTE_DELEGATE: 'Vote for delegate {delegate}',
       UNVOTE_DELEGATE: 'Unvote delegate {delegate}'
     },
+    WARNING: {
+      BROADCAST: 'Transaction was broadcasted to other peers. It may not be accepted by them'
+    },
     AMOUNT: 'Amount',
     BLOCK_ID: 'Block ID',
     CONFIRMATION_COUNT: '{0} Confirmations',


### PR DESCRIPTION
## Proposed changes
This PR fixes 1 problem introduced on https://github.com/ArkEcosystem/desktop-wallet/pull/820, which ignores that the API response could include other errors.

Apart from that, it displays a warning when the transaction is only broadcasted.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Test (adding missing tests or fixing existing tests)

## Checklist
- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
