### PR TITLE
fix: correctly position settings arrow

### DIFF
--- a/src/renderer/components/Menu/MenuOptions/MenuOptions.vue
+++ b/src/renderer/components/Menu/MenuOptions/MenuOptions.vue
@@ -49,7 +49,7 @@ export default {
 }
 
 .MenuOptions__settings--vertical:after {
-  top: 104px;
+  top: 170px;
 }
 
 .MenuOptions--vertical:after {


### PR DESCRIPTION
## Proposed changes

Due to additions to the settings menu, the arrow was no longer at the right position

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
