### PR TITLE
fix: send transfer transaction to current peer

### DIFF
--- a/src/renderer/components/Transaction/TransactionModal.vue
+++ b/src/renderer/components/Transaction/TransactionModal.vue
@@ -126,7 +126,7 @@ export default {
 
       let response
       try {
-        if (this.walletOverride) {
+        if (this.walletOverride && this.session_network.id !== this.walletNetwork.id) {
           const peer = await this.$store.dispatch('peer/findBest', {
             refresh: true,
             network: this.walletNetwork

--- a/src/renderer/components/Transaction/TransactionModal.vue
+++ b/src/renderer/components/Transaction/TransactionModal.vue
@@ -16,7 +16,7 @@
     <TransactionConfirm
       v-if="transaction"
       :transaction="transaction"
-      :wallet="alternativeWallet"
+      :wallet="walletOverride"
       @back="onBack"
       @confirm="onConfirm"
     />
@@ -62,7 +62,7 @@ export default {
   data: () => ({
     step: 0,
     transaction: null,
-    alternativeWallet: null
+    walletOverride: null
   }),
 
   computed: {
@@ -85,11 +85,11 @@ export default {
     },
     walletNetwork () {
       const sessionNetwork = this.session_network
-      if (!this.alternativeWallet || !this.alternativeWallet.id) {
+      if (!this.walletOverride || !this.walletOverride.id) {
         return sessionNetwork
       }
 
-      const profile = this.$store.getters['profile/byId'](this.alternativeWallet.profileId)
+      const profile = this.$store.getters['profile/byId'](this.walletOverride.profileId)
 
       if (!profile.id) {
         return sessionNetwork
@@ -103,7 +103,7 @@ export default {
     onBuilt ({ transaction, wallet }) {
       this.step = 1
       this.transaction = transaction
-      this.alternativeWallet = wallet
+      this.walletOverride = wallet
     },
 
     onBack () {
@@ -126,7 +126,7 @@ export default {
 
       let response
       try {
-        if (this.alternativeWallet) {
+        if (this.walletOverride) {
           const peer = await this.$store.dispatch('peer/findBest', {
             refresh: true,
             network: this.walletNetwork
@@ -210,7 +210,7 @@ export default {
         vendorField,
         confirmations: 0,
         recipient: transaction.recipientId || transaction.sender,
-        profileId: this.alternativeWallet ? this.alternativeWallet.profileId : this.session_profile.id,
+        profileId: this.walletOverride ? this.walletOverride.profileId : this.session_profile.id,
         raw: transaction
       })
     }


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

A bug was introduced when adding/upgrading the URI system whereby every transfer transaction would be sent to a new peer. This checks to make sure the wallet being sent from is on a different network to the current profile.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
