### PR TITLE
fix: only show add to contacts button when wallet is not a contact yet

### DIFF
--- a/src/renderer/components/Wallet/WalletHeading/WalletHeadingPrimaryActions.vue
+++ b/src/renderer/components/Wallet/WalletHeading/WalletHeadingPrimaryActions.vue
@@ -34,7 +34,7 @@
     </ButtonModal>
 
     <ButtonModal
-      v-show="!currentWallet.name && currentWallet.isContact"
+      v-show="!currentWallet.name && currentWallet.isContact && doesNotExists"
       :class="buttonStyle"
       :label="$t('PAGES.WALLET_SHOW.ADD_CONTACT')"
       icon="contact-add"
@@ -102,6 +102,10 @@ export default {
 
     currentWallet () {
       return this.wallet_fromRoute
+    },
+
+    doesNotExists () {
+      return !this.$store.getters['wallet/byAddress'](this.currentWallet.address)
     }
   },
 


### PR DESCRIPTION
## Proposed changes

Contacts without a name would also get the `Add as contact` button, which would result in an error if you clicked it as it already existed as a contact. This PR adds a check to make sure it doesn't show the button wallets that are already a contact

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
