### PR TITLE
feat: ask users, when leaving the profile edition without having saved it, if they want to do it

### DIFF
--- a/__tests__/unit/pages/Profile/ProfileAll.spec.js
+++ b/__tests__/unit/pages/Profile/ProfileAll.spec.js
@@ -142,12 +142,12 @@ describe('pages > ProfileAll', () => {
   })
 
   describe('totalBalances', () => {
-    it('should return the sum of balances per network, using their symbols', () => {
+    it('should return the sum of balances per network, using their symbols, sorted by quantity descently', () => {
       wrapper = mountPage()
       expect(wrapper.vm.totalBalances).toEqual([
         'm 500.150909',
-        'o 0.1219',
-        'd 0.5201'
+        'd 0.5201',
+        'o 0.1219'
       ])
     })
 
@@ -159,12 +159,12 @@ describe('pages > ProfileAll', () => {
         ]
       })
 
-      it('should include their balances', () => {
+      it('should include their balances, sorted by quantity descently', () => {
         wrapper = mountPage()
         expect(wrapper.vm.totalBalances).toEqual([
           'm 666.22093608',
-          'o 0.1219',
-          'd 0.5201'
+          'd 0.5201',
+          'o 0.1219'
         ])
       })
     })

--- a/config/index.js
+++ b/config/index.js
@@ -60,7 +60,7 @@ exports.MARKET = {
   source: {
     baseUrl: 'https://min-api.cryptocompare.com'
   },
-  defaultCurrency: 'USD',
+  defaultCurrency: 'BTC',
   crypto: [
     'BTC',
     'ETH',

--- a/src/renderer/components/App/AppSidemenu/AppSidemenuSettings.vue
+++ b/src/renderer/components/App/AppSidemenu/AppSidemenuSettings.vue
@@ -129,6 +129,7 @@
         :title="$t('APP_SIDEMENU.SETTINGS.RESET_DATA.QUESTION')"
         :note="$t('APP_SIDEMENU.SETTINGS.RESET_DATA.NOTE')"
         container-classes="max-w-md"
+        @close="toggleResetDataModal"
         @cancel="toggleResetDataModal"
         @continue="onResetData"
       />

--- a/src/renderer/components/Contact/ContactRemovalConfirmation.vue
+++ b/src/renderer/components/Contact/ContactRemovalConfirmation.vue
@@ -2,6 +2,7 @@
   <ModalConfirmation
     :question="$t('CONTACT_REMOVAL_CONFIRMATION.QUESTION')"
     container-classes="ContactRemovalConfirmation"
+    @close="emitCancel"
     @cancel="emitCancel"
     @continue="removeContact"
   >

--- a/src/renderer/components/Modal/ModalConfirmation.vue
+++ b/src/renderer/components/Modal/ModalConfirmation.vue
@@ -3,7 +3,7 @@
     :container-classes="containerClasses"
     :title="title"
     :portal-target="portalTarget"
-    @close="emitCancel"
+    @close="emitClose"
   >
     <section class="ModalConfirmation__container flex flex-col">
       <div class="mb-6">
@@ -100,6 +100,10 @@ export default {
   methods: {
     emitCancel () {
       this.$emit('cancel')
+    },
+
+    emitClose () {
+      this.$emit('close')
     },
 
     emitContinue () {

--- a/src/renderer/components/Profile/ProfileLeavingConfirmation.vue
+++ b/src/renderer/components/Profile/ProfileLeavingConfirmation.vue
@@ -1,0 +1,88 @@
+<template>
+  <ModalConfirmation
+    :question="$t('PROFILE_LEAVING_CONFIRMATION.QUESTION')"
+    :cancel-button="$t('PROFILE_LEAVING_CONFIRMATION.NO')"
+    :continue-button="$t('PROFILE_LEAVING_CONFIRMATION.YES')"
+    container-classes="ProfileLeavingConfirmation"
+    @close="emitClose"
+    @cancel="emitSave"
+    @continue="emitIgnore"
+  >
+    <div class="flex flex-row justify-center">
+      <img
+        :title="profile.name"
+        :src="assets_loadImage('arrows/arrow-confirmation.svg')"
+        class="ProfileLeavingConfirmation__container__arrow"
+      >
+      <ProfileAvatar
+        :profile="profile"
+        letter-size="3xl"
+      />
+      <img
+        :title="profile.name"
+        :src="assets_loadImage('arrows/arrow-confirmation.svg')"
+        class="ProfileLeavingConfirmation__container__arrow ProfileLeavingConfirmation__container__arrow--reverse"
+      >
+    </div>
+  </ModalConfirmation>
+</template>
+
+<script>
+import { ModalConfirmation } from '@/components/Modal'
+import { ProfileAvatar } from '@/components/Profile'
+
+export default {
+  name: 'ProfileLeavingConfirmation',
+
+  components: {
+    ModalConfirmation,
+    ProfileAvatar
+  },
+
+  props: {
+    profile: {
+      type: Object,
+      required: true
+    }
+  },
+
+  methods: {
+    emitIgnore () {
+      this.$emit('ignore')
+    },
+
+    emitSave () {
+      this.$emit('save')
+    },
+
+    emitClose () {
+      this.$emit('close')
+    }
+  }
+}
+</script>
+
+<style>
+.ProfileLeavingConfirmation .ModalConfirmation__container {
+  min-width: calc(var(--profile-avatar-xl) + 74px * 2 + 80px);
+  max-width: calc(var(--profile-avatar-xl) + 74px * 2 + 120px)
+}
+.ProfileLeavingConfirmation .ModalConfirmation__container > div:first-child {
+  @apply .mb-0
+}
+.ProfileLeavingConfirmation .ProfileAvatar {
+  @apply .flex .flex-col .justify-around
+}
+.ProfileLeavingConfirmation .ProfileAvatar__image {
+  height: calc(var(--profile-avatar-xl) * 0.66);
+  width: var(--profile-avatar-xl);
+}
+.ProfileLeavingConfirmation__container__arrow {
+  width: 74px;
+  height: 75px;
+  margin-top: calc(var(--profile-avatar-xl) - 75px + 2rem)
+}
+.ProfileLeavingConfirmation__container__arrow--reverse {
+  transform: scaleX(-1)
+}
+</style>

--- a/src/renderer/components/Profile/ProfileRemovalConfirmation.vue
+++ b/src/renderer/components/Profile/ProfileRemovalConfirmation.vue
@@ -3,6 +3,7 @@
     :question="$t('PROFILE_REMOVAL_CONFIRMATION.QUESTION')"
     :note="$t('PROFILE_REMOVAL_CONFIRMATION.NOTE')"
     container-classes="ProfileRemovalConfirmation"
+    @close="emitCancel"
     @cancel="emitCancel"
     @continue="removeProfile"
   >
@@ -89,8 +90,6 @@ export default {
 .ProfileRemovalConfirmation .ProfileAvatar__image {
   height: calc(var(--profile-avatar-xl) * 0.66);
   width: var(--profile-avatar-xl);
-}
-.ProfileRemovalConfirmation .ProfileAvatar__letter {
 }
 .ProfileRemovalConfirmation__container__arrow {
   width: 74px;

--- a/src/renderer/components/Profile/index.js
+++ b/src/renderer/components/Profile/index.js
@@ -1,7 +1,9 @@
 import ProfileAvatar from './ProfileAvatar'
+import ProfileLeavingConfirmation from './ProfileLeavingConfirmation'
 import ProfileRemovalConfirmation from './ProfileRemovalConfirmation'
 
 export {
   ProfileAvatar,
+  ProfileLeavingConfirmation,
   ProfileRemovalConfirmation
 }

--- a/src/renderer/components/Transaction/TransactionForm/TransactionFormTransfer.vue
+++ b/src/renderer/components/Transaction/TransactionForm/TransactionFormTransfer.vue
@@ -122,6 +122,7 @@
       :note="$t('TRANSACTION.CONFIRM_SEND_ALL_NOTE')"
       container-classes="SendAllConfirmation"
       portal-target="loading"
+      @close="emitCancelSendAll"
       @cancel="emitCancelSendAll"
       @continue="enableSendAll"
     />

--- a/src/renderer/components/Wallet/WalletRemovalConfirmation.vue
+++ b/src/renderer/components/Wallet/WalletRemovalConfirmation.vue
@@ -3,6 +3,7 @@
     :question="$t('WALLET_REMOVAL_CONFIRMATION.QUESTION')"
     :note="$t('WALLET_REMOVAL_CONFIRMATION.NOTE')"
     container-classes="WalletRemovalConfirmation"
+    @close="emitCancel"
     @cancel="emitCancel"
     @continue="removeWallet"
   >

--- a/src/renderer/i18n/locales/en-US.js
+++ b/src/renderer/i18n/locales/en-US.js
@@ -645,6 +645,12 @@ export default {
     }
   },
 
+  PROFILE_LEAVING_CONFIRMATION: {
+    QUESTION: 'Are you sure you want to ignore the changes done to this profile?',
+    NO: 'No, save them',
+    YES: 'Yes, ignore them'
+  },
+
   PROFILE_REMOVAL_CONFIRMATION: {
     NOTE: 'Although it would remove your wallets, it does not delete any data on the blockchain. You could recover the wallets as long as you have their passphrases',
     QUESTION: 'Are you sure you want to remove this profile?'

--- a/src/renderer/pages/Profile/ProfileAll.vue
+++ b/src/renderer/pages/Profile/ProfileAll.vue
@@ -77,8 +77,7 @@
 </template>
 
 <script>
-import { mapValues, uniqBy } from 'lodash'
-import { mapGetters } from 'vuex'
+import { mapValues, sortBy, uniqBy } from 'lodash'
 import { ProfileAvatar, ProfileRemovalConfirmation } from '@/components/Profile'
 
 export default {
@@ -94,7 +93,10 @@ export default {
   }),
 
   computed: {
-    ...mapGetters({ profiles: 'profile/all' }),
+    profiles () {
+      return sortBy(this.$store.getters['profile/all'], ['name', 'networkId'])
+    },
+
     addProfileImagePath () {
       return 'pages/new-profile-avatar.svg'
     },

--- a/src/renderer/pages/Profile/ProfileAll.vue
+++ b/src/renderer/pages/Profile/ProfileAll.vue
@@ -77,7 +77,7 @@
 </template>
 
 <script>
-import { mapValues, sortBy, uniqBy } from 'lodash'
+import { map, mapValues, sortBy, uniqBy } from 'lodash'
 import { ProfileAvatar, ProfileRemovalConfirmation } from '@/components/Profile'
 
 export default {
@@ -137,10 +137,14 @@ export default {
       for (const networkId in this.aggregatedBalances) {
         const network = this.$store.getters['network/byId'](networkId)
         const amount = this.currency_subToUnit(this.aggregatedBalances[networkId], network)
-        const balance = this.currency_format(amount, { currency: network.symbol, maximumFractionDigits: network.fractionDigits })
-        balances.push(balance)
+        const formatted = this.currency_format(amount, { currency: network.symbol, maximumFractionDigits: network.fractionDigits })
+        balances.push({
+          formatted,
+          amount: Number(amount)
+        })
       }
-      return balances
+      const sorted = sortBy(balances, ['amount', 'formatted'])
+      return map(sorted, 'formatted').reverse()
     }
   },
 

--- a/src/renderer/pages/Profile/ProfileEdition.vue
+++ b/src/renderer/pages/Profile/ProfileEdition.vue
@@ -400,8 +400,11 @@ export default {
     })
   },
 
-  beforeDestroy () {
-    this.$store.dispatch('session/load')
+  beforeRouteLeave (to, from, next) {
+    if (this.isModified) {
+      this.$store.dispatch('session/load', this.profile.id)
+    }
+    next()
   },
 
   mounted () {

--- a/src/renderer/pages/Profile/ProfileEdition.vue
+++ b/src/renderer/pages/Profile/ProfileEdition.vue
@@ -244,6 +244,14 @@
         </MenuTab>
       </div>
     </main>
+
+    <ProfileLeavingConfirmation
+      v-if="routeLeaveCallback"
+      :profile="profile"
+      @close="onStopLeaving"
+      @ignore="onLeave(false)"
+      @save="onLeave(true)"
+    />
   </div>
 </template>
 
@@ -253,6 +261,7 @@ import { BIP39, I18N } from '@config'
 import { InputText } from '@/components/Input'
 import { ListDivided, ListDividedItem } from '@/components/ListDivided'
 import { MenuDropdown, MenuDropdownHandler, MenuTab, MenuTabItem } from '@/components/Menu'
+import { ProfileLeavingConfirmation } from '@/components/Profile'
 import { SelectionAvatar, SelectionBackground, SelectionTheme } from '@/components/Selection'
 import SvgIcon from '@/components/SvgIcon'
 import Profile from '@/models/profile'
@@ -272,6 +281,7 @@ export default {
     MenuTabItem,
     MenuDropdown,
     MenuDropdownHandler,
+    ProfileLeavingConfirmation,
     SelectionAvatar,
     SelectionBackground,
     SelectionTheme,
@@ -287,6 +297,7 @@ export default {
       currency: '',
       timeFormat: ''
     },
+    routeLeaveCallback: null,
     tab: 'profile'
   }),
 
@@ -402,9 +413,11 @@ export default {
 
   beforeRouteLeave (to, from, next) {
     if (this.isModified) {
-      this.$store.dispatch('session/load', this.profile.id)
+      // Capture the callback to trigger it when user has decided to update or not the profile
+      this.routeLeaveCallback = next
+    } else {
+      next()
     }
-    next()
   },
 
   mounted () {
@@ -416,6 +429,20 @@ export default {
   },
 
   methods: {
+    onStopLeaving () {
+      this.routeLeaveCallback = null
+    },
+
+    async onLeave (hasToSave) {
+      if (hasToSave) {
+        await this.updateProfile()
+      } else {
+        this.$store.dispatch('session/load', this.session_profile.id)
+      }
+
+      this.routeLeaveCallback()
+    },
+
     flagImage (language) {
       return this.assets_loadImage(`flags/${language}.svg`)
     },
@@ -429,11 +456,15 @@ export default {
       }
     },
 
-    async save () {
+    async updateProfile () {
       await this.$store.dispatch('profile/update', {
         ...this.profile,
         ...this.modified
       })
+    },
+
+    async save () {
+      await this.updateProfile()
 
       this.$router.push({ name: 'profiles' })
     },


### PR DESCRIPTION
## Proposed changes
Resolves https://github.com/ArkEcosystem/desktop-wallet/issues/1018.

Users could:
 a) Close the modal and continue on the profile edition
 b) Ignore the modified settings and navigate to the expected route
 c) Save the modified settings and navigate to the expected route

Apart from that, it fixes that, the order on the profiles page is altered after updating a profile.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [x] Test (adding missing tests or fixing existing tests)

## Checklist
- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes