### PR TITLE
fix: split japanese passphrases correctly

### DIFF
--- a/src/renderer/components/Transaction/TransactionForm/TransactionFormSecondSignature.vue
+++ b/src/renderer/components/Transaction/TransactionForm/TransactionFormSecondSignature.vue
@@ -173,6 +173,10 @@ export default {
     },
 
     passphraseWords () {
+      // Check for Japanese "space"
+      if (/\u3000/.test(this.secondPassphrase)) {
+        return this.secondPassphrase.split('\u3000')
+      }
       return this.secondPassphrase.split(' ')
     },
 

--- a/src/renderer/pages/Wallet/WalletNew.vue
+++ b/src/renderer/pages/Wallet/WalletNew.vue
@@ -305,11 +305,18 @@ export default {
     additionalSuggestions () {
       const passphrases = Object.values(this.wallets)
 
-      return flatten(passphrases.map(passphrase => passphrase.split(' ')))
+      // Check for Japanese "space"
+      return flatten(passphrases.map(passphrase =>
+        /\u3000/.test(passphrase) ? passphrase.split('\u3000') : passphrase.split(' ')
+      ))
     },
     passphraseWords () {
       const passphrase = this.schema.passphrase
       if (passphrase) {
+        // Check for Japanese "space"
+        if (/\u3000/.test(passphrase)) {
+          return this.schema.passphrase.split('\u3000')
+        }
         return this.schema.passphrase.split(' ')
       }
       return []


### PR DESCRIPTION
## Proposed changes

Properly split Japanese passphrases so this no longer happens:

<img width="465" alt="schermafbeelding 2018-12-21 om 21 11 26" src="https://user-images.githubusercontent.com/35610748/50361848-78eacb80-0565-11e9-97cf-941e861020e1.png">
<img width="483" alt="schermafbeelding 2018-12-18 om 23 13 53" src="https://user-images.githubusercontent.com/35610748/50361851-7b4d2580-0565-11e9-99c7-35c393e0e459.png">

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
