### PR TITLE
fix: network modal button disabling

### DIFF
--- a/src/renderer/components/Network/NetworkModal.vue
+++ b/src/renderer/components/Network/NetworkModal.vue
@@ -178,7 +178,7 @@
 
       <button
         v-if="network && !network.isDefault"
-        :disabled="$v.form.$invalid || isNetworkInUse"
+        :disabled="isNetworkInUse"
         class="blue-button mt-5 ml-4"
         type="button"
         @click="removeNetwork"
@@ -256,6 +256,7 @@ export default {
       'Basic',
       'Advanced'
     ],
+    originalName: null,
     configChoice: 'Basic',
     apiVersion: 2,
     hasFetched: false,
@@ -336,6 +337,7 @@ export default {
     // Set network values if one is passed along
     if (this.network) {
       this.form.name = this.network.title
+      this.originalName = this.network.title // To ensure that we allow the "duplicate" name as it's the same network
       this.form.description = this.network.description
       this.form.server = this.network.server
 
@@ -555,7 +557,7 @@ export default {
       name: {
         required,
         doesNotExists (value) {
-          return !this.$store.getters['network/byName'](value)
+          return (this.originalName && value === this.originalName) || !this.$store.getters['network/byName'](value)
         }
       },
       description: {


### PR DESCRIPTION
## Proposed changes

The `remove` button should be available even if a field is invalid, since you want to remove it anyway. The `save` button had an issue as a name was seen as "duplicate" in the form as there was an existing network with that name when you tried to edit it. This PR adds an extra check to ensure that the same name is allowed if we're currently editing that network.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
