### PR TITLE
refactor: unite router links of create/import buttons

### DIFF
--- a/src/renderer/components/Wallet/WalletButtons/WalletButtonCreate.vue
+++ b/src/renderer/components/Wallet/WalletButtons/WalletButtonCreate.vue
@@ -1,18 +1,17 @@
 <template>
   <div class="WalletButton__create">
-    <RouterLink :to="{ name: 'wallet-new' }">
-      <span class="rounded-full bg-theme-button h-8 w-8 mb-3 flex items-center justify-center">
+    <RouterLink
+      :to="{ name: 'wallet-new' }"
+      class="font-bold"
+    >
+      <span class="rounded-full bg-theme-button h-8 w-8 mb-3 mx-auto flex items-center justify-center">
         <SvgIcon
           name="plus"
           class="text-center"
           view-box="0 0 9 9"
         />
       </span>
-    </RouterLink>
-    <RouterLink
-      :to="{ name: 'wallet-new' }"
-      class="font-bold"
-    >
+
       {{ $t('PAGES.WALLET_ALL.CREATE_WALLET') }}
     </RouterLink>
   </div>
@@ -32,10 +31,7 @@ export default {
 
 <style lang="postcss" scoped>
 .WalletButton__create {
-  @apply .border-r .border-theme-feature-item-alternative
-}
-.WalletButton__create {
-  @apply .appearance-none .font-semibold .flex .flex-col .items-center
+  @apply .appearance-none .font-semibold .flex .flex-col .items-center .border-r .border-theme-feature-item-alternative
 }
 .WalletButton__create > span {
   @apply .w-full .text-center
@@ -44,7 +40,7 @@ export default {
   @apply .cursor-pointer .fill-current .text-theme-option-button-text;
   transition: opacity 0.4s;
 }
-.WalletButton__create > a > .rounded-full:hover {
+.WalletButton__create > a:hover > .rounded-full {
   opacity: 0.5;
 }
 

--- a/src/renderer/components/Wallet/WalletButtons/WalletButtonImport.vue
+++ b/src/renderer/components/Wallet/WalletButtons/WalletButtonImport.vue
@@ -1,18 +1,17 @@
 <template>
   <div class="WalletButton__import">
-    <RouterLink :to="{ name: 'wallet-import' }">
-      <span class="rounded-full bg-theme-button h-8 w-8 mb-3 flex items-center justify-center">
+    <RouterLink
+      :to="{ name: 'wallet-import' }"
+      class="font-bold"
+    >
+      <span class="rounded-full bg-theme-button h-8 w-8 mb-3 mx-auto flex items-center justify-center">
         <SvgIcon
           name="arrow-import"
           class="text-center"
           view-box="0 0 7 10"
         />
       </span>
-    </RouterLink>
-    <RouterLink
-      :to="{ name: 'wallet-import' }"
-      class="font-bold"
-    >
+
       {{ $t('PAGES.WALLET_ALL.IMPORT_WALLET') }}
     </RouterLink>
   </div>
@@ -41,7 +40,7 @@ export default {
   @apply .cursor-pointer .fill-current .text-theme-option-button-text;
   transition: opacity 0.4s;
 }
-.WalletButton__import > a > .rounded-full:hover {
+.WalletButton__import > a:hover > .rounded-full {
   opacity: 0.5;
 }
 


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

Instead of having two separate router links this PR refactors the wallet create / import buttons to have only one router link instead, increasing the clickable area and thus enhancing the UX of these components.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes