### PR TITLE
fix: only invert dropdown arrow for peer screen

### DIFF
--- a/src/renderer/components/App/AppSidemenu/AppSidemenuNetworkStatus.vue
+++ b/src/renderer/components/App/AppSidemenu/AppSidemenuNetworkStatus.vue
@@ -256,6 +256,10 @@ export default {
   @apply .text-white;
 }
 
+.AppSidemenuNetworkStatus__peer .MenuDropdownHandler span svg {
+  transform: rotate(-180deg);
+}
+
 .AppSidemenuNetworkStatus__ButtonModal {
   @apply block;
 }

--- a/src/renderer/components/Menu/MenuDropdown/MenuDropdownHandler.vue
+++ b/src/renderer/components/Menu/MenuDropdown/MenuDropdownHandler.vue
@@ -15,7 +15,7 @@
       </slot>
     </span>
 
-    <span class="flex pl-2 pr-1 rotate-vertical">
+    <span class="flex pl-2 pr-1">
       <SvgIcon
         :class="{ 'opacity-25': iconDisabled }"
         name="arrow-dropdown"
@@ -74,9 +74,3 @@ export default {
   }
 }
 </script>
-
-<style scoped>
-.rotate-vertical {
-  transform: rotate(-180deg);
-}
-</style>


### PR DESCRIPTION
## Proposed changes

#897 inverted the dropdown arrow since that was needed for the peer modal, but it was changed for every dropdown. This PR changes the arrow only for the peer modal where it was needed

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
