### PR TITLE
fix: change delegate voting banner if wallet is not owned

### DIFF
--- a/src/renderer/components/Wallet/WalletDetails/WalletDetails.vue
+++ b/src/renderer/components/Wallet/WalletDetails/WalletDetails.vue
@@ -35,7 +35,7 @@
               'border-r border-theme-line-separator' : votedDelegate.rank
             }"
             class="font-semibold pr-6"
-            path="WALLET_DELEGATES.VOTED_FOR"
+            :path="isOwned ? 'WALLET_DELEGATES.VOTED_FOR' : 'WALLET_DELEGATES.WALLET_VOTED_FOR'"
           >
             <strong place="delegate">
               {{ votedDelegate.username }}
@@ -64,6 +64,7 @@
         </div>
       </div>
       <div
+        v-if="isOwned"
         class="WalletDetails__unvote"
         @click="openUnvote"
       >
@@ -177,6 +178,13 @@ export default {
 
     isDelegatesTab () {
       return this.currentTab === 'WalletDelegates'
+    },
+
+    isOwned () {
+      const wallet = this.$store.getters['wallet/byAddress'](this.currentWallet.address)
+      const wallets = this.$store.getters['wallet/byProfileId'](this.session_profile.id)
+
+      return wallets.includes(wallet)
     }
   },
 

--- a/src/renderer/i18n/locales/en-US.js
+++ b/src/renderer/i18n/locales/en-US.js
@@ -829,7 +829,8 @@ export default {
     EXPLANATION: 'Voting is an optional, but important mechanism that keeps the Ark network secure. The 51 delegates with the most votes from the network are responsible for verifying and forging transactions into new blocks. This page can be used to cast your vote for a delegate that you support. Learn more about voting for a delegate by clicking on the following link:',
     VOTE_DELEGATE: 'Vote Delegate {delegate}',
     UNVOTE_DELEGATE: 'Unvote Delegate {delegate}',
-    VOTED_FOR: 'You voted for delegate {delegate}'
+    VOTED_FOR: 'You voted for delegate {delegate}',
+    WALLET_VOTED_FOR: 'This wallet voted for delegate {delegate}'
   },
 
   WALLET_RENAME: {


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

The vote banner in the delegates tab shows the unvote button even if the wallet is not owned by the user, i.e. it has not been imported as such. This PR hides the button and changes the text from `You` to `This wallet`.

Owned:
![image](https://user-images.githubusercontent.com/6547002/51030288-3b43f600-1599-11e9-8caa-981c642ef6f6.png)

Not owned:
![image](https://user-images.githubusercontent.com/6547002/51030276-2ebf9d80-1599-11e9-9ce3-36a1dbbbb0c0.png)

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes