### PR TITLE
fix(misc): Password visibility and Read more links

### DIFF
--- a/src/renderer/components/Announcements/AnnouncementsPost.vue
+++ b/src/renderer/components/Announcements/AnnouncementsPost.vue
@@ -28,7 +28,7 @@
 
     <a
       :title="title"
-      class="block mt-4 cursor-pointer"
+      class="inline-block mt-4 cursor-pointer"
       @click="openInBrowser(url)"
     >
       {{ $t('ANNOUNCEMENTS.READ_MORE') }} &#8594;

--- a/src/renderer/components/Input/InputPassword.vue
+++ b/src/renderer/components/Input/InputPassword.vue
@@ -31,7 +31,7 @@
         @click="toggleVisible"
       >
         <SvgIcon
-          :name="passwordIsVisible ? 'password-hide' : 'password-show'"
+          :name="passwordIsVisible ? 'passphrase-hide' : 'passphrase-show'"
           view-box="0 0 20 20"
         />
       </button>


### PR DESCRIPTION
Change the password-show/hide svg links to passphrase-x because
it renders correctly.
The Read more links now are only clickable on the Read more text.

Fixes: #871 #831

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build (changes that affect the build system)
- [ ] Docs (documentation only changes)
- [ ] Test (adding missing tests or fixing existing tests)
- [ ] Other... Please describe:

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
