### PR TITLE
refactor: new wallet selection styles and ui

### DIFF
--- a/src/renderer/pages/Wallet/WalletNew.vue
+++ b/src/renderer/pages/Wallet/WalletNew.vue
@@ -70,29 +70,25 @@
             </div>
 
             <TransitionGroup
-              class="list-reset"
+              class="WalletNew__wallets list-reset"
               name="WalletNew__wallets"
               tag="ul"
             >
               <li
                 v-for="(passphrase, address) in wallets"
                 :key="address"
-                class="flex items-center py-4 w-full border-b border-dashed border-theme-line-separator truncate"
+                :class="schema.address === address ? 'WalletNew__wallets--selected' : 'WalletNew__wallets--unselected'"
+                class="flex items-center py-4 w-full border-b border-dashed border-theme-line-separator truncate cursor-pointer"
+                @click="selectWallet(address, passphrase)"
               >
                 <WalletIdenticon
                   :value="address"
                   :size="35"
-                  class="flex-no-shrink"
+                  class="flex-no-shrink identicon"
                 />
-                <a
-                  :class="{ 'WalletNew__wallets--selected': schema.address === address }"
-                  class="WalletNew__wallets--address text-theme-wallet-new-unselected ml-2 cursor-pointer flex-no-shrink"
-                  @click="selectWallet(address, passphrase)"
-                >
-                  <span class="font-semibold text-sm">
-                    {{ address }}
-                  </span>
-                </a>
+                <span class="WalletNew__wallets--address text-theme-wallet-new-unselected ml-2 flex-no-shrink font-semibold text-sm">
+                  {{ address }}
+                </span>
               </li>
             </TransitionGroup>
           </MenuStepItem>
@@ -533,16 +529,27 @@ export default {
   opacity: 0
 }
 
-.WalletNew__wallets--selected {
-  @apply .text-theme-wallet-new-selected .font-bold
-}
-
-.WalletNew__wallets--address {
+.WalletNew__wallets .identicon {
+  font-size: 0;
+  opacity: 0.5;
   transition: all 0.5s;
 }
-.WalletNew__wallets--address:hover {
+.WalletNew__wallets--unselected:hover .identicon {
+  opacity: 1;
+}
+.WalletNew__wallets--unselected:hover .WalletNew__wallets--address {
   transition: all 0.5s;
   @apply .text-theme-wallet-new-selected .no-underline
+}
+
+.WalletNew__wallets--selected .identicon {
+  opacity: 1;
+}
+.WalletNew__wallets--selected .WalletNew__wallets--address {
+  @apply .text-theme-wallet-new-selected;
+}
+.WalletNew__wallets--address {
+  transition: all 0.5s;
 }
 
 .WalletNew__ButtonReload-colorClass {

--- a/src/renderer/pages/Wallet/WalletNew.vue
+++ b/src/renderer/pages/Wallet/WalletNew.vue
@@ -78,17 +78,28 @@
                 v-for="(passphrase, address, index) in wallets"
                 :key="address"
                 :class="[
-                  schema.address === address ? 'WalletNew__wallets--selected' : 'WalletNew__wallets--unselected',
+                  isSelected(address) ? 'WalletNew__wallets--selected' : 'WalletNew__wallets--unselected',
                   index !== Object.keys(wallets).length - 1 ? 'border-b border-dashed border-theme-line-separator' : ''
                 ]"
                 class="flex items-center py-4 w-full truncate cursor-pointer"
                 @click="selectWallet(address, passphrase)"
               >
-                <WalletIdenticon
-                  :value="address"
-                  :size="35"
-                  class="flex-no-shrink identicon"
-                />
+                <div class="relative">
+                  <WalletIdenticon
+                    :value="address"
+                    :size="35"
+                    class="flex-no-shrink identicon"
+                  />
+                  <span
+                    v-if="isSelected(address)"
+                    class="WalletNew_wallets__check absolute rounded-full flex items-center justify-center -mb-1 w-5 h-5 bg-green border-2 border-theme-feature text-white"
+                  >
+                    <SvgIcon
+                      name="checkmark"
+                      view-box="0 0 10 9"
+                    />
+                  </span>
+                </div>
                 <span class="WalletNew__wallets--address text-theme-wallet-new-unselected ml-2 flex-no-shrink font-semibold text-sm">
                   {{ address }}
                 </span>
@@ -257,6 +268,7 @@ import { InputField, InputPassword, InputSwitch, InputText } from '@/components/
 import { MenuStep, MenuStepItem } from '@/components/Menu'
 import { ModalLoader } from '@/components/Modal'
 import { PassphraseVerification, PassphraseWords } from '@/components/Passphrase'
+import { SvgIcon } from '@/components/SvgIcon'
 import WalletIdenticon from '@/components/Wallet/WalletIdenticon'
 import WalletService from '@/services/wallet'
 import Wallet from '@/models/wallet'
@@ -276,6 +288,7 @@ export default {
     ModalLoader,
     PassphraseVerification,
     PassphraseWords,
+    SvgIcon,
     WalletIdenticon
   },
 
@@ -446,6 +459,10 @@ export default {
 
         this.isRefreshing = false
       }, 300)
+    },
+
+    isSelected (address) {
+      return this.schema.address === address
     }
   },
 
@@ -563,5 +580,10 @@ export default {
   @apply .bg-blue .text-white;
   box-shadow: 0 5px 15px rgba(9, 100, 228, 0.34);
   transition: all .1s ease-in
+}
+
+.WalletNew_wallets__check {
+  left: 42%;
+  top: 52%;
 }
 </style>

--- a/src/renderer/pages/Wallet/WalletNew.vue
+++ b/src/renderer/pages/Wallet/WalletNew.vue
@@ -75,10 +75,13 @@
               tag="ul"
             >
               <li
-                v-for="(passphrase, address) in wallets"
+                v-for="(passphrase, address, index) in wallets"
                 :key="address"
-                :class="schema.address === address ? 'WalletNew__wallets--selected' : 'WalletNew__wallets--unselected'"
-                class="flex items-center py-4 w-full border-b border-dashed border-theme-line-separator truncate cursor-pointer"
+                :class="[
+                  schema.address === address ? 'WalletNew__wallets--selected' : 'WalletNew__wallets--unselected',
+                  index !== Object.keys(wallets).length - 1 ? 'border-b border-dashed border-theme-line-separator' : ''
+                ]"
+                class="flex items-center py-4 w-full truncate cursor-pointer"
                 @click="selectWallet(address, passphrase)"
               >
                 <WalletIdenticon

--- a/src/renderer/styles/_theme.css
+++ b/src/renderer/styles/_theme.css
@@ -138,7 +138,7 @@
   --theme-transaction-detail-arrow: #4d536c;
 
   --theme-wallet-new-selected: #787fa3;
-  --theme-wallet-new-unselected: #404457;
+  --theme-wallet-new-unselected: #585c6f;
   --theme-wallet-sign-verify-message-text: #585c6f;
 
   --theme-feature: #2d2f38;


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

This PR increases the UI/UX of the wallet selection on the new wallet page by:

- making the whole list element clickable instead of only the address, thus increasing the clickable area
- reducing the opacity as well of unselected wallets instead of only changing the color of the address

![wallets](https://user-images.githubusercontent.com/6547002/51484228-3d793200-1d9b-11e9-9ede-e5c8c2682856.gif)

[the transition delays are caused by my 🥔]

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes