### PR TITLE
fix: Change display logic when refreshing addresses

### DIFF
--- a/src/renderer/pages/Wallet/WalletNew.vue
+++ b/src/renderer/pages/Wallet/WalletNew.vue
@@ -88,12 +88,9 @@
                   </a>
                 </li>
               </TransitionGroup>
-              <TransitionGroup
+              <ul
                 v-show="isRefreshing"
-                key="inactive"
                 class="list-reset"
-                name="WalletNew__wallets"
-                tag="ul"
               >
                 <li
                   v-for="(address, index) in emptyWallets"
@@ -106,7 +103,7 @@
                     class="WalletNew__wallets--unselected-identicon flex-no-shrink"
                   />
                 </li>
-              </TransitionGroup>
+              </ul>
             </div>
           </MenuStepItem>
 

--- a/src/renderer/pages/Wallet/WalletNew.vue
+++ b/src/renderer/pages/Wallet/WalletNew.vue
@@ -93,7 +93,7 @@
                 class="list-reset"
               >
                 <li
-                  v-for="(address, index) in emptyWallets"
+                  v-for="(address, index) of emptyWallets"
                   :key="address + index"
                   class="flex items-center py-4 w-full border-b border-dashed border-theme-line-separator truncate"
                 >
@@ -570,7 +570,7 @@ export default {
 
 .WalletNew__wallets--selected-identicon {
   transition: all 0.5s;
-  opacity: 1!important
+  opacity: 1 !important
 }
 
 .WalletNew__wallets--unselected-identicon {
@@ -578,7 +578,7 @@ export default {
 }
 
 .WalletNew__wallets--unselected-identicon:hover {
-  opacity: 1!important;
+  opacity: 1 !important;
   transition: all 0.5s;
   @apply .text-theme-wallet-new-selected .no-underline
 }

--- a/src/renderer/pages/Wallet/WalletNew.vue
+++ b/src/renderer/pages/Wallet/WalletNew.vue
@@ -58,55 +58,56 @@
                 @click="refreshAddresses"
               />
             </div>
-
-            <TransitionGroup
-              v-show="!isRefreshing"
-              key="active"
-              class="list-reset"
-              name="WalletNew__wallets"
-              tag="ul"
-            >
-              <li
-                v-for="(passphrase, address) in wallets"
-                :key="address"
-                class="flex items-center py-4 w-full border-b border-dashed border-theme-line-separator truncate"
+            <div>
+              <TransitionGroup
+                v-show="!isRefreshing"
+                key="active"
+                class="list-reset"
+                name="WalletNew__wallets"
+                tag="ul"
               >
-                <WalletIdenticon
-                  :value="address"
-                  :size="35"
-                  :class="{ 'WalletNew__wallets--selected-identicon': schema.address === address }"
-                  class="WalletNew__wallets--unselected-identicon flex-no-shrink"
-                />
-                <a
-                  :class="{ 'WalletNew__wallets--selected': schema.address === address }"
-                  class="WalletNew__wallets--address text-theme-wallet-new-unselected ml-2 cursor-pointer flex-no-shrink"
-                  @click="selectWallet(address, passphrase)"
+                <li
+                  v-for="(passphrase, address) in wallets"
+                  :key="address"
+                  class="flex items-center py-4 w-full border-b border-dashed border-theme-line-separator truncate"
                 >
-                  <span class="font-semibold text-sm">
-                    {{ address }}
-                  </span>
-                </a>
-              </li>
-            </TransitionGroup>
-            <TransitionGroup
-              v-show="isRefreshing"
-              key="inactive"
-              class="list-reset"
-              name="WalletNew__wallets"
-              tag="ul"
-            >
-              <li
-                v-for="(address, index) in emptyWallets"
-                :key="address + index"
-                class="flex items-center py-4 w-full border-b border-dashed border-theme-line-separator truncate"
+                  <WalletIdenticon
+                    :value="address"
+                    :size="35"
+                    :class="{ 'WalletNew__wallets--selected-identicon': schema.address === address }"
+                    class="WalletNew__wallets--unselected-identicon flex-no-shrink"
+                  />
+                  <a
+                    :class="{ 'WalletNew__wallets--selected': schema.address === address }"
+                    class="WalletNew__wallets--address text-theme-wallet-new-unselected ml-2 cursor-pointer flex-no-shrink"
+                    @click="selectWallet(address, passphrase)"
+                  >
+                    <span class="font-semibold text-sm">
+                      {{ address }}
+                    </span>
+                  </a>
+                </li>
+              </TransitionGroup>
+              <TransitionGroup
+                v-show="isRefreshing"
+                key="inactive"
+                class="list-reset"
+                name="WalletNew__wallets"
+                tag="ul"
               >
-                <WalletIdenticon
-                  :value="address"
-                  :size="35"
-                  class="WalletNew__wallets--unselected-identicon flex-no-shrink"
-                />
-              </li>
-            </TransitionGroup>
+                <li
+                  v-for="(address, index) in emptyWallets"
+                  :key="address + index"
+                  class="flex items-center py-4 w-full border-b border-dashed border-theme-line-separator truncate"
+                >
+                  <WalletIdenticon
+                    :value="address"
+                    :size="35"
+                    class="WalletNew__wallets--unselected-identicon flex-no-shrink"
+                  />
+                </li>
+              </TransitionGroup>
+            </div>
           </MenuStepItem>
 
           <MenuStepItem

--- a/src/renderer/pages/Wallet/WalletNew.vue
+++ b/src/renderer/pages/Wallet/WalletNew.vue
@@ -60,6 +60,8 @@
             </div>
 
             <TransitionGroup
+              v-show="!isRefreshing"
+              key="active"
               class="list-reset"
               name="WalletNew__wallets"
               tag="ul"
@@ -83,6 +85,25 @@
                     {{ address }}
                   </span>
                 </a>
+              </li>
+            </TransitionGroup>
+            <TransitionGroup
+              v-show="isRefreshing"
+              key="inactive"
+              class="list-reset"
+              name="WalletNew__wallets"
+              tag="ul"
+            >
+              <li
+                v-for="(address, index) in emptyWallets"
+                :key="address + index"
+                class="flex items-center py-4 w-full border-b border-dashed border-theme-line-separator truncate"
+              >
+                <WalletIdenticon
+                  :value="address"
+                  :size="35"
+                  class="flex-no-shrink"
+                />
               </li>
             </TransitionGroup>
           </MenuStepItem>
@@ -277,6 +298,7 @@ export default {
     isPassphraseVerified: false,
     ensureEntirePassphrase: false,
     step: 1,
+    emptyWallets: ['...', '...', '...'],
     wallets: {},
     walletPassword: null,
     walletConfirmPassword: null,
@@ -514,7 +536,7 @@ export default {
 }
 
 .WalletNew__wallets-enter-active {
-  transition: opacity 1s
+  transition: opacity 0.75s
 }
 .WalletNew__wallets-leave-active {
   transition: opacity 0.2s

--- a/src/renderer/pages/Wallet/WalletNew.vue
+++ b/src/renderer/pages/Wallet/WalletNew.vue
@@ -74,7 +74,8 @@
                 <WalletIdenticon
                   :value="address"
                   :size="35"
-                  class="flex-no-shrink"
+                  :class="{ 'WalletNew__wallets--selected-identicon': schema.address === address }"
+                  class="WalletNew__wallets--unselected-identicon flex-no-shrink"
                 />
                 <a
                   :class="{ 'WalletNew__wallets--selected': schema.address === address }"
@@ -102,7 +103,7 @@
                 <WalletIdenticon
                   :value="address"
                   :size="35"
-                  class="flex-no-shrink"
+                  class="WalletNew__wallets--unselected-identicon flex-no-shrink"
                 />
               </li>
             </TransitionGroup>
@@ -567,5 +568,20 @@ export default {
   @apply .bg-blue .text-white;
   box-shadow: 0 5px 15px rgba(9, 100, 228, 0.34);
   transition: all .1s ease-in
+}
+
+.WalletNew__wallets--selected-identicon {
+  transition: all 0.5s;
+  opacity: 1!important
+}
+
+.WalletNew__wallets--unselected-identicon {
+  opacity: 0.3
+}
+
+.WalletNew__wallets--unselected-identicon:hover {
+  opacity: 1!important;
+  transition: all 0.5s;
+  @apply .text-theme-wallet-new-selected .no-underline
 }
 </style>


### PR DESCRIPTION
 - Display placeholder WalletIdenticons to prevent y-axis motion
 - Create a separate TransitionGroup which remains in place to prevent x-axis motion

Fixes: #944

## Proposed changes
![walletnew_reload-ui](https://user-images.githubusercontent.com/23587429/50777773-7e852880-126a-11e9-8ec0-bedd510e1de0.gif)


## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build (changes that affect the build system)
- [ ] Docs (documentation only changes)
- [ ] Test (adding missing tests or fixing existing tests)
- [ ] Other... Please describe:

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!--

