### PR TITLE
fix: correctly handle zero balance on wallet heading info

### DIFF
--- a/src/renderer/components/Wallet/WalletHeading/WalletHeadingInfo.vue
+++ b/src/renderer/components/Wallet/WalletHeading/WalletHeadingInfo.vue
@@ -138,18 +138,26 @@ export default {
       return secondPublicKey || lazySecondPublicKey
     },
     alternativeBalance () {
-      const balance = this.currentWallet ? this.currentWallet.balance : null
-      const lazyBalance = this.lazyWallet.balance
-      const unitBalance = this.currency_subToUnit(balance || lazyBalance || 0)
+      let balance = this.currentWallet ? this.currentWallet.balance : null
+
+      if (balance === null) {
+        balance = this.lazyWallet.balance || 0
+      }
+
+      const unitBalance = this.currency_subToUnit(balance)
       return this.currency_format(unitBalance * this.price, { currency: this.alternativeCurrency })
     },
     alternativeCurrency () {
       return this.$store.getters['session/currency']
     },
     balance () {
-      const balance = this.currentWallet ? this.currentWallet.balance : null
-      const lazyBalance = this.lazyWallet.balance
-      return this.formatter_networkCurrency(balance || lazyBalance || 0)
+      let balance = this.currentWallet ? this.currentWallet.balance : null
+
+      if (balance === null) {
+        balance = this.lazyWallet.balance || 0
+      }
+
+      return this.formatter_networkCurrency(balance)
     },
     name () {
       return this.wallet_name(this.currentWallet.address)


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

When switching from a wallet with balance to a wallet with zero balance, the desktop wallet will still show the balance(s) from the previous wallet, because of `(balance || lazyBalance || 0)`.
## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes