### PR TITLE
fix: aip13 freeze

### DIFF
--- a/config/networks/devnet.json
+++ b/config/networks/devnet.json
@@ -11,6 +11,40 @@
     "enabled": false,
     "ticker": null
   },
+  "feeStatistics": [
+    {
+      "type": 0,
+      "fees": {
+        "avgFee": 10000000,
+        "maxFee": 10000000,
+        "minFee": 10000000
+      }
+    },
+    {
+      "type": 1,
+      "fees": {
+        "avgFee": 500000000,
+        "maxFee": 500000000,
+        "minFee": 500000000
+      }
+    },
+    {
+      "type": 2,
+      "fees": {
+        "avgFee": 2500000000,
+        "maxFee": 2500000000,
+        "minFee": 2500000000
+      }
+    },
+    {
+      "type": 3,
+      "fees": {
+        "avgFee": 100000000,
+        "maxFee": 100000000,
+        "minFee": 100000000
+      }
+    }
+  ],
   "constants": {
     "activeDelegates": 51,
     "epoch": "2017-03-21T13:00:00.000Z"

--- a/config/networks/mainnet.json
+++ b/config/networks/mainnet.json
@@ -11,6 +11,40 @@
     "enabled": true,
     "ticker": "ARK"
   },
+  "feeStatistics": [
+    {
+      "type": 0,
+      "fees": {
+        "avgFee": 10000000,
+        "maxFee": 10000000,
+        "minFee": 10000000
+      }
+    },
+    {
+      "type": 1,
+      "fees": {
+        "avgFee": 500000000,
+        "maxFee": 500000000,
+        "minFee": 500000000
+      }
+    },
+    {
+      "type": 2,
+      "fees": {
+        "avgFee": 2500000000,
+        "maxFee": 2500000000,
+        "minFee": 2500000000
+      }
+    },
+    {
+      "type": 3,
+      "fees": {
+        "avgFee": 100000000,
+        "maxFee": 100000000,
+        "minFee": 100000000
+      }
+    }
+  ],
   "constants": {
     "activeDelegates": 51,
     "epoch": "2017-03-21T13:00:00.000Z"

--- a/src/renderer/services/client.js
+++ b/src/renderer/services/client.js
@@ -46,6 +46,21 @@ export default class ClientService {
     }
   }
 
+  static async fetchFeeStatistics (server, apiVersion, timeout) {
+    // This is only for v2 networks
+    if (apiVersion === 1) {
+      return
+    }
+    const client = new ApiClient(server, apiVersion)
+    if (timeout) {
+      client.http.timeout = timeout
+    }
+    const { data } = await client.resource('node').configuration()
+    if (data.data && data.data.feeStatistics) {
+      return data.data.feeStatistics
+    }
+  }
+
   constructor (watchProfile = true) {
     this.__host = null
     this.__version = null

--- a/src/renderer/services/synchronizer.js
+++ b/src/renderer/services/synchronizer.js
@@ -1,5 +1,5 @@
 import { flatten, includes, isFunction, pullAll } from 'lodash'
-import { announcements, delegates, ledger, market, peer, wallets } from './synchronizer/'
+import { announcements, delegates, fees, ledger, market, peer, wallets } from './synchronizer/'
 /**
  * This class adds the possibility to define actions (not to confuse with Vuex actions)
  * that could be dispatched using 2 modes: `default` and `focus`.
@@ -184,6 +184,10 @@ export default class Synchronizer {
         default: { interval: longer },
         focus: { interval: longer }
       },
+      fees: {
+        default: { interval: longer },
+        focus: { interval: longer }
+      },
       peer: {
         default: { interval: medium },
         focus: { interval: shorter }
@@ -201,6 +205,10 @@ export default class Synchronizer {
 
     this.define('delegates', config.delegates, async () => {
       await delegates(this)
+    })
+
+    this.define('fees', config.fees, async () => {
+      await fees(this)
     })
 
     this.define('market', config.market, async () => {

--- a/src/renderer/services/synchronizer/fees.js
+++ b/src/renderer/services/synchronizer/fees.js
@@ -1,0 +1,3 @@
+export default async synchronizer => {
+  await synchronizer.$store.dispatch('network/fetchFees')
+}

--- a/src/renderer/services/synchronizer/index.js
+++ b/src/renderer/services/synchronizer/index.js
@@ -1,5 +1,6 @@
 import announcements from './announcements'
 import delegates from './delegates'
+import fees from './fees'
 import ledger from './ledger'
 import market from './market'
 import peer from './peer'
@@ -8,6 +9,7 @@ import wallets from './wallets'
 export {
   announcements,
   delegates,
+  fees,
   ledger,
   market,
   peer,

--- a/src/renderer/store/modules/network.js
+++ b/src/renderer/store/modules/network.js
@@ -1,5 +1,5 @@
 import BaseModule from '../base'
-import { isEmpty } from 'lodash'
+import { cloneDeep, isEmpty } from 'lodash'
 import { NETWORKS } from '@config'
 import i18n from '@/i18n'
 import alertEvents from '@/plugins/alert-events'
@@ -71,6 +71,27 @@ export default new BaseModule(NetworkModel, {
       if (!isEmpty(getters['network/all'])) return
 
       commit('SET_ALL', NETWORKS)
+    },
+
+    // Updates the feeStatistics for the available networks
+    async fetchFees ({ commit, getters }) {
+      let networks = getters['all']
+      let updatedNetworks = cloneDeep(networks)
+      if (networks) {
+        let i
+        for (i = 0; i < updatedNetworks.length; i++) {
+          let network = updatedNetworks[i]
+          try {
+            let feeStats = await Client.fetchFeeStatistics(network.server, network.apiVersion)
+            if (feeStats) {
+              network.feeStatistics = feeStats
+            }
+          } catch (error) {
+            //
+          }
+        }
+      }
+      commit('SET_ALL', updatedNetworks)
     },
 
     async updateNetworkConfig ({ dispatch, getters, _, rootGetters }, networkId) {


### PR DESCRIPTION
## Proposed changes

Some people reported that they could not fill in their passphrase when the wallet would get opened through an AIP13 link (based on currently ongoing arkland raffle). This issue was because `feeStatistics` could be `undefined` on a network. This PR sets a default `feeStatistics` property on the default networks that we supply in the config, and adds a synchronizer service that updates this statistic every 100 blocks.

Also resolves #856 since that was caused by the same issue

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
