### PR TITLE
feat: add validation of network name when adding a new network

### DIFF
--- a/src/renderer/components/Network/NetworkModal.vue
+++ b/src/renderer/components/Network/NetworkModal.vue
@@ -275,7 +275,16 @@ export default {
     },
 
     nameError () {
-      return this.requiredFieldError(this.$v.form.name, this.$refs['input-name'])
+      const isRequired = this.requiredFieldError(this.$v.form.name, this.$refs['input-name'])
+      if (isRequired) {
+        return isRequired
+      }
+      if (this.$v.form.name.$dirty) {
+        if (!this.$v.form.name.doesNotExists) {
+          return this.$t('VALIDATION.NAME.DUPLICATED', [this.form.name])
+        }
+      }
+      return null
     },
 
     descriptionError () {
@@ -544,7 +553,10 @@ export default {
   validations: {
     form: {
       name: {
-        required
+        required,
+        doesNotExists (value) {
+          return !this.$store.getters['network/byName'](value)
+        }
       },
       description: {
         required

--- a/src/renderer/store/modules/network.js
+++ b/src/renderer/store/modules/network.js
@@ -22,6 +22,9 @@ export default new BaseModule(NetworkModel, {
     byToken: state => token => {
       return state.all.find(network => network.token === token)
     },
+    byName: state => name => {
+      return state.all.find(network => network.name === name)
+    },
 
     feeStatisticsByType: (_, __, ___, rootGetters) => type => {
       const network = rootGetters['session/network']


### PR DESCRIPTION
## Proposed changes

When entering a new network, it will now check if the given name already exists. Previously this would throw an error in the console upon adding the network.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
