### PR TITLE
improvement: make wallet heading name more visible in dark mode

### DIFF
--- a/src/renderer/components/Wallet/WalletHeading/WalletHeadingInfo.vue
+++ b/src/renderer/components/Wallet/WalletHeading/WalletHeadingInfo.vue
@@ -28,7 +28,7 @@
     <div class="flex flex-col justify-center text-white antialiased pl-4">
       <div
         v-if="name"
-        class="flex flex-row text-lg font-semibold text-theme-feature-item-text"
+        class="flex flex-row text-lg font-semibold text-theme-heading-text"
       >
         <span class="block xl:hidden">
           {{ name | truncate(12) }}
@@ -93,7 +93,7 @@
         {{ balance }}
         <span
           v-if="isMarketEnabled"
-          class="WalletHeading__balance__alternative text-xs text-theme-feature-item-text"
+          class="WalletHeading__balance__alternative text-xs text-theme-heading-text"
         >
           {{ alternativeBalance }}
         </span>

--- a/src/renderer/styles/_theme.css
+++ b/src/renderer/styles/_theme.css
@@ -50,6 +50,7 @@
   --theme-button-special-choice: #e78068;
 
   --theme-heading-background: #343956;
+  --theme-heading-text: #c0cddf;
 
   --theme-chart-background: #f8fafc;
   --theme-chart-price: #3b4559;
@@ -152,6 +153,7 @@
   --theme-button-special-choice: #e78068;
 
   --theme-heading-background: #31333d;
+  --theme-heading-text: #c0cddf;
   --theme-chart-price: white;
   --theme-chart-background: #373a43;
 

--- a/tailwind.js
+++ b/tailwind.js
@@ -89,6 +89,7 @@ let colors = {
 
   'theme-caption-text': 'var(--theme-caption-text)',
   'theme-heading-background': 'var(--theme-heading-background)',
+  'theme-heading-text': 'var(--theme-heading-text)',
 
   'theme-button-special-choice': 'var(--theme-button-special-choice)',
 


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

Changes the wallet heading font color to be the same in dark and light mode, since the heading doesn't change colors between themes and the text is very hard to read in dark mode:

![image](https://user-images.githubusercontent.com/6547002/51413340-ed1d8c80-1b6e-11e9-887a-eb6cb84de44a.png)

![image](https://user-images.githubusercontent.com/6547002/51413354-f9a1e500-1b6e-11e9-857c-052930f2c35e.png)

before:

![image](https://user-images.githubusercontent.com/6547002/51413431-38d03600-1b6f-11e9-9719-a4e90b3c7a22.png)

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes