### PR TITLE
fix: importing of profile avatar selection modal component

### DIFF
--- a/src/renderer/components/Input/InputGrid/InputGridModal.vue
+++ b/src/renderer/components/Input/InputGrid/InputGridModal.vue
@@ -49,7 +49,7 @@
 </template>
 
 <script>
-import ModalWindow from '@/components/Modal'
+import ModalWindow from '@/components/Modal/ModalWindow'
 import InputGridItem from './InputGridItem'
 
 /**


### PR DESCRIPTION
## Proposed changes
There was a problem when trying to select a profile avatar on the profile creation and edition pages: when clicking the avatars where displayed, but not inside a modal window.
The root cause was that the `ModalWindow` component wasn't correctly detected.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
