### PR TITLE
refactor: success/error colors and delay on clipboard button tooltip

### DIFF
--- a/src/renderer/components/Button/ButtonClipboard.vue
+++ b/src/renderer/components/Button/ButtonClipboard.vue
@@ -87,8 +87,17 @@ export default {
       }
 
       if (this.isCopying) {
-        this.isCopySupported ? this.copyText = this.$t('BUTTON_CLIPBOARD.DONE') : this.copyText = this.$t('BUTTON_CLIPBOARD.NOT_SUPPORTED')
+        tooltip.delay = { show: 0, hide: 1000 }
+
+        if (this.isCopySupported) {
+          this.copyText = this.$t('BUTTON_CLIPBOARD.DONE')
+          tooltip.classes = 'success'
+        } else {
+          this.copyText = this.$t('BUTTON_CLIPBOARD.NOT_SUPPORTED')
+          tooltip.classes = 'error'
+        }
       }
+
       return tooltip
     }
   }

--- a/src/renderer/styles/_tooltip.css
+++ b/src/renderer/styles/_tooltip.css
@@ -10,6 +10,24 @@
   padding: 12px;
 }
 
+.tooltip.success .tooltip-inner {
+  background-color: #2db761;
+  color: white;
+}
+
+.tooltip.success .tooltip-arrow {
+  border-color: #2db761;
+}
+
+.tooltip.error .tooltip-inner {
+  background-color: #cc1f1a;
+  color: white;
+}
+
+.tooltip.error .tooltip-arrow {
+  border-color: #cc1f1a;
+}
+
 .tooltip .tooltip-arrow {
   width: 0;
   height: 0;

--- a/src/renderer/styles/_tooltip.css
+++ b/src/renderer/styles/_tooltip.css
@@ -11,21 +11,19 @@
 }
 
 .tooltip.success .tooltip-inner {
-  background-color: #2db761;
-  color: white;
+  @apply .bg-green .text-white;
 }
 
 .tooltip.success .tooltip-arrow {
-  border-color: #2db761;
+  @apply .border-green;
 }
 
 .tooltip.error .tooltip-inner {
-  background-color: #cc1f1a;
-  color: white;
+  @apply .bg-red-dark .text-white;
 }
 
 .tooltip.error .tooltip-arrow {
-  border-color: #cc1f1a;
+  @apply .border-red-dark;
 }
 
 .tooltip .tooltip-arrow {


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

Adds tooltip colors and a delay to the tooltip hiding.

![tooltip](https://user-images.githubusercontent.com/6547002/51508040-ece1f300-1df3-11e9-8a49-76bfe0e68110.gif)

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes