### PR TITLE
fix: various tx table and modal UI improvements

### DIFF
--- a/src/renderer/components/ListDivided/ListDividedItem.vue
+++ b/src/renderer/components/ListDivided/ListDividedItem.vue
@@ -14,7 +14,10 @@
       {{ label }}
     </span>
 
-    <div class="ListDividedItem__value">
+    <div
+      :class="itemValueClass"
+      class="ListDividedItem__value"
+    >
       <slot>
         <span
           v-if="value"
@@ -46,6 +49,11 @@ export default {
       type: [String, Number],
       required: false,
       default: null
+    },
+    itemValueClass: {
+      type: String,
+      required: false,
+      default: ''
     }
   }
 }

--- a/src/renderer/components/Transaction/TransactionShow.vue
+++ b/src/renderer/components/Transaction/TransactionShow.vue
@@ -5,7 +5,10 @@
     @close="emitClose"
   >
     <ListDivided>
-      <ListDividedItem :label="$t('TRANSACTION.ID')">
+      <ListDividedItem
+        :label="$t('TRANSACTION.ID')"
+        item-value-class="flex items-center"
+      >
         <span
           v-tooltip="{
             content: transaction.id,
@@ -18,7 +21,7 @@
         </span>
         <ButtonClipboard
           :value="transaction.id"
-          class="text-theme-page-text-light mx-1"
+          class="text-theme-page-text-light mx-2"
         />
         <button
           v-if="transaction.confirmations > 0"
@@ -27,6 +30,7 @@
             trigger: 'hover'
           }"
           @click="openTransaction"
+          class="flex items-center"
         >
           <SvgIcon
             name="open-external"
@@ -39,6 +43,7 @@
       <ListDividedItem
         v-if="transaction.blockId"
         :label="$t('TRANSACTION.BLOCK_ID')"
+        item-value-class="flex items-center"
       >
         {{ transaction.blockId }}
         <button
@@ -47,6 +52,7 @@
             trigger: 'hover'
           }"
           @click="openBlock"
+          class="flex items-center ml-2"
         >
           <SvgIcon
             name="open-external"
@@ -56,7 +62,10 @@
         </button>
       </ListDividedItem>
 
-      <ListDividedItem :label="$t('TRANSACTION.SENDER')">
+      <ListDividedItem
+        :label="$t('TRANSACTION.SENDER')"
+        item-value-class="flex items-center"
+      >
         <a
           href="#"
           @click.stop="openAddressInWallet(transaction.sender)"
@@ -65,7 +74,7 @@
         </a>
         <ButtonClipboard
           :value="transaction.sender"
-          class="text-theme-page-text-light mx-1"
+          class="text-theme-page-text-light mx-2"
         />
         <button
           v-tooltip="{
@@ -73,6 +82,7 @@
             trigger: 'hover'
           }"
           @click="openAddress(transaction.sender)"
+          class="flex items-center"
         >
           <SvgIcon
             name="open-external"
@@ -85,6 +95,7 @@
       <ListDividedItem
         v-if="transaction.recipient"
         :label="$t('TRANSACTION.RECIPIENT')"
+        item-value-class="flex items-center"
       >
         <a
           href="#"
@@ -94,7 +105,7 @@
         </a>
         <ButtonClipboard
           :value="transaction.recipient"
-          class="text-theme-page-text-light mx-1"
+          class="text-theme-page-text-light mx-2"
         />
         <button
           v-tooltip="{
@@ -102,6 +113,7 @@
             trigger: 'hover'
           }"
           @click="openAddress(transaction.recipient)"
+          class="flex items-center"
         >
           <SvgIcon
             name="open-external"
@@ -120,7 +132,10 @@
         :value="formatter_networkCurrency(transaction.fee)"
       />
 
-      <ListDividedItem :label="$t('TRANSACTION.CONFIRMATIONS')">
+      <ListDividedItem
+        :label="$t('TRANSACTION.CONFIRMATIONS')"
+        item-value-class="flex items-center"
+      >
         <span v-if="transaction.isExpired">
           {{ $t('TRANSACTION.EXPIRED') }}
         </span>
@@ -137,7 +152,7 @@
             content: $t('TRANSACTION.CONFIRMATION_COUNT', { confirmations: transaction.confirmations }),
             trigger: 'hover'
           }"
-          class="ml-1"
+          class="flex items-center ml-2"
         >
           <SvgIcon
             name="time"

--- a/src/renderer/components/Transaction/TransactionShow.vue
+++ b/src/renderer/components/Transaction/TransactionShow.vue
@@ -29,8 +29,8 @@
             content: `${$t('TRANSACTION.OPEN_IN_EXPLORER')}`,
             trigger: 'hover'
           }"
-          @click="openTransaction"
           class="flex items-center"
+          @click="openTransaction"
         >
           <SvgIcon
             name="open-external"
@@ -51,8 +51,8 @@
             content: `${$t('TRANSACTION.OPEN_IN_EXPLORER')}`,
             trigger: 'hover'
           }"
-          @click="openBlock"
           class="flex items-center ml-2"
+          @click="openBlock"
         >
           <SvgIcon
             name="open-external"
@@ -81,8 +81,8 @@
             content: `${$t('TRANSACTION.OPEN_IN_EXPLORER')}`,
             trigger: 'hover'
           }"
-          @click="openAddress(transaction.sender)"
           class="flex items-center"
+          @click="openAddress(transaction.sender)"
         >
           <SvgIcon
             name="open-external"
@@ -112,8 +112,8 @@
             content: `${$t('TRANSACTION.OPEN_IN_EXPLORER')}`,
             trigger: 'hover'
           }"
-          @click="openAddress(transaction.recipient)"
           class="flex items-center"
+          @click="openAddress(transaction.recipient)"
         >
           <SvgIcon
             name="open-external"

--- a/src/renderer/components/Transaction/TransactionTable.vue
+++ b/src/renderer/components/Transaction/TransactionTable.vue
@@ -116,6 +116,7 @@
         >
           <WalletAddress
             :address="data.row.sender"
+            :addressLength="8"
             tooltip-container=".TransactionTable"
           />
         </div>
@@ -127,6 +128,7 @@
         >
           <WalletAddress
             :address="data.row.recipient"
+            :addressLength="8"
             :type="data.row.type"
             :asset="data.row.asset"
             tooltip-container=".TransactionTable"

--- a/src/renderer/components/Transaction/TransactionTable.vue
+++ b/src/renderer/components/Transaction/TransactionTable.vue
@@ -116,7 +116,7 @@
         >
           <WalletAddress
             :address="data.row.sender"
-            :addressLength="8"
+            :address-length="8"
             tooltip-container=".TransactionTable"
           />
         </div>
@@ -128,7 +128,7 @@
         >
           <WalletAddress
             :address="data.row.recipient"
-            :addressLength="8"
+            :address-length="8"
             :type="data.row.type"
             :asset="data.row.asset"
             tooltip-container=".TransactionTable"

--- a/src/renderer/components/Wallet/WalletAddress.vue
+++ b/src/renderer/components/Wallet/WalletAddress.vue
@@ -10,7 +10,7 @@
         href="#"
         @click.stop="openAddress"
       >
-        {{ wallet_formatAddress(address, 10) }}
+        {{ wallet_formatAddress(address, addressLength) }}
       </a>
     </span>
     <span v-else-if="type === 1">
@@ -79,6 +79,11 @@ export default {
       type: String,
       required: false,
       default: () => '#app'
+    },
+    addressLength: {
+      type: Number,
+      required: false,
+      default: 10
     }
   },
 


### PR DESCRIPTION
## Proposed changes

Aligns the icons in the transaction show modal and fixes the wallet addresses being truncated twice on the dashboard:

<img width="559" alt="schermafbeelding 2018-12-23 om 14 35 36" src="https://user-images.githubusercontent.com/35610748/50384113-66d17000-06c0-11e9-81b4-1294af1234a9.png">

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
