### PR TITLE
fix: display the right error message on the fee slider

### DIFF
--- a/src/renderer/components/Input/InputCurrency.vue
+++ b/src/renderer/components/Input/InputCurrency.vue
@@ -174,14 +174,14 @@ export default {
           if (this.maximumError) {
             return this.maximumError
           } else {
-            const amount = this.currency_format(this.minimumAmount, { currency: this.currency })
+            const amount = this.currency_format(this.maximumAmount, { currency: this.currency })
             return this.$t('INPUT_CURRENCY.ERROR.NOT_ENOUGH_AMOUNT', { amount })
           }
         } else if (!this.$v.model.isMoreThanMinimum) {
           if (this.minimumError) {
             return this.minimumError
           } else {
-            const amount = this.currency_format(this.maximumAmount, { currency: this.currency })
+            const amount = this.currency_format(this.minimumAmount, { currency: this.currency })
             return this.$t('INPUT_CURRENCY.ERROR.LESS_THAN_MINIMUM', { amount })
           }
         } else if (this.customError) {


### PR DESCRIPTION
## Proposed changes
The "Advanced" option of the fee slider displays the wrong message when the introduced value is 10 times bigger than the default maximum fee.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
