### PR TITLE
fix: get balance for unowned wallets

### DIFF
--- a/__tests__/unit/components/Wallet/WalletHeadingInfo.spec.js
+++ b/__tests__/unit/components/Wallet/WalletHeadingInfo.spec.js
@@ -17,7 +17,8 @@ const network = {
 
 const sampleWalletData = {
   address: 'AJAAfMJj1w6U5A3t6BGA7NYZsaVve6isMm',
-  balance: 797.8921
+  balance: 797.8921,
+  profileId: 'abc'
 }
 
 const alternativeCurrency = 'EUR'

--- a/src/renderer/components/Wallet/WalletHeading/WalletHeadingInfo.vue
+++ b/src/renderer/components/Wallet/WalletHeading/WalletHeadingInfo.vue
@@ -138,26 +138,19 @@ export default {
       return secondPublicKey || lazySecondPublicKey
     },
     alternativeBalance () {
-      let balance = this.currentWallet ? this.currentWallet.balance : null
-
-      if (balance === null) {
-        balance = this.lazyWallet.balance || 0
-      }
-
-      const unitBalance = this.currency_subToUnit(balance)
+      const unitBalance = this.currency_subToUnit(this.rawBalance)
       return this.currency_format(unitBalance * this.price, { currency: this.alternativeCurrency })
     },
     alternativeCurrency () {
       return this.$store.getters['session/currency']
     },
     balance () {
-      let balance = this.currentWallet ? this.currentWallet.balance : null
-
-      if (balance === null) {
-        balance = this.lazyWallet.balance || 0
-      }
-
-      return this.formatter_networkCurrency(balance)
+      return this.formatter_networkCurrency(this.rawBalance)
+    },
+    rawBalance () {
+      return this.currentWallet.profileId.length
+        ? this.currentWallet.balance
+        : (this.lazyWallet.balance || 0)
     },
     name () {
       return this.wallet_name(this.currentWallet.address)
@@ -206,7 +199,7 @@ export default {
     // Called by the parent when the address changed
     // Fetch watch-only address, since the wallet is not stored on vuex
     async refreshWallet () {
-      if (!this.currentWallet) {
+      if (this.currentWallet.profileId.length) {
         return
       }
 


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

This is intended as a different fix for #1057, thus replacing #1071. The reason is that in #1071 an API call is fired to fetch the wallet regardless of wether it is available in the store or not.

A stored wallet/contact has a `profileId` assigned to it, unowned wallets do not (empty string). Based on this property we can decide wether to fetch the wallet through the API or from the store.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes