### PR TITLE
fix: update alternative currency when no input

### DIFF
--- a/src/renderer/components/Input/InputCurrency.vue
+++ b/src/renderer/components/Input/InputCurrency.vue
@@ -264,8 +264,10 @@ export default {
      * @param {(String|Number)} value
      */
     updateInputValue (value) {
-      // Ignore invalid values
-      if (value && this.checkAmount(value)) {
+      if (value === '') {
+        this.inputValue = ''
+        return true
+      } else if (value && this.checkAmount(value)) {
         let number = Number(value.toString().replace(',', '.'))
         number.toString().includes('-')
           ? this.inputValue = number.toFixed(number.toString().split('-')[1]) // Small numbers will be like 1e-7 so we use the number after '-' for toFixed()


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

The alternative currency amount is not being set to 0 when there is no input.

@ItsANameToo this seems to work as originally intended, i am unable to reproduce the same bugs as in #882. Can you confirm?

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes