### PR TITLE
fix: align settings arrow from the bottom

### DIFF
--- a/src/renderer/components/Menu/MenuOptions/MenuOptions.vue
+++ b/src/renderer/components/Menu/MenuOptions/MenuOptions.vue
@@ -49,7 +49,7 @@ export default {
 }
 
 .MenuOptions__settings--vertical:after {
-  top: 170px;
+  bottom: 230px;
 }
 
 .MenuOptions--vertical:after {


### PR DESCRIPTION
## Proposed changes

As reported by @dated , the arrows for the settings get aligned from the top, while it can have a different amount of options between profiles. To counter this, we can align them from the bottom.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
