### PR TITLE
fix: refresh all ledger wallets, not just cache

### DIFF
--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -196,7 +196,7 @@ export default {
         this.$store.dispatch('ledger/init', this.session_network.slip44)
         this.$store.dispatch('peer/connectToBest', {})
         if (this.$store.getters['ledger/isConnected']) {
-          this.$store.dispatch('ledger/reloadWallets', true)
+          this.$store.dispatch('ledger/reloadWallets', { clearFirst: true })
         }
       })
       this.$eventBus.on('ledger:connected', async () => {

--- a/src/renderer/services/synchronizer/ledger.js
+++ b/src/renderer/services/synchronizer/ledger.js
@@ -1,3 +1,3 @@
 export default async synchronizer => {
-  await synchronizer.$store.dispatch('ledger/reloadWallets')
+  await synchronizer.$store.dispatch('ledger/reloadWallets', { useCachedWallets: false })
 }

--- a/src/renderer/store/modules/ledger.js
+++ b/src/renderer/store/modules/ledger.js
@@ -130,7 +130,7 @@ export default {
 
       commit('SET_CONNECTED', true)
       eventBus.emit('ledger:connected')
-      await dispatch('reloadWallets')
+      await dispatch('reloadWallets', {})
 
       return true
     },
@@ -204,7 +204,7 @@ export default {
      * @param  {Boolean} [clearFirst=false] Clear ledger wallets from store before reloading
      * @return {Object[]}
      */
-    async reloadWallets ({ commit, dispatch, getters, rootGetters }, clearFirst = false) {
+    async reloadWallets ({ commit, dispatch, getters, rootGetters }, { clearFirst = false, useCachedWallets = true }) {
       if (!getters['isConnected']) {
         return []
       }
@@ -216,8 +216,12 @@ export default {
       }
       commit('SET_LOADING', true)
       const firstAddress = await dispatch('getAddress', 0)
-      let wallets = keyBy(getters['cachedWallets'](firstAddress), 'address')
-      const startIndex = Object.keys(wallets).length ? Object.keys(wallets).length - 1 : 0
+      let wallets = []
+      let startIndex = 0
+      if (useCachedWallets) {
+        wallets = keyBy(getters['cachedWallets'](firstAddress), 'address')
+        startIndex = Object.keys(wallets).length ? Object.keys(wallets).length - 1 : startIndex
+      }
       try {
         for (let ledgerIndex = startIndex; ; ledgerIndex++) {
           let isColdWallet = false


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

In order to save on duplicate requests, the ledger store deals with refreshing wallet information. However the problem was that it was only refreshing the last wallet because it was basing it on the cache.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
