### PR TITLE
feat: add the time format setting to the profile creation

### DIFF
--- a/src/renderer/i18n/locales/en-US.js
+++ b/src/renderer/i18n/locales/en-US.js
@@ -164,9 +164,9 @@ export default {
   },
 
   TIME_FORMAT: {
-    'Default': 'Default',
-    '12h': '12h',
-    '24h': '24h'
+    'DEFAULT': 'Default',
+    '12H': '12h',
+    '24H': '24h'
   },
 
   BIP39_LANGUAGES: {

--- a/src/renderer/mixins/formatter.js
+++ b/src/renderer/mixins/formatter.js
@@ -21,9 +21,10 @@ export default {
         return moment(value).format(format)
       }
 
-      // Default = L LTS, 12h = L h:mm:ss, 24h = L HH:mm:ss
-      let defaultFormat = 'L LTS'
       const timeFormat = this.session_profile.timeFormat
+
+      // default = L LTS, 12h = L h:mm:ss, 24h = L HH:mm:ss
+      let defaultFormat = 'L LTS'
       if (timeFormat === '12h') {
         defaultFormat = 'L h:mm:ss A'
       } else if (timeFormat === '24h') {

--- a/src/renderer/pages/Profile/ProfileEdition.vue
+++ b/src/renderer/pages/Profile/ProfileEdition.vue
@@ -296,7 +296,7 @@ export default {
     },
     timeFormats () {
       return ['Default', '12h', '24h'].reduce((all, format) => {
-        all[format] = this.$t(`TIME_FORMAT.${format}`)
+        all[format] = this.$t(`TIME_FORMAT.${format.toUpperCase()}`)
         return all
       }, {})
     },

--- a/src/renderer/pages/Profile/ProfileNew.vue
+++ b/src/renderer/pages/Profile/ProfileNew.vue
@@ -248,7 +248,7 @@ export default {
     },
     timeFormat: {
       get () {
-        return this.$store.getters['session/timeFormat']
+        return this.$store.getters['session/timeFormat'] || 'Default'
       },
       set (timeFormat) {
         this.selectTimeFormat(timeFormat)
@@ -266,7 +266,7 @@ export default {
     },
     timeFormats () {
       return ['Default', '12h', '24h'].reduce((all, format) => {
-        all[format] = this.$t(`TIME_FORMAT.${format}`)
+        all[format] = this.$t(`TIME_FORMAT.${format.toUpperCase()}`)
         return all
       }, {})
     },

--- a/src/renderer/pages/Profile/ProfileNew.vue
+++ b/src/renderer/pages/Profile/ProfileNew.vue
@@ -67,6 +67,16 @@
                 />
               </div>
 
+              <div class="flex mb-5 w-1/2 ProfileNew__time-format-container">
+                <InputSelect
+                  v-model="timeFormat"
+                  :items="timeFormats"
+                  :label="$t('COMMON.TIME_FORMAT')"
+                  name="time-format"
+                  class="flex-1"
+                />
+              </div>
+
               <div class="flex items-center justify-between mt-5 pt-5 mb-2 border-t border-theme-line-separator border-dashed">
                 <div class="mr-2">
                   <h5 class="mb-2">
@@ -236,6 +246,14 @@ export default {
         this.selectTheme(theme)
       }
     },
+    timeFormat: {
+      get () {
+        return this.$store.getters['session/timeFormat']
+      },
+      set (timeFormat) {
+        this.selectTimeFormat(timeFormat)
+      }
+    },
     currencies () {
       return this.$store.getters['market/currencies']
     },
@@ -243,6 +261,12 @@ export default {
       return BIP39.languages.reduce((all, language) => {
         all[language] = this.$t(`BIP39_LANGUAGES.${language}`)
 
+        return all
+      }, {})
+    },
+    timeFormats () {
+      return ['Default', '12h', '24h'].reduce((all, format) => {
+        all[format] = this.$t(`TIME_FORMAT.${format}`)
         return all
       }, {})
     },
@@ -342,6 +366,11 @@ export default {
     async selectTheme (theme) {
       this.schema.theme = theme
       await this.$store.dispatch('session/setTheme', theme)
+    },
+
+    async selectTimeFormat (timeFormat) {
+      this.schema.timeFormat = timeFormat
+      await this.$store.dispatch('session/setTimeFormat', timeFormat)
     }
   },
 
@@ -358,3 +387,10 @@ export default {
   }
 }
 </script>
+
+<style scoped>
+.ProfileNew__time-format-container {
+  /* To produce the exact same width  (.pr-5 class / 2) */
+  padding-right: 0.625rem
+}
+</style>

--- a/src/renderer/store/modules/session.js
+++ b/src/renderer/store/modules/session.js
@@ -145,7 +145,7 @@ export default {
       state.avatar = 'pages/new-profile-avatar.svg'
       state.background = null
       state.currency = MARKET.defaultCurrency
-      state.timeFormat = 'default'
+      state.timeFormat = 'Default'
       state.isMarketChartEnabled = true
       state.language = I18N.defaultLocale
       state.bip39Language = 'english'

--- a/src/renderer/store/modules/session.js
+++ b/src/renderer/store/modules/session.js
@@ -145,7 +145,7 @@ export default {
       state.avatar = 'pages/new-profile-avatar.svg'
       state.background = null
       state.currency = MARKET.defaultCurrency
-      state.timeFormat = 'Default'
+      state.timeFormat = 'default'
       state.isMarketChartEnabled = true
       state.language = I18N.defaultLocale
       state.bip39Language = 'english'


### PR DESCRIPTION
## Proposed changes
That setting was on the profile edition, but not on the profile creation

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist
- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes