### PR TITLE
refactor: speed session load up by using 1 mutation instead of dispatching lots of actions

### DIFF
--- a/src/renderer/store/modules/session.js
+++ b/src/renderer/store/modules/session.js
@@ -159,30 +159,34 @@ export default {
       state.contentProtection = true
       state.ledgerCache = false
       state.transactionTableRowCount = 10
+    },
+
+    REPLACE (state, value) {
+      state.avatar = value.avatar
+      state.background = value.background
+      state.currency = value.currency
+      state.timeFormat = value.timeFormat
+      state.isMarketChartEnabled = value.isMarketChartEnabled
+      state.language = value.language
+      state.bip39Language = value.bip39Language
+      state.name = value.name
+      state.theme = value.theme
+      state.walletLayout = value.walletLayout
+      state.walletSortParams = value.walletSortParams
+      state.contactSortParams = value.contactSortParams
+      state.backgroundUpdateLedger = value.backgroundUpdateLedger
+      state.broadcastPeers = value.broadcastPeers
+      state.ledgerCache = value.ledgerCache
+      state.transactionTableRowCount = value.transactionTableRowCount
     }
   },
 
   actions: {
-    load ({ rootGetters, dispatch }, profileId) {
+    load ({ commit, rootGetters, dispatch }, profileId) {
       const profile = rootGetters['profile/byId'](profileId)
       if (!profile) return
 
-      dispatch('setAvatar', profile.avatar)
-      dispatch('setBackground', profile.background)
-      dispatch('setCurrency', profile.currency)
-      dispatch('setTimeFormat', profile.timeFormat)
-      dispatch('setIsMarketChartEnabled', profile.isMarketChartEnabled)
-      dispatch('setName', profile.name)
-      dispatch('setLanguage', profile.language)
-      dispatch('setBip39Language', profile.bip39Language)
-      dispatch('setTheme', profile.theme)
-      dispatch('setWalletLayout', profile.walletLayout)
-      dispatch('setWalletSortParams', profile.walletSortParams)
-      dispatch('setContactSortParams', profile.contactSortParams)
-      dispatch('setBackgroundUpdateLedger', profile.backgroundUpdateLedger)
-      dispatch('setBroadcastPeers', profile.broadcastPeers)
-      dispatch('setLedgerCache', profile.ledgerCache)
-      dispatch('setTransactionTableRowCount', profile.transactionTableRowCount)
+      commit('REPLACE', profile)
 
       return profile
     },


### PR DESCRIPTION
## Proposed changes
This change reduces the time to load initially the session about 2 seconds and switching profiles is reduced about 1 second. Your mileage may vary.

## Types of changes
- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist
- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes