### PR TITLE
feat: display the ticker price on the dashboard, even when the chart is disabled

### DIFF
--- a/src/renderer/components/MarketChart/MarketChartHeader.vue
+++ b/src/renderer/components/MarketChart/MarketChartHeader.vue
@@ -2,7 +2,7 @@
   <nav class="MarketChartHeader flex flex-row justify-between">
     <div class="text-lg font-semibold mt-1 text-theme-chart-price">
       <span v-if="price">
-        {{ $t('MARKET_CHART_HEADER.PRICE') }}:
+        {{ $t('MARKET_CHART_HEADER.PRICE', { currency: ticker }) }}:
         <!-- TODO price in crypto and fiat instead of only in 1 currency -->
         {{ currency_format(price, { currency, currencyDisplay: 'code' }) }}
       </span>
@@ -46,6 +46,9 @@ export default {
     },
     price () {
       return this.$store.getters['market/lastPrice']
+    },
+    ticker () {
+      return this.session_network.market.ticker
     }
   }
 }

--- a/src/renderer/i18n/locales/en-US.js
+++ b/src/renderer/i18n/locales/en-US.js
@@ -268,7 +268,7 @@ export default {
   },
 
   MARKET_CHART_HEADER: {
-    PRICE: 'Price'
+    PRICE: '{currency} price'
   },
 
   BUTTON_CLIPBOARD: {

--- a/src/renderer/pages/Dashboard.vue
+++ b/src/renderer/pages/Dashboard.vue
@@ -2,6 +2,17 @@
   <div class="Dashboard relative flex flex-row h-full w-full">
     <main class="bg-theme-feature rounded-lg lg:mr-4 flex-1 w-full flex-col overflow-y-auto">
       <div
+        v-if="!isChartEnabled && isMarketEnabled"
+        class="pt-10 px-10 rounded-t-lg text-lg font-semibold mt-1 text-theme-chart-price"
+      >
+        <span v-if="price">
+          {{ $t('MARKET_CHART_HEADER.PRICE', { currency: ticker }) }}:
+          <!-- TODO price in crypto and fiat instead of only in 1 currency -->
+          {{ currency_format(price, { currency, currencyDisplay: 'code' }) }}
+        </span>
+      </div>
+
+      <div
         v-if="isChartEnabled && isMarketEnabled"
         class="bg-theme-chart-background pt-10 px-10 pb-4 rounded-t-lg"
       >
@@ -59,6 +70,15 @@ export default {
     },
     isMarketEnabled () {
       return this.session_network && this.session_network.market && this.session_network.market.enabled
+    },
+    currency () {
+      return this.$store.getters['session/currency']
+    },
+    price () {
+      return this.$store.getters['market/lastPrice']
+    },
+    ticker () {
+      return this.session_network.market.ticker
     }
   },
 


### PR DESCRIPTION
## Proposed changes
Since some users may disable the chart for performance reasons, as a trading attitude/technique, etc. showing the price might be helpful for them.

The price is requested periodically unless is disabled on the network configuration, so displaying the price doesn't involve additional requests.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes