### PR TITLE
[WIP] [DO NOT MERGE] feat: shown placeholder message if wallet is a known wallet

### DIFF
--- a/src/renderer/components/Wallet/WalletAddress.vue
+++ b/src/renderer/components/Wallet/WalletAddress.vue
@@ -53,6 +53,12 @@
     <span v-else-if="type === 8">
       {{ $t("TRANSACTION.TYPE.DELEGATE_RESIGNATION") }}
     </span>
+
+    <span
+      v-if="isKnownWallet()"
+    >
+      isKnown
+    </span>
   </span>
 </template>
 
@@ -129,6 +135,10 @@ export default {
   methods: {
     determineVote () {
       this.votedDelegate = store.getters['delegate/byPublicKey'](this.votePublicKey)
+    },
+
+    isKnownWallet () {
+      return this.session_network.knownWallets[this.address]
     },
 
     openAddress () {


### PR DESCRIPTION
## Proposed changes

This will make the wallet show an icon (waiting for the design from Oleg) when a wallet is a `known wallet`. The way it is set up makes sure that a known wallet will also get the icon if it has been imported as a contact with a different name, so if you have for example `binance` as a contact, it will still show the icon but with the contact name you have given it.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
