### PR TITLE
fix: contact sorting

### DIFF
--- a/src/renderer/pages/Contact/ContactAll.vue
+++ b/src/renderer/pages/Contact/ContactAll.vue
@@ -71,7 +71,7 @@
 
 <script>
 import { ContactRemovalConfirmation } from '@/components/Contact'
-import { sortByProp } from '@/components/utils/Sorting'
+import { orderBy } from 'lodash'
 import { WalletIdenticon, WalletIdenticonPlaceholder } from '@/components/Wallet'
 
 export default {
@@ -91,7 +91,7 @@ export default {
     contacts () {
       const contacts = this.$store.getters['wallet/contactsByProfileId'](this.session_profile.id)
       const prop = 'name'
-      return contacts.slice().sort(sortByProp(prop))
+      return orderBy(contacts, ['name', 'address'], ['asc', 'asc'])
     }
   },
 


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
This resolves bug discussed by @zillionn in #795 
Contact are sorted based on name and then based on address. By this, ordering of contacts will remain fixed every time that contactsAll page is opened.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
