### PR TITLE
fix: use ticker instead of token for market chart

### DIFF
--- a/__tests__/unit/components/MarketChart/MarketChart.spec.js
+++ b/__tests__/unit/components/MarketChart/MarketChart.spec.js
@@ -2,10 +2,14 @@ import { shallowMount } from '@vue/test-utils'
 import { MarketChart } from '@/components/MarketChart'
 
 const mocks = {
+  session_network: {
+    market: {
+      ticker: 'ARK'
+    }
+  },
   $store: {
     getters: {
-      'session/currency': 'USD',
-      'session/network': { market: { ticker: 'ARK' }}
+      'session/currency': 'USD'
     }
   }
 }

--- a/__tests__/unit/components/MarketChart/MarketChart.spec.js
+++ b/__tests__/unit/components/MarketChart/MarketChart.spec.js
@@ -5,7 +5,7 @@ const mocks = {
   $store: {
     getters: {
       'session/currency': 'USD',
-      'session/network': { token: 'ARK' }
+      'session/network': { market: { ticker: 'ARK' }}
     }
   }
 }

--- a/src/renderer/components/MarketChart/MarketChart.vue
+++ b/src/renderer/components/MarketChart/MarketChart.vue
@@ -78,8 +78,8 @@ export default {
       return this.$store.getters['session/theme']
     },
 
-    token () {
-      return this.session_network.token
+    ticker () {
+      return this.session_network.market.ticker
     }
   },
 
@@ -92,7 +92,7 @@ export default {
       this.renderChart()
     },
 
-    token () {
+    ticker () {
       this.renderChart()
     },
 
@@ -117,148 +117,150 @@ export default {
     async renderChart () {
       await this.renderGradient()
 
-      const response = await cryptoCompare.historicByType(this.period, this.token, this.currency)
+      const response = await cryptoCompare.historicByType(this.period, this.ticker, this.currency)
 
-      // Since BTC price could be very low :(, the linear scale could produce
-      // imprecise values, such as converting 0.00001078 to 0, provoking that
-      // the chart isn't displayed correctly
-      const scaleCorrection = 1000
-      const data = response.datasets.map(datum => datum * scaleCorrection)
+      if (response && response.datasets) {
+        // Since BTC price could be very low :(, the linear scale could produce
+        // imprecise values, such as converting 0.00001078 to 0, provoking that
+        // the chart isn't displayed correctly
+        const scaleCorrection = 1000
+        const data = response.datasets.map(datum => datum * scaleCorrection)
 
-      const themeGridLines = this.colours[this.theme].lines
-      const themeTicks = this.colours[this.theme].ticks
+        const themeGridLines = this.colours[this.theme].lines
+        const themeTicks = this.colours[this.theme].ticks
 
-      const fontConfig = {
-        fontColor: themeTicks,
-        fontSize: 14,
-        fontStyle: 600
-      }
+        const fontConfig = {
+          fontColor: themeTicks,
+          fontSize: 14,
+          fontStyle: 600
+        }
 
-      this.options = {
-        showScale: true,
-        responsive: true,
-        maintainAspectRatio: false,
-        elements: {
-          line: {
-            cubicInterpolationMode: 'monotone'
-            // NOTE: to improve rendering time
-            // tension: 0
-          }
-        },
-        legend: {
-          display: false
-        },
-        layout: {
-          padding: {
-            left: 0,
-            right: 0,
-            top: 10,
-            bottom: 10
-          }
-        },
-        scales: {
-          yAxes: [
-            {
-              gridLines: {
-                borderDash: [5, 5],
-                color: themeGridLines,
-                display: true,
-                drawBorder: false
-              },
-              ticks: {
-                padding: 15,
-                ...fontConfig,
-                callback: (value, index) => {
-                  if (index % 2 === 0) return
-
-                  const formatConfig = { currency: this.currency }
-                  const price = value / scaleCorrection
-
-                  if (price < 1e-4) {
-                    formatConfig.maximumFractionDigits = 8
-                  } else if (price < 1e-2) {
-                    formatConfig.maximumFractionDigits = 5
-                  } else {
-                    formatConfig.maximumFractionDigits = 3
-                  }
-
-                  return this.currency_format(price, formatConfig)
-                }
-              }
+        this.options = {
+          showScale: true,
+          responsive: true,
+          maintainAspectRatio: false,
+          elements: {
+            line: {
+              cubicInterpolationMode: 'monotone'
+              // NOTE: to improve rendering time
+              // tension: 0
             }
-          ],
-          xAxes: [
-            {
-              gridLines: {
-                drawBorder: false,
-                display: false
-              },
-              ticks: {
-                padding: 10,
-                ...fontConfig,
-                callback: (value, index, values) => {
-                  if (this.period !== 'day' && index === values.length - 1) {
-                    return this.$t('MARKET_CHART.TODAY')
-                  } else if (this.period === 'week') {
-                    const width = this.$el.clientWidth
-                    if (width > 1200) {
-                      return this.$t(`MARKET_CHART.WEEK.LONG.${value.toUpperCase()}`)
+          },
+          legend: {
+            display: false
+          },
+          layout: {
+            padding: {
+              left: 0,
+              right: 0,
+              top: 10,
+              bottom: 10
+            }
+          },
+          scales: {
+            yAxes: [
+              {
+                gridLines: {
+                  borderDash: [5, 5],
+                  color: themeGridLines,
+                  display: true,
+                  drawBorder: false
+                },
+                ticks: {
+                  padding: 15,
+                  ...fontConfig,
+                  callback: (value, index) => {
+                    if (index % 2 === 0) return
+
+                    const formatConfig = { currency: this.currency }
+                    const price = value / scaleCorrection
+
+                    if (price < 1e-4) {
+                      formatConfig.maximumFractionDigits = 8
+                    } else if (price < 1e-2) {
+                      formatConfig.maximumFractionDigits = 5
                     } else {
-                      return this.$t(`MARKET_CHART.WEEK.SHORT.${value.toUpperCase()}`)
+                      formatConfig.maximumFractionDigits = 3
                     }
-                  }
 
-                  return value
+                    return this.currency_format(price, formatConfig)
+                  }
                 }
               }
-            }
-          ]
-        },
-        tooltips: {
-          displayColors: false,
-          callbacks: {
-            label: (item, data) => {
-              return this.currency_format(item.yLabel / scaleCorrection, { currency: this.currency })
-            },
-            title: (items, data) => {
-              const { index } = items[0]
-              const values = data.datasets[0].data
-              let title = items[0].xLabel
+            ],
+            xAxes: [
+              {
+                gridLines: {
+                  drawBorder: false,
+                  display: false
+                },
+                ticks: {
+                  padding: 10,
+                  ...fontConfig,
+                  callback: (value, index, values) => {
+                    if (this.period !== 'day' && index === values.length - 1) {
+                      return this.$t('MARKET_CHART.TODAY')
+                    } else if (this.period === 'week') {
+                      const width = this.$el.clientWidth
+                      if (width > 1200) {
+                        return this.$t(`MARKET_CHART.WEEK.LONG.${value.toUpperCase()}`)
+                      } else {
+                        return this.$t(`MARKET_CHART.WEEK.SHORT.${value.toUpperCase()}`)
+                      }
+                    }
 
-              if (this.period === 'day') {
-                const midnight = data.labels.indexOf('00:00')
-                if (index < midnight) {
-                  return this.$t('MARKET_CHART.YESTERDAY_AT', { hour: title })
+                    return value
+                  }
                 }
-                return this.$t('MARKET_CHART.TODAY_AT', { hour: title })
-              } else if (index === values.length - 1) {
-                return this.$t('MARKET_CHART.TODAY')
-              } else if (this.period === 'week') {
-                return this.$t(`MARKET_CHART.WEEK.LONG.${title.toUpperCase()}`)
-              } else {
-                const days = values.length
-                const today = dayjs()
-                today.date(values[days - 1])
-                title = today.subtract(days - index - 1, 'day')
-                return this.$d(title)
+              }
+            ]
+          },
+          tooltips: {
+            displayColors: false,
+            callbacks: {
+              label: (item, data) => {
+                return this.currency_format(item.yLabel / scaleCorrection, { currency: this.currency })
+              },
+              title: (items, data) => {
+                const { index } = items[0]
+                const values = data.datasets[0].data
+                let title = items[0].xLabel
+
+                if (this.period === 'day') {
+                  const midnight = data.labels.indexOf('00:00')
+                  if (index < midnight) {
+                    return this.$t('MARKET_CHART.YESTERDAY_AT', { hour: title })
+                  }
+                  return this.$t('MARKET_CHART.TODAY_AT', { hour: title })
+                } else if (index === values.length - 1) {
+                  return this.$t('MARKET_CHART.TODAY')
+                } else if (this.period === 'week') {
+                  return this.$t(`MARKET_CHART.WEEK.LONG.${title.toUpperCase()}`)
+                } else {
+                  const days = values.length
+                  const today = dayjs()
+                  today.date(values[days - 1])
+                  title = today.subtract(days - index - 1, 'day')
+                  return this.$d(title)
+                }
               }
             }
           }
         }
-      }
 
-      this.chartData = {
-        labels: response.labels,
-        datasets: [{
-          // Do not show the points, but enable a big target for the tooltip
-          pointHitRadius: 12,
-          pointRadius: 0,
-          borderWidth: 3,
-          type: 'line',
-          fill: false,
-          borderColor: this.gradient || this.colours.gradient[0],
-          data
-        }]
+        this.chartData = {
+          labels: response.labels,
+          datasets: [{
+            // Do not show the points, but enable a big target for the tooltip
+            pointHitRadius: 12,
+            pointRadius: 0,
+            borderWidth: 3,
+            type: 'line',
+            fill: false,
+            borderColor: this.gradient || this.colours.gradient[0],
+            data
+          }]
+        }
       }
     },
 


### PR DESCRIPTION
## Proposed changes

Use the market ticker instead of the token to fetch the chart data, as that is what it was supposed to be used for I guess 🤔 It also adds a check if the response from cryptoCompare contains the right data, as the `datasets` property was not there if an incorrect ticker / token was used.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
