### PR TITLE
fix(styling): Add ButtonReload hover color

### DIFF
--- a/src/renderer/components/Button/ButtonReload.vue
+++ b/src/renderer/components/Button/ButtonReload.vue
@@ -2,7 +2,7 @@
   <button
     v-tooltip="{ content: title, trigger: 'hover' }"
     :class="[
-      withoutBackground ? 'hover:bg-transparent' : `py-2 px-4 rounded ${colorClass ? colorClass : 'bg-theme-button-light text-theme-button-light-text'}`
+      withoutBackground ? 'hover:bg-transparent' : `py-2 px-4 rounded ${colorClass ? colorClass : 'bg-theme-button-light text-theme-button-light-text'} ${hoverClass ? hoverClass : 'hover:bg-theme-option-button-hover'}`
     ]"
     class="ButtonReload cursor-pointer inline-flex items-center self-stretch"
     :disabled="isRefreshing"


### PR DESCRIPTION
Add conditional class, which is set through the hoverClass prop
and has a default of 'hover:bg-theme-option-button-hover'

Verified that it didn't apply to background-less ButtonReload

Fixes #874

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build (changes that affect the build system)
- [ ] Docs (documentation only changes)
- [ ] Test (adding missing tests or fixing existing tests)
- [ ] Other... Please describe:

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes (lint)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
