### PR TITLE
fix: watch only wallet import and secondary actions

### DIFF
--- a/__tests__/unit/components/Wallet/WalletHeading.spec.js
+++ b/__tests__/unit/components/Wallet/WalletHeading.spec.js
@@ -11,7 +11,17 @@ localVue.use(Vuex)
 const i18n = useI18n(localVue)
 
 const store = new Vuex.Store({
-  state: {}
+  state: {},
+  modules: {
+    wallet: {
+      namespaced: true,
+      getters: {
+        byAddress: () => address => {
+          return sampleWalletData
+        }
+      }
+    }
+  }
 })
 
 const sampleWalletData = {
@@ -20,7 +30,7 @@ const sampleWalletData = {
 }
 
 describe('WalletHeading', () => {
-  it('should be instatiated', () => {
+  it('should be instantiated', () => {
     const wrapper = shallowMount(WalletHeading, {
       store,
       localVue,
@@ -34,7 +44,7 @@ describe('WalletHeading', () => {
 })
 
 describe('WalletHeadingActions', () => {
-  it('should be instatiated', () => {
+  it('should be instantiated', () => {
     const wrapper = shallowMount(WalletHeadingActions, {
       store,
       localVue,
@@ -48,7 +58,7 @@ describe('WalletHeadingActions', () => {
 })
 
 describe('WalletHeadingPrimaryActions', () => {
-  it('should be instatiated', () => {
+  it('should be instantiated', () => {
     const wrapper = shallowMount(WalletHeadingPrimaryActions, {
       i18n,
       provide: {
@@ -68,7 +78,7 @@ describe('WalletHeadingPrimaryActions', () => {
 })
 
 describe('WalletHeadingSecondaryActions', () => {
-  it('should be instatiated', () => {
+  it('should be instantiated', () => {
     const wrapper = shallowMount(WalletHeadingSecondaryActions, {
       i18n,
       mocks: {

--- a/__tests__/unit/components/Wallet/WalletHeadingInfo.spec.js
+++ b/__tests__/unit/components/Wallet/WalletHeadingInfo.spec.js
@@ -58,7 +58,7 @@ describe('WalletHeadingInfo component', () => {
     })
   })
 
-  it('should be instatiated', () => {
+  it('should be instantiated', () => {
     expect(wrapper.isVueInstance()).toBeTrue()
   })
 

--- a/__tests__/unit/models/base.spec.js
+++ b/__tests__/unit/models/base.spec.js
@@ -17,7 +17,7 @@ describe('BaseModel', () => {
       item = { integer: 1, timestamp: new Date().getTime() }
     })
 
-    it('should be instatiated', () => {
+    it('should be instantiated', () => {
       expect(rigidModel).toBeInstanceOf(BaseModel)
     })
 

--- a/src/renderer/components/Wallet/WalletHeading/WalletHeadingActions.vue
+++ b/src/renderer/components/Wallet/WalletHeading/WalletHeadingActions.vue
@@ -9,7 +9,7 @@
       class="-mr-2"
     />
     <button
-      v-if="!currentWallet.isWatchOnly"
+      v-if="allowSecondaryActions()"
       class="option-heading-button flex items-center self-stretch ml-2 p-2"
       @click="$store.dispatch('wallet/setSecondaryButtonsVisible', !secondaryButtonsVisible)"
     >
@@ -48,6 +48,12 @@ export default {
 
     currentWallet () {
       return this.wallet_fromRoute
+    }
+  },
+
+  methods: {
+    allowSecondaryActions () {
+      return this.currentWallet.isLedger || this.currentWallet.isContact || !!this.$store.getters['wallet/byAddress'](this.currentWallet.address)
     }
   }
 }

--- a/src/renderer/components/Wallet/WalletHeading/WalletHeadingSecondaryActions.vue
+++ b/src/renderer/components/Wallet/WalletHeading/WalletHeadingSecondaryActions.vue
@@ -26,7 +26,7 @@
     </ButtonModal>
 
     <ButtonModal
-      v-show="!currentWallet.isContact && !currentWallet.isDelegate"
+      v-show="!currentWallet.isContact && !currentWallet.isDelegate && !currentWallet.isWatchOnly"
       :class="buttonStyle"
       :label="$t('WALLET_HEADING.ACTIONS.REGISTER_DELEGATE')"
       icon="register-delegate"
@@ -42,7 +42,7 @@
     </ButtonModal>
 
     <ButtonModal
-      v-show="!currentWallet.isContact && !currentWallet.isLedger && !currentWallet.secondPublicKey"
+      v-show="!currentWallet.isContact && !currentWallet.isLedger && !currentWallet.isWatchOnly && !currentWallet.secondPublicKey"
       :class="buttonStyle"
       :label="$t('WALLET_HEADING.ACTIONS.SECOND_PASSPHRASE')"
       icon="2nd-passphrase"

--- a/src/renderer/mixins/wallet.js
+++ b/src/renderer/mixins/wallet.js
@@ -23,7 +23,7 @@ export default {
           address,
           name: '',
           profileId: '',
-          isContact: true,
+          isContact: false,
           isWatchOnly: true
         })
       }

--- a/src/renderer/pages/Wallet/WalletImport.vue
+++ b/src/renderer/pages/Wallet/WalletImport.vue
@@ -268,6 +268,8 @@ export default {
       }
       if (!this.useOnlyAddress) {
         this.wallet.publicKey = WalletService.getPublicKeyFromPassphrase(this.wallet.passphrase)
+      } else {
+        this.wallet.isWatchOnly = true
       }
 
       if (!this.useOnlyAddress && this.walletPassword && this.walletPassword.length) {


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

This fixes the following:

- when importing a wallet as watch only, the respective flag isn't set on the wallet
- the secondary action buttons to register a delegate and second signature were visible for watch only wallets
- when navigating to an address that is neither wallet nor contact, it should not be loaded as a contact and the secondary action buttons should not be toggeable

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes