### PR TITLE
feat: keep the expand button at the top

### DIFF
--- a/src/renderer/components/Wallet/WalletSidebar/WalletSidebar.vue
+++ b/src/renderer/components/Wallet/WalletSidebar/WalletSidebar.vue
@@ -6,12 +6,12 @@
       'WalletSidebar--collapsed': !isExpanded,
       'WalletSidebar--expanded': isExpanded
     }"
-    class="WalletSidebar justify-start pt-0 overflow-y-auto"
+    class="WalletSidebar justify-start pt-0"
     @input="onSelect"
   >
     <div
       v-if="showMenu"
-      class="WalletSidebar__menu flex flex-row m-4 justify-around"
+      class="WalletSidebar__menu flex flex-row px-4 pt-4 justify-around"
     >
       <div
         v-if="!isExpanded"
@@ -304,12 +304,14 @@ export default {
 <style lang="postcss" scoped>
 .WalletSidebar {
   transition: width 0.1s ease-out;
+  @apply .overflow-y-auto
 }
 .WalletSidebar__container {
   transition: opacity 0.1s;
 }
 .WalletSidebar__menu {
   border-bottom: 0.08rem solid var(--theme-feature-item-alternative);
+  @apply .sticky .z-10 .bg-theme-feature .pin-t
 }
 .WalletSidebar__menu__button {
   @apply .cursor-pointer .fill-current .text-theme-option-button-text .py-2 .my-6;

--- a/src/renderer/pages/Wallet/WalletShow.vue
+++ b/src/renderer/pages/Wallet/WalletShow.vue
@@ -11,7 +11,7 @@
     />
     <WalletSidebar
       v-if="wallet"
-      class="sticky pin min-h-full border-l border-theme-line-separator py-10 rounded-r-lg hidden lg:block"
+      class="border-l border-theme-line-separator rounded-r-lg hidden lg:block"
       :class="{
         'w-1/3': isSidebarExpanded,
         'w-1/7': !isSidebarExpanded


### PR DESCRIPTION
## Proposed changes
Keeping the button to expand/collapse at the top would allow seeing (expanding) the balance of the last wallets without having to go to the top to expand the sidebar.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes