### PR TITLE
fix: do not display the not-voting icon before knowing if the wallet is voting

### DIFF
--- a/src/renderer/components/Wallet/WalletHeading/WalletHeadingPrimaryActions.vue
+++ b/src/renderer/components/Wallet/WalletHeading/WalletHeadingPrimaryActions.vue
@@ -112,7 +112,7 @@ export default {
 
   watch: {
     // Never show the not-voting icon until knowing if the wallet is voting or not
-    'currentWallet.address': () => {
+    'currentWallet.address' () {
       this.showNotVoting = false
     },
     // To react to changes on the injected `walletVote` and changed not-voting icon immediately

--- a/src/renderer/components/Wallet/WalletHeading/WalletHeadingPrimaryActions.vue
+++ b/src/renderer/components/Wallet/WalletHeading/WalletHeadingPrimaryActions.vue
@@ -4,7 +4,7 @@
     class="WalletHeading__PrimaryActions flex items-center"
   >
     <button
-      v-if="!walletVote.publicKey"
+      v-if="showNotVoting"
       v-tooltip="{ content: $t('PAGES.WALLET_SHOW.NO_VOTE'), trigger:'hover' }"
       class="bg-theme-button-special-choice cursor-pointer rounded-full w-2 h-2 m-3"
       @click="goToDelegates"
@@ -91,7 +91,8 @@ export default {
 
   data () {
     return {
-      isRefreshing: false
+      isRefreshing: false,
+      showNotVoting: false
     }
   },
 
@@ -106,6 +107,17 @@ export default {
 
     doesNotExist () {
       return !this.$store.getters['wallet/byAddress'](this.currentWallet.address)
+    }
+  },
+
+  watch: {
+    // Never show the not-voting icon until knowing if the wallet is voting or not
+    currentWallet () {
+      this.showNotVoting = false
+    },
+    // To react to changes on the injected `walletVote` and changed not-voting icon immediately
+    'walletVote.publicKey' () {
+      this.showNotVoting = !this.walletVote.publicKey
     }
   },
 

--- a/src/renderer/components/Wallet/WalletHeading/WalletHeadingPrimaryActions.vue
+++ b/src/renderer/components/Wallet/WalletHeading/WalletHeadingPrimaryActions.vue
@@ -112,7 +112,7 @@ export default {
 
   watch: {
     // Never show the not-voting icon until knowing if the wallet is voting or not
-    currentWallet () {
+    'currentWallet.address': () => {
       this.showNotVoting = false
     },
     // To react to changes on the injected `walletVote` and changed not-voting icon immediately


### PR DESCRIPTION
## Proposed changes
When navigating to 1 wallet, or switching from 1 to other, the orange dot that warns about that the wallet is not voting, is displayed even when the wallet is voting while fetching data.

That was very annoying, and this PR changes the behaviour and it doesn't show it until checking on the server that the wallet is not voting.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes