### PR TITLE
fix: use wallet_name for contacts too

### DIFF
--- a/src/renderer/pages/Contact/ContactAll.vue
+++ b/src/renderer/pages/Contact/ContactAll.vue
@@ -41,7 +41,7 @@
           <div class="flex flex-col justify-center overflow-hidden pl-4">
             <div class="ContactAll__grid__contact__name font-semibold text-base truncate block">
               <RouterLink :to="{ name: 'wallet-show', params: { address: contact.id } }">
-                {{ wallet_nameOnContact(contact.address) || wallet_truncate(contact.address) }}
+                {{ wallet_name(contact.address) || wallet_truncate(contact.address) }}
               </RouterLink>
             </div>
             <span class="font-bold mt-2 text-lg">


### PR DESCRIPTION
## Proposed changes

Changes contacts overview to also make use of `wallet_name` since named wallets likes `Binance` would be shown by address in the overview (if you didn't give it a name), while they would be shown as `Binance` in the wallet overview and everywhere else.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
