### PR TITLE
handle case where qr reader fails without error fixes #887

### DIFF
--- a/src/renderer/components/Modal/ModalQrCodeScanner.vue
+++ b/src/renderer/components/Modal/ModalQrCodeScanner.vue
@@ -70,7 +70,14 @@ export default {
 
   methods: {
     async onInit (promise) {
+      let promiseSuccessfullyHandled = false
       try {
+        setTimeout(() => {
+          if (!promiseSuccessfullyHandled) {
+            this.isLoading = false
+            this.errorMessage = this.$t('MODAL_QR_SCANNER.ERROR.NOT_READABLE')
+          }
+        }, 10000)
         await promise
         this.errorMessage = ''
       } catch (error) {
@@ -88,7 +95,10 @@ export default {
           this.errorMessage = this.$t('MODAL_QR_SCANNER.ERROR.STREAM')
         }
       } finally {
-        setTimeout(() => { this.isLoading = false }, 1000)
+        setTimeout(() => {
+          promiseSuccessfullyHandled = true
+          this.isLoading = false
+        }, 1000)
       }
     },
 


### PR DESCRIPTION
## Proposed changes
The QR Reader can fail without throwing an error. In case the QR Reader is not successfully handled, (as noted in the issue #887) the app just freezes, and the user can't do anything except close the app. My change is to see if the QR Reader is successfully handled, if it is not then we throw an error and say loading is done after 10 seconds. This way the user gets some feedback and in turn can exit. 

## Types of changes
- [x ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build (changes that affect the build system)
- [ ] Docs (documentation only changes)
- [ ] Test (adding missing tests or fixing existing tests)
- [ ] Other... Please describe:

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x kinda] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!--

## Further comments

The linting passed. The unit tests there was 3 failures. But these same unit tests failed when I ran them on just the develop branch w/o my changes. So I don't believe my code changes introduced these.
-->
