### PR TITLE
fix: errors during and after removing profiles

### DIFF
--- a/__tests__/unit/components/Profile/ProfileRemovalConfirmation.spec.js
+++ b/__tests__/unit/components/Profile/ProfileRemovalConfirmation.spec.js
@@ -1,0 +1,101 @@
+import { shallowMount } from '@vue/test-utils'
+import useI18nGlobally from '../../__utils__/i18n'
+import { ProfileRemovalConfirmation } from '@/components/Profile'
+
+const i18n = useI18nGlobally()
+let wrapper
+
+const profile = { id: 'my profile' }
+let $store = {}
+let $router = {}
+
+const mountComponent = ({ profiles } = {}) => {
+  $router.push = jest.fn()
+  $store.dispatch = jest.fn()
+  $store.getters = {
+    'profile/all': profiles
+  }
+
+  return shallowMount(ProfileRemovalConfirmation, {
+    i18n,
+    propsData: {
+      profile
+    },
+    mocks: {
+      $router,
+      $store
+    }
+  })
+}
+
+beforeEach(() => {
+  wrapper = mountComponent()
+})
+
+describe('ProfileRemovalConfirmation', () => {
+  it('should render modal', () => {
+    expect(wrapper.isVueInstance()).toBeTrue()
+  })
+
+  describe('removeProfile', () => {
+    describe('when there are several profiles', () => {
+      const profile2 = { id: 'two' }
+
+      beforeEach(() => {
+        wrapper = mountComponent({
+          profiles: [profile, profile2]
+        })
+      })
+
+      it('should set other profile before removal', () => {
+        wrapper.vm.removeProfile()
+
+        expect($store.dispatch.mock.calls[0]).toEqual(['session/setProfileId', profile2.id])
+      })
+
+      it('should delete the profile', () => {
+        wrapper.vm.removeProfile()
+
+        expect($store.dispatch.mock.calls[1]).toEqual(['profile/delete', profile])
+      })
+
+      it('should emit the `removed` event', () => {
+        wrapper.vm.removeProfile()
+
+        expect(wrapper.emitted('removed'))
+      })
+    })
+
+    describe('when there is only 1 profile', () => {
+      beforeEach(() => {
+        wrapper = mountComponent({
+          profiles: [profile]
+        })
+      })
+
+      it('should reset the session before removal', () => {
+        wrapper.vm.removeProfile()
+
+        expect($store.dispatch.mock.calls[0]).toEqual(['session/reset'])
+      })
+
+      it('should delete the profile', () => {
+        wrapper.vm.removeProfile()
+
+        expect($store.dispatch.mock.calls[1]).toEqual(['profile/delete', profile])
+      })
+
+      it('should redirect to the profile creation page', () => {
+        wrapper.vm.removeProfile()
+
+        expect($router.push).toHaveBeenCalledWith({ name: 'profile-new' })
+      })
+
+      it('should emit the `removed` event', () => {
+        wrapper.vm.removeProfile()
+
+        expect(wrapper.emitted('removed'))
+      })
+    })
+  })
+})

--- a/src/renderer/components/Input/InputGrid/InputGridItem.vue
+++ b/src/renderer/components/Input/InputGrid/InputGridItem.vue
@@ -89,7 +89,8 @@ export default {
 
   computed: {
     currentNetwork () {
-      return this.session_network
+      // To avoid failing after removing the current and last profile
+      return this.$store.getters['session/profile'] ? this.session_network : null
     },
 
     label () {

--- a/src/renderer/components/Profile/ProfileRemovalConfirmation.vue
+++ b/src/renderer/components/Profile/ProfileRemovalConfirmation.vue
@@ -46,8 +46,22 @@ export default {
 
   methods: {
     removeProfile () {
-      this.$store.dispatch('profile/delete', this.profile)
-      this.emitRemoved()
+      const removeCurrentProfile = () => {
+        this.$store.dispatch('profile/delete', this.profile)
+        this.emitRemoved()
+      }
+
+      const profiles = this.$store.getters['profile/all']
+
+      if (profiles.length <= 1) {
+        this.$store.dispatch('session/reset')
+        removeCurrentProfile()
+        this.$router.push({ name: 'profile-new' })
+      } else {
+        const nextProfile = profiles.find(profile => profile.id !== this.profile.id)
+        this.$store.dispatch('session/setProfileId', nextProfile.id)
+        removeCurrentProfile()
+      }
     },
 
     emitCancel () {

--- a/src/renderer/pages/Profile/ProfileAll.vue
+++ b/src/renderer/pages/Profile/ProfileAll.vue
@@ -156,13 +156,6 @@ export default {
 
     onRemoval () {
       this.hideRemovalConfirmation()
-
-      if (this.profiles.length) {
-        this.$store.dispatch('session/setProfileId', this.profiles[0].id)
-      } else {
-        this.$store.dispatch('session/reset')
-        this.$router.push({ name: 'profile-new' })
-      }
     },
 
     openRemovalConfirmation (profile) {

--- a/src/renderer/store/modules/session.js
+++ b/src/renderer/store/modules/session.js
@@ -35,7 +35,7 @@ export default {
       return rootGetters['profile/byId'](state.profileId)
     },
     network (state, getters, __, rootGetters) {
-      if (!state.profileId) {
+      if (!getters['profile']) {
         return
       }
 


### PR DESCRIPTION
## Proposed changes
This PR fixes several problems that occur when removing a profile. Some of them are visible on the console after clicking on Remove, while others occur after that, when the user is redirected to the profile creation (if no other profile is available) or when the user start again the application without profiles.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Test (adding missing tests or fixing existing tests)

## Checklist
- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works