### PR TITLE
fix: input amount minimum

### DIFF
--- a/__tests__/unit/mixins/currency.spec.js
+++ b/__tests__/unit/mixins/currency.spec.js
@@ -66,13 +66,13 @@ describe('Mixins > Currency', () => {
       it('should display the symbol currency of the current network', () => {
         const amount = 1.00035
 
-        expect(format(amount, { currencyFrom: 'network' })).toEqual('×1.00035')
+        expect(format(amount, { currencyFrom: 'network' })).toEqual('× 1.00035')
       })
 
       it('should use the i18n locale', () => {
         const amount = Math.pow(10, 4) + 1e-8
 
-        expect(format(amount, { currencyFrom: 'network' })).toEqual('×10,000.00000001')
+        expect(format(amount, { currencyFrom: 'network' })).toEqual('× 10,000.00000001')
 
         // NOTE: this is not going to work when tested on Node (https://github.com/nodejs/node/issues/8818)
         // although this assertion would work on browsers
@@ -87,7 +87,7 @@ describe('Mixins > Currency', () => {
 
         wrapper.vm.$store.getters['session/currency'] = 'BTC'
 
-        expect(format(amount, { currencyFrom: 'session' })).toEqual('Ƀ10,000.00001')
+        expect(format(amount, { currencyFrom: 'session' })).toEqual('Ƀ 10,000.00001')
 
         wrapper.vm.$store.getters['session/currency'] = 'EUR'
 
@@ -99,7 +99,7 @@ describe('Mixins > Currency', () => {
       it('should use the symbol of that currency', () => {
         const amount = Math.pow(10, 5) + Math.pow(10, -5)
 
-        expect(format(amount, { currency: 'BTC' })).toEqual('Ƀ100,000.00001')
+        expect(format(amount, { currency: 'BTC' })).toEqual('Ƀ 100,000.00001')
         expect(format(amount, { currency: 'EUR' })).toEqual('€100,000.00')
       })
 
@@ -113,13 +113,13 @@ describe('Mixins > Currency', () => {
         it('should admit it is the current network currency', () => {
           const amount = Math.pow(10, 5) + Math.pow(10, -5)
 
-          expect(format(amount, { currency: 'NET' })).toEqual('×100,000.00001')
+          expect(format(amount, { currency: 'NET' })).toEqual('× 100,000.00001')
         })
 
         it('should admit it is from any known network', () => {
           const amount = Math.pow(10, 5) + Math.pow(10, -5)
 
-          expect(format(amount, { currency: 'TOK' })).toEqual('t100,000.00001')
+          expect(format(amount, { currency: 'TOK' })).toEqual('t 100,000.00001')
         })
       })
     })
@@ -128,7 +128,7 @@ describe('Mixins > Currency', () => {
       it('should use it to display the currency', () => {
         const amount = 9835.387653
 
-        expect(format(amount, { currencyFrom: 'network', currencyDisplay: 'code' })).toEqual('NET9,835.387653')
+        expect(format(amount, { currencyFrom: 'network', currencyDisplay: 'code' })).toEqual('NET 9,835.387653')
         expect(format(amount, { currency: 'EUR', currencyDisplay: 'symbol' })).toEqual('€9,835.39')
       })
     })
@@ -144,8 +144,8 @@ describe('Mixins > Currency', () => {
         it('should use it to display the currency, indepently of the `currencyDisplay` option', () => {
           const amount = 9835.387653
 
-          expect(format(amount, { currencyFrom: 'network', currencyDisplay: 'code', subunit: true })).toEqual('netoshi983,538,765,300.00')
-          expect(format(amount, { currency: 'NET', currencyDisplay: 'symbol', subunit: true })).toEqual('netoshi983,538,765,300.00')
+          expect(format(amount, { currencyFrom: 'network', currencyDisplay: 'code', subunit: true })).toEqual('netoshi 983,538,765,300.00')
+          expect(format(amount, { currency: 'NET', currencyDisplay: 'symbol', subunit: true })).toEqual('netoshi 983,538,765,300.00')
         })
       })
     })
@@ -153,7 +153,7 @@ describe('Mixins > Currency', () => {
     it('should work with big quantities', () => {
       let amount = Math.pow(10, 12) + 0.01
 
-      expect(format(amount, { currencyFrom: 'network' })).toEqual('×1,000,000,000,000.01')
+      expect(format(amount, { currencyFrom: 'network' })).toEqual('× 1,000,000,000,000.01')
 
       amount = Number.MAX_SAFE_INTEGER - 2// 9007199254740989
 

--- a/__tests__/unit/mixins/formatter.spec.js
+++ b/__tests__/unit/mixins/formatter.spec.js
@@ -50,10 +50,10 @@ describe('Mixins > Formatter', () => {
   describe('formatter_networkCurrency', () => {
     describe('when a number is provided', () => {
       it('should return it as percentage', () => {
-        expect(wrapper.vm.formatter_networkCurrency(10000000)).toEqual('×0.10')
-        expect(wrapper.vm.formatter_networkCurrency(100000000)).toEqual('×1.00')
-        expect(wrapper.vm.formatter_networkCurrency(1000000000)).toEqual('×10.00')
-        expect(wrapper.vm.formatter_networkCurrency(0)).toEqual('×0.00')
+        expect(wrapper.vm.formatter_networkCurrency(10000000)).toEqual('× 0.10')
+        expect(wrapper.vm.formatter_networkCurrency(100000000)).toEqual('× 1.00')
+        expect(wrapper.vm.formatter_networkCurrency(1000000000)).toEqual('× 10.00')
+        expect(wrapper.vm.formatter_networkCurrency(0)).toEqual('× 0.00')
       })
     })
   })

--- a/__tests__/unit/pages/Profile/ProfileAll.spec.js
+++ b/__tests__/unit/pages/Profile/ProfileAll.spec.js
@@ -145,9 +145,9 @@ describe('pages > ProfileAll', () => {
     it('should return the sum of balances per network, using their symbols', () => {
       wrapper = mountPage()
       expect(wrapper.vm.totalBalances).toEqual([
-        'm500.150909',
-        'o0.1219',
-        'd0.5201'
+        'm 500.150909',
+        'o 0.1219',
+        'd 0.5201'
       ])
     })
 
@@ -162,9 +162,9 @@ describe('pages > ProfileAll', () => {
       it('should include their balances', () => {
         wrapper = mountPage()
         expect(wrapper.vm.totalBalances).toEqual([
-          'm666.22093608',
-          'o0.1219',
-          'd0.5201'
+          'm 666.22093608',
+          'o 0.1219',
+          'd 0.5201'
         ])
       })
     })
@@ -173,7 +173,7 @@ describe('pages > ProfileAll', () => {
   describe('profileBalance', () => {
     it('should return the formatted balance of a profile, using the network symbol', () => {
       wrapper = mountPage()
-      expect(wrapper.vm.profileBalance(profiles[0])).toEqual('m0.137')
+      expect(wrapper.vm.profileBalance(profiles[0])).toEqual('m 0.137')
     })
   })
 })

--- a/src/renderer/components/Transaction/TransactionForm/TransactionFormTransfer.vue
+++ b/src/renderer/components/Transaction/TransactionForm/TransactionFormTransfer.vue
@@ -181,9 +181,9 @@ export default {
     },
     // Customize the message to display the minimum amount as subunit
     amountTooLowError () {
-      const { fractionDigits, token } = this.walletNetwork
+      const { fractionDigits } = this.walletNetwork
       const minimumAmount = Math.pow(10, -fractionDigits)
-      const amount = this.currency_format(minimumAmount, { currency: token, currencyDisplay: 'code', subunit: true })
+      const amount = this.currency_simpleFormatCrypto(minimumAmount.toFixed(fractionDigits))
       return this.$t('INPUT_CURRENCY.ERROR.LESS_THAN_MINIMUM', { amount })
     },
     notEnoughBalanceError () {

--- a/src/renderer/mixins/currency.js
+++ b/src/renderer/mixins/currency.js
@@ -87,7 +87,7 @@ export default {
       }
 
       return this.$n(value.toString(), config)
-        .replace(cryptoPlaceholder, cryptoCurrency)
+        .replace(cryptoPlaceholder, cryptoCurrency + ' ')
     },
 
     currency_simpleFormatCrypto (value, network) {

--- a/src/renderer/mixins/currency.js
+++ b/src/renderer/mixins/currency.js
@@ -90,6 +90,11 @@ export default {
         .replace(cryptoPlaceholder, cryptoCurrency)
     },
 
+    currency_simpleFormatCrypto (value, network) {
+      const { token } = network || this.session_network
+      return `${value} ${token}`
+    },
+
     currency_subToUnit (value, network) {
       const { fractionDigits } = network || this.session_network
       return new BigNumber(value.toString()).dividedBy(Math.pow(10, fractionDigits)).toString()


### PR DESCRIPTION
## Proposed changes

Changes the error showing the minimum allowed amount for a transfer to a fraction number instead of `arktoshi1.00`. Reasoning is that it's easier to compare `0.000000001` to the allowed `0.00000001` than `arktoshi1.00`:

<img width="479" alt="schermafbeelding 2018-12-31 om 17 08 03" src="https://user-images.githubusercontent.com/35610748/50563797-548aae00-0d20-11e9-9336-e23fcda34fbb.png">

It also adds a space between crypto and amount to make it more readable:

<img width="324" alt="schermafbeelding 2018-12-31 om 17 15 23" src="https://user-images.githubusercontent.com/35610748/50563808-6d935f00-0d20-11e9-80e7-dd2a376186b5.png">

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
