### PR TITLE
fix: load all networks correctly

### DIFF
--- a/__tests__/unit/store/modules/network.spec.js
+++ b/__tests__/unit/store/modules/network.spec.js
@@ -1,10 +1,19 @@
 import store from '@/store'
 import config from '@config'
 
+const storeSnapshot = JSON.parse(JSON.stringify(store.state))
+beforeEach(() => {
+  store.replaceState(JSON.parse(JSON.stringify(storeSnapshot)))
+})
+
 describe('NetworkModule', () => {
   const networks = [
-    { id: 'yes', token: 'YES', symbol: 'y' },
-    { id: 'maybe', token: 'MAY', symbol: 'm' }
+    { id: 'yes', name: 'yes', token: 'YES', symbol: 'y' },
+    { id: 'maybe', name: 'maybe', token: 'MAY', symbol: 'm' }
+  ]
+  const customNetworks = [
+    { id: 'custom', name: 'custom', token: 'CUST', symbol: 'c' },
+    { id: 'custom 2', name: 'custom 2', token: 'CUST', symbol: 'c' }
   ]
 
   describe('getters bySymbol', () => {
@@ -50,11 +59,28 @@ describe('NetworkModule', () => {
   })
 
   describe('actions load', () => {
-    it('should set the network defaults', () => {
+    it('should set the network defaults if empty', () => {
       expect(store.getters['network/all']).toBeEmpty()
-      store.dispatch('network/load', config.NETWORKS)
+      store.dispatch('network/load')
 
       expect(store.getters['network/all']).toEqual(config.NETWORKS)
+    })
+
+    it('should not set the network if not empty', () => {
+      store.commit('network/STORE', networks[0])
+      expect(store.getters['network/all']).toEqual([networks[0]])
+      store.dispatch('network/load')
+
+      expect(store.getters['network/all']).toEqual([networks[0]])
+    })
+
+    it('should load missing custom networks', () => {
+      store.commit('network/STORE', networks[0])
+      customNetworks.forEach(network => store.commit('network/ADD_CUSTOM_NETWORK', network))
+      expect(store.getters['network/all']).toEqual([networks[0]])
+      store.dispatch('network/load')
+
+      expect(store.getters['network/all']).toEqual([networks[0], ...customNetworks])
     })
   })
 })

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -145,8 +145,8 @@ export default {
    * retrieving the essential data (session and network) from the database
    */
   async created () {
-    await this.$store.dispatch('network/load', config.NETWORKS)
     this.$store._vm.$on('vuex-persist:ready', async () => {
+      await this.$store.dispatch('network/load', config.NETWORKS)
       const currentProfileId = this.$store.getters['session/profileId']
       await this.$store.dispatch('session/reset')
       await this.$store.dispatch('session/setProfileId', currentProfileId)

--- a/src/renderer/i18n/locales/en-US.js
+++ b/src/renderer/i18n/locales/en-US.js
@@ -646,10 +646,6 @@ export default {
     MODAL_HEADER: 'Networks'
   },
 
-  NETWORK: {
-    FAILED_CONFIG_UPDATE: 'Failed to update network configuration for {network}'
-  },
-
   TRANSACTION: {
     TYPE: {
       TRANSFER: 'Transfer',

--- a/src/renderer/store/modules/network.js
+++ b/src/renderer/store/modules/network.js
@@ -68,7 +68,9 @@ export default new BaseModule(NetworkModel, {
 
   actions: {
     load ({ commit, getters }) {
-      if (!isEmpty(getters['network/all'])) return
+      if (!isEmpty(getters['all'])) {
+        return
+      }
 
       commit('SET_ALL', NETWORKS)
     },

--- a/src/renderer/store/modules/network.js
+++ b/src/renderer/store/modules/network.js
@@ -1,8 +1,6 @@
 import BaseModule from '../base'
 import { cloneDeep, isEmpty } from 'lodash'
 import { NETWORKS } from '@config'
-import i18n from '@/i18n'
-import alertEvents from '@/plugins/alert-events'
 import eventBus from '@/plugins/event-bus'
 import NetworkModel from '@/models/network'
 import Client from '@/services/client'
@@ -108,42 +106,6 @@ export default new BaseModule(NetworkModel, {
         }
       }
       commit('SET_ALL', updatedNetworks)
-    },
-
-    async updateNetworkConfig ({ dispatch, getters }, networkId) {
-      var network = getters['byId'](networkId)
-      if (!network) {
-        network = getters['customNetworkById'](networkId)
-      }
-
-      let response
-      try {
-        response = await Client.fetchNetworkConfig(network.server, network.apiVersion)
-      } catch (error) {
-        console.error(`Failed to update network config for ${network.server}`)
-        alertEvents.$error(i18n.t('NETWORK.FAILED_CONFIG_UPDATE', {
-          network: network.server
-        }))
-
-        return
-      }
-
-      if (response) {
-        try {
-          const result = dispatch('update', {
-            ...network,
-            ...response
-          })
-          return result
-        } catch (error) {
-          // Network did not exist yet, so create it
-          const result = dispatch('create', {
-            ...network,
-            ...response
-          })
-          return result
-        }
-      }
     },
 
     addCustomNetwork ({ dispatch, commit }, network) {

--- a/src/renderer/store/modules/network.js
+++ b/src/renderer/store/modules/network.js
@@ -110,10 +110,10 @@ export default new BaseModule(NetworkModel, {
       commit('SET_ALL', updatedNetworks)
     },
 
-    async updateNetworkConfig ({ dispatch, getters, _, rootGetters }, networkId) {
+    async updateNetworkConfig ({ dispatch, getters }, networkId) {
       var network = getters['byId'](networkId)
       if (!network) {
-        network = rootGetters['network/customNetworkById'](networkId)
+        network = getters['customNetworkById'](networkId)
       }
 
       let response

--- a/src/renderer/store/modules/network.js
+++ b/src/renderer/store/modules/network.js
@@ -68,7 +68,21 @@ export default new BaseModule(NetworkModel, {
 
   actions: {
     load ({ commit, getters }) {
-      if (!isEmpty(getters['all'])) {
+      const all = cloneDeep(getters['all'])
+      if (!isEmpty(all)) {
+        // TODO: remove in future major version
+        // This is a "hack" to make sure all custom networks are in state.all
+        let missingCustom = false
+        for (const custom of Object.values(getters['customNetworks'])) {
+          if (!all.find(network => network.name === custom.name)) {
+            all.push(custom)
+            missingCustom = true
+          }
+        }
+        if (missingCustom) {
+          commit('SET_ALL', all)
+        }
+
         return
       }
 


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

I seemed to have an intermittent issue where all my custom networks were disappearing. This I believe was caused by 2 separate things. "Loading" the network data too early, before vuex was ready. And also the local `getter` was trying to access the root (`getters['network/all']`).

In case this has caused issues in other wallets, I've added a temporary fix to make sure `all` has all of the custom networks on load.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [ ] Test (adding missing tests or fixing existing tests)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
