### PR TITLE
fix: network modal name wrapping

### DIFF
--- a/src/renderer/components/Network/NetworkSelectionModal.vue
+++ b/src/renderer/components/Network/NetworkSelectionModal.vue
@@ -21,7 +21,9 @@
               class="w-18 h-18 p-2"
               :src="assets_loadImage('networks/default.svg')"
             >
-            <div class="NetworkSelectionModal__network--name">{{ network.name }}</div>
+            <div class="NetworkSelectionModal__network--name">
+              {{ network.name | truncate(20) }}
+            </div>
           </button>
         </div>
       </div>

--- a/src/renderer/components/Network/NetworkSelectionModal.vue
+++ b/src/renderer/components/Network/NetworkSelectionModal.vue
@@ -21,7 +21,7 @@
               class="w-18 h-18 p-2"
               :src="assets_loadImage('networks/default.svg')"
             >
-            <div>{{ network.name }}</div>
+            <div class="NetworkSelectionModal__network--name">{{ network.name }}</div>
           </button>
         </div>
       </div>
@@ -95,5 +95,9 @@ export default {
 }
 .NetworkSelectionModal__network--selected {
   @apply .border-green
+}
+.NetworkSelectionModal__network--name {
+  max-width: 4.5rem;
+  @apply .break-words
 }
 </style>


### PR DESCRIPTION
## Proposed changes

Resolves #864 

Wraps network names even if they have no spaces, and also truncates them if they are longer than a certain amount so the networks will not take up more than 3 rows of text in the modal.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
