### PR TITLE
fix: compile portal-vue to not display developer note in production

### DIFF
--- a/.electron-vue/webpack.renderer.config.js
+++ b/.electron-vue/webpack.renderer.config.js
@@ -22,7 +22,7 @@ const { VueLoaderPlugin } = require('vue-loader')
  * that provide pure *.vue files that need compiling
  * https://simulatedgreg.gitbooks.io/electron-vue/content/en/webpack-configurations.html#white-listing-externals
  */
-let whiteListedModules = ['vue']
+let whiteListedModules = ['vue', 'portal-vue']
 
 let rendererConfig = {
   devtool: '#cheap-module-eval-source-map',


### PR DESCRIPTION
## Proposed changes

In the production version is showing the developer note:

<img width="510" alt="captura de tela 2019-02-22 as 11 37 48" src="https://user-images.githubusercontent.com/4539235/53249200-51fc6300-3696-11e9-80a4-bd8662100d47.png">

## Types of changes

- [x] Build (changes that affect the build system)