### PR TITLE
feat: add sidebar animation

### DIFF
--- a/src/renderer/components/Wallet/WalletSidebar/WalletSidebar.vue
+++ b/src/renderer/components/Wallet/WalletSidebar/WalletSidebar.vue
@@ -6,7 +6,7 @@
       'WalletSidebar--collapsed': !isExpanded,
       'WalletSidebar--expanded': isExpanded
     }"
-    class="WalletSidebar justify-start pt-0 overflow-y-auto"
+    class="WalletSidebar justify-start pt-0 overflow-y-auto menu-transition"
     @input="onSelect"
   >
     <div
@@ -15,6 +15,9 @@
     >
       <div
         v-if="!isExpanded"
+        v-tooltip="{
+          content: $t('WALLET_SIDEBAR.EXPAND')
+        }"
         class="WalletSidebar__menu__button"
         @click="expand"
       >
@@ -94,57 +97,62 @@
     </MenuNavigationItem>
 
     <!-- List of actual wallets -->
-    <MenuNavigationItem
-      v-for="wallet in selectableWallets"
-      :id="wallet.id"
-      :key="wallet.id"
-      class="WalletSidebar__wallet"
+    <div
+      :class="{ 'opacity-0': isResizing }"
+      class="menu-transition"
     >
-      <div
-        slot-scope="{ isActive }"
-        :class="{ 'flex flex-row': isExpanded }"
-        class="WalletSidebar__wallet__wrapper transition items-center w-full mx-6 py-6 truncate"
+      <MenuNavigationItem
+        v-for="wallet in selectableWallets"
+        :id="wallet.id"
+        :key="wallet.id"
+        class="WalletSidebar__wallet menu-transition"
       >
-        <WalletIdenticon
-          :size="50"
-          :value="wallet.address"
-          class="WalletSidebar__wallet__identicon flex-no-shrink"
-        />
         <div
-          :class="{
-            'text-theme-page-text': isActive,
-            'text-theme-page-text-light': !isActive,
-            'pt-2': !isExpanded,
-            'pl-2': isExpanded
-          }"
-          class="WalletSidebar__wallet__info flex flex-col font-semibold overflow-hidden"
+          slot-scope="{ isActive }"
+          :class="{ 'flex flex-row': isExpanded }"
+          class="WalletSidebar__wallet__wrapper transition items-center w-full mx-6 py-6 truncate"
         >
-          <span
-            class="flex items-center"
-            :class="{ 'justify-center': !isExpanded }"
+          <WalletIdenticon
+            :size="50"
+            :value="wallet.address"
+            class="WalletSidebar__wallet__identicon flex-no-shrink"
+          />
+          <div
+            :class="{
+              'text-theme-page-text': isActive,
+              'text-theme-page-text-light': !isActive,
+              'pt-2': !isExpanded,
+              'pl-2': isExpanded
+            }"
+            class="WalletSidebar__wallet__info flex flex-col font-semibold overflow-hidden"
           >
-            <span class="block truncate">
-              {{ wallet_name(wallet.address) || wallet_truncate(wallet.address, !isExpanded ? 6 : (wallet.isLedger ? 12 : 24)) }}
+            <span
+              class="flex items-center"
+              :class="{ 'justify-center': !isExpanded }"
+            >
+              <span class="block truncate">
+                {{ wallet_name(wallet.address) || wallet_truncate(wallet.address, !isExpanded ? 6 : (wallet.isLedger ? 12 : 24)) }}
+              </span>
+              <span
+                v-if="wallet.isLedger"
+                v-tooltip="!isExpanded ? $t('COMMON.LEDGER_WALLET') : ''"
+                :class="{ 'w-5': !isExpanded }"
+                class="ledger-badge"
+              >
+                {{ !isExpanded ? $t('COMMON.LEDGER').charAt(0) : $t('COMMON.LEDGER') }}
+              </span>
             </span>
             <span
-              v-if="wallet.isLedger"
-              v-tooltip="!isExpanded ? $t('COMMON.LEDGER_WALLET') : ''"
-              :class="{ 'w-5': !isExpanded }"
-              class="ledger-badge"
+              v-if="isExpanded"
+              class="font-bold mt-2 text-xl"
             >
-              {{ !isExpanded ? $t('COMMON.LEDGER').charAt(0) : $t('COMMON.LEDGER') }}
+              {{ formatter_networkCurrency(wallet.balance, 2) }}
+              <!-- TODO display a +/- n ARK on recent transactions -->
             </span>
-          </span>
-          <span
-            v-if="isExpanded"
-            class="font-bold mt-2 text-xl"
-          >
-            {{ formatter_networkCurrency(wallet.balance, 2) }}
-            <!-- TODO display a +/- n ARK on recent transactions -->
-          </span>
+          </div>
         </div>
-      </div>
-    </MenuNavigationItem>
+      </MenuNavigationItem>
+    </div>
   </MenuNavigation>
 </template>
 
@@ -183,6 +191,7 @@ export default {
 
   data: () => ({
     hasBeenExpanded: false,
+    isResizing: false,
     selectableWallets: []
   }),
 
@@ -236,12 +245,25 @@ export default {
 
   methods: {
     collapse () {
-      this.hasBeenExpanded = false
-      this.$emit('collapsed')
+      this.isResizing = true
+      setTimeout(() => {
+        setTimeout(() => {
+          this.isResizing = false
+        }, 350)
+        this.hasBeenExpanded = false
+        this.$emit('collapsed')
+      }, 100)
     },
+
     expand () {
-      this.hasBeenExpanded = true
-      this.$emit('expanded')
+      this.isResizing = true
+      setTimeout(() => {
+        setTimeout(() => {
+          this.isResizing = false
+        }, 350)
+        this.hasBeenExpanded = true
+        this.$emit('expanded')
+      }, 100)
     },
 
     onSelect (address) {
@@ -307,7 +329,7 @@ export default {
 }
 
 .WalletSidebar--collapsed .WalletSidebar__wallet__wrapper {
-  @apply .flex-col .justify-center
+  @apply .flex-col .justify-center .border-b .border-theme-feature
 }
 .WalletSidebar--collapsed .WalletSidebar__wallet__identicon {
   @apply .mb-2
@@ -322,4 +344,7 @@ export default {
   transform: scaleY(-1) scaleX(-1)
 }
 
+.menu-transition {
+  transition: width .4s ease-out, opacity 0.1s;
+}
 </style>

--- a/src/renderer/components/Wallet/WalletSidebar/WalletSidebar.vue
+++ b/src/renderer/components/Wallet/WalletSidebar/WalletSidebar.vue
@@ -6,7 +6,7 @@
       'WalletSidebar--collapsed': !isExpanded,
       'WalletSidebar--expanded': isExpanded
     }"
-    class="WalletSidebar justify-start pt-0 overflow-y-auto menu-transition"
+    class="WalletSidebar justify-start pt-0 overflow-y-auto"
     @input="onSelect"
   >
     <div
@@ -99,13 +99,13 @@
     <!-- List of actual wallets -->
     <div
       :class="{ 'opacity-0': isResizing }"
-      class="menu-transition"
+      class="WalletSidebar__container"
     >
       <MenuNavigationItem
         v-for="wallet in selectableWallets"
         :id="wallet.id"
         :key="wallet.id"
-        class="WalletSidebar__wallet menu-transition"
+        class="WalletSidebar__wallet"
       >
         <div
           slot-scope="{ isActive }"
@@ -249,10 +249,10 @@ export default {
       setTimeout(() => {
         setTimeout(() => {
           this.isResizing = false
-        }, 350)
+        }, 125)
         this.hasBeenExpanded = false
         this.$emit('collapsed')
-      }, 100)
+      }, 75)
     },
 
     expand () {
@@ -260,10 +260,10 @@ export default {
       setTimeout(() => {
         setTimeout(() => {
           this.isResizing = false
-        }, 350)
+        }, 125)
         this.hasBeenExpanded = true
         this.$emit('expanded')
-      }, 100)
+      }, 75)
     },
 
     onSelect (address) {
@@ -302,6 +302,12 @@ export default {
 </style>
 
 <style lang="postcss" scoped>
+.WalletSidebar {
+  transition: width 0.1s ease-out;
+}
+.WalletSidebar__container {
+  transition: opacity 0.1s;
+}
 .WalletSidebar__menu {
   border-bottom: 0.08rem solid var(--theme-feature-item-alternative);
 }
@@ -342,9 +348,5 @@ export default {
   width: 40px;
   height: 40px;
   transform: scaleY(-1) scaleX(-1)
-}
-
-.menu-transition {
-  transition: width .4s ease-out, opacity 0.1s;
 }
 </style>

--- a/src/renderer/i18n/locales/en-US.js
+++ b/src/renderer/i18n/locales/en-US.js
@@ -825,6 +825,7 @@ export default {
   WALLET_SIDEBAR: {
     FILTER: 'Filter',
     HIDE: 'Hide',
+    EXPAND: 'Expand',
     LOADING_LEDGER: 'Loading Ledger...'
   },
 


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

Adds an animation to the sidebar upon expanding or collapsing and fixes the "white border issue" caused by the transition on the bottom border. I deemed the fading out and in necessary since there is no proper way to transition the flex-direction property.

![sidebar](https://user-images.githubusercontent.com/6547002/51753927-4f204980-20bb-11e9-885a-ac0de6f5fcfe.gif)

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes