### PR TITLE
fix: use the configured time format on the market chart

### DIFF
--- a/__tests__/unit/components/MarketChart/MarketChart.spec.js
+++ b/__tests__/unit/components/MarketChart/MarketChart.spec.js
@@ -7,6 +7,9 @@ const mocks = {
       ticker: 'ARK'
     }
   },
+  session_profile: {
+    timeFormat: 'Default'
+  },
   $store: {
     getters: {
       'session/currency': 'USD'
@@ -21,5 +24,35 @@ describe('MarketChart', () => {
     })
 
     expect(wrapper.isVueInstance()).toBeTrue()
+  })
+
+  describe('formatHour', () => {
+    it('should use the session to return 12h or 24h format', () => {
+      let wrapper = shallowMount(MarketChart, {
+        mocks
+      })
+
+      expect(wrapper.vm.formatHour('11:00')).toEqual('11:00')
+      expect(wrapper.vm.formatHour('18:00')).toEqual('18:00')
+
+      mocks.session_profile.timeFormat = '12h'
+      wrapper = shallowMount(MarketChart, {
+        mocks
+      })
+
+      expect(wrapper.vm.formatHour('00:10')).toEqual('12:10 PM')
+      expect(wrapper.vm.formatHour('03:00')).toEqual('3:00 AM')
+      expect(wrapper.vm.formatHour('11:09')).toEqual('11:09 AM')
+      expect(wrapper.vm.formatHour('18:00')).toEqual('6:00 PM')
+      expect(wrapper.vm.formatHour('24:05')).toEqual('12:05 PM')
+
+      mocks.session_profile.timeFormat = '24h'
+      wrapper = shallowMount(MarketChart, {
+        mocks
+      })
+
+      expect(wrapper.vm.formatHour('11:00')).toEqual('11:00')
+      expect(wrapper.vm.formatHour('18:00')).toEqual('18:00')
+    })
   })
 })

--- a/src/renderer/components/MarketChart/MarketChart.vue
+++ b/src/renderer/components/MarketChart/MarketChart.vue
@@ -209,7 +209,7 @@ export default {
                       }
                     }
 
-                    return value
+                    return this.formatHour(value)
                   }
                 }
               }
@@ -290,6 +290,29 @@ export default {
 
     getPeriod () {
       return this.period
+    },
+
+    /**
+     * Returns the hour in the configured format (24h or 12h)
+     * @param {String} HH:mm
+     * @return {String}
+     */
+    formatHour (time) {
+      if (this.session_profile.timeFormat !== '12h') {
+        return time
+      } else {
+        const [hours, minutes] = time.split(':')
+        let hour = parseInt(hours)
+        let am = false
+        if (hour === 0) {
+          hour = 12
+        } else if (hour > 12) {
+          hour -= 12
+        } else {
+          am = true
+        }
+        return `${hour}:${minutes} ${am ? 'AM' : 'PM'}`
+      }
     }
   }
 }

--- a/src/renderer/mixins/formatter.js
+++ b/src/renderer/mixins/formatter.js
@@ -14,23 +14,29 @@ export default {
       return this.$n(this.currency_subToUnit(value), { maximumFractionDigits: 2 })
     },
 
-    formatter_date (value, format) {
+    /**
+     * Formats a date:
+     *  - Default  => L LTS
+     *  - 12h      => L h:mm:ss
+     *  - 24h      => L HH:mm:ss
+     * @param {Date}
+     * @param {String} [format] - The specific format to use. If not provided, uses the session setting `timeFormat`
+     * @return {String}
+     */
+    formatter_date (value, format = null) {
       moment.locale(window.navigator.userLanguage || window.navigator.language)
-      // Simply return based on format if one is specified
-      if (format) {
-        return moment(value).format(format)
-      }
 
-      const timeFormat = this.session_profile.timeFormat
-
-      // default = L LTS, 12h = L h:mm:ss, 24h = L HH:mm:ss
-      let defaultFormat = 'L LTS'
-      if (timeFormat === '12h') {
-        defaultFormat = 'L h:mm:ss A'
-      } else if (timeFormat === '24h') {
-        defaultFormat = 'L HH:mm:ss'
+      if (!format) {
+        const sessionFormat = this.session_profile.timeFormat
+        if (sessionFormat === '12h') {
+          format = 'L h:mm:ss A'
+        } else if (sessionFormat === '24h') {
+          format = 'L HH:mm:ss'
+        } else {
+          format = 'L LTS'
+        }
       }
-      return moment(value).format(defaultFormat)
+      return moment(value).format(format)
     }
   }
 }


### PR DESCRIPTION
## Proposed changes
When adding the time format setting, the market chart was not adapted.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [x] Test (adding missing tests or fixing existing tests)

## Checklist
- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works