### PR TITLE
misc: set correct icon color on warning

### DIFF
--- a/src/renderer/components/Passphrase/PassphraseInput.vue
+++ b/src/renderer/components/Passphrase/PassphraseInput.vue
@@ -233,11 +233,12 @@ export default {
 .PassphraseInput__input::placeholder {
   @apply .text-transparent
 }
-
-.InputField--invalid .PassphraseInput__qr-button {
-  @apply .text-red-dark
-}
+.InputField--invalid .PassphraseInput__qr-button,
 .InputField--invalid .PassphraseInput__visibility-button {
   @apply .text-red-dark
+}
+.InputField--warning .PassphraseInput__qr-button,
+.InputField--warning .PassphraseInput__visibility-button {
+  @apply .text-orange-dark
 }
 </style>


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

Sets the correct color on the passphrase input component if there is a warning.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Other... Please describe: ui

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes