### PR TITLE
fix: do not update network config as it overwrites network changes

### DIFF
--- a/src/renderer/store/modules/network.js
+++ b/src/renderer/store/modules/network.js
@@ -70,7 +70,6 @@ export default new BaseModule(NetworkModel, {
       commit('SET_ALL', NETWORKS)
     },
 
-    // TODO: look into where this is used, as it might need to be changed to getters[network/update] instead
     async updateNetworkConfig ({ dispatch, getters, _, rootGetters }, networkId) {
       var network = getters['byId'](networkId)
       if (!network) {

--- a/src/renderer/store/modules/session.js
+++ b/src/renderer/store/modules/session.js
@@ -186,10 +186,7 @@ export default {
 
     async setProfileId ({ commit, dispatch }, value) {
       commit('SET_PROFILE_ID', value)
-      const profile = await dispatch('load', value)
-      if (profile) {
-        await dispatch('network/updateNetworkConfig', profile.networkId, { root: true })
-      }
+      await dispatch('load', value)
     },
 
     setTheme ({ commit }, value) {


### PR DESCRIPTION
## Proposed changes

Networks got reloaded when you switched profiles, which reset any custom changes you made to it. This PR currently removes that behaviour, but I'm unsure what the use of fetching new network data was, so proposing two additional changes instead of simply removing it:

1. we could call the `updateNetworkConfig` function the first time the app loads and we load the default networks from the config file (this is only done once).
2. we could add a "refresh" button to the network modal in which you can see your network configs, which would overwrite any changes you made by fetching the latest config from a network peer. By doing it this way you will see the new settings and can adjust them to your liking, instead of having this happen in the background.

What do you think of the above solutions?

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
