### PR TITLE
feat: ignore the case of the query when filtering by name of wallets, contacts, Ledgers, known wallets or delegates

### DIFF
--- a/__tests__/unit/components/Wallet/WalletSidebar.spec.js
+++ b/__tests__/unit/components/Wallet/WalletSidebar.spec.js
@@ -133,12 +133,20 @@ describe('WalletSidebar', () => {
             wallets[1]
           ])
         })
+
+        it('should not ignore the case', () => {
+          wrapper.vm.applyFilters({
+            searchQuery: 'Xd'
+          })
+
+          expect(wrapper.vm.filterWallets(wallets)).toBeEmpty()
+        })
       })
 
       describe('when wallet balances match', () => {
         it('should return only those wallets', () => {
           wrapper.vm.applyFilters({
-            searchQuery: 13
+            searchQuery: '13'
           })
 
           expect(wrapper.vm.filterWallets(wallets)).toEqual([
@@ -159,6 +167,17 @@ describe('WalletSidebar', () => {
             wallets[1]
           ])
         })
+
+        it('should ignore the case', () => {
+          wrapper.vm.applyFilters({
+            searchQuery: 'Am'
+          })
+
+          expect(wrapper.vm.filterWallets(wallets)).toEqual([
+            wallets[0],
+            wallets[1]
+          ])
+        })
       })
 
       describe('when wallet alternative (delegate, network, etc.) names match', () => {
@@ -169,6 +188,20 @@ describe('WalletSidebar', () => {
           })
           wrapper.vm.applyFilters({
             searchQuery: 'examples'
+          })
+
+          expect(wrapper.vm.filterWallets(wallets)).toEqual([
+            wallets[0]
+          ])
+        })
+
+        it('should ignore the case', () => {
+          wrapper.vm.wallet_name = jest.fn().mockImplementation(address => {
+            const wallet = wallets.find(wallet => wallet.address === address)
+            return `${wallet.name}s`
+          })
+          wrapper.vm.applyFilters({
+            searchQuery: 'eXaMples'
           })
 
           expect(wrapper.vm.filterWallets(wallets)).toEqual([

--- a/src/renderer/components/Wallet/WalletSidebar/WalletSidebar.vue
+++ b/src/renderer/components/Wallet/WalletSidebar/WalletSidebar.vue
@@ -371,16 +371,22 @@ export default {
       }
       if (this.filters.searchQuery) {
         filtered = filter(filtered, ({ address, balance, name }) => {
-          const alternativeName = this.wallet_name(address)
-          const names = alternativeName
-            ? [name, alternativeName]
-            : [name]
-
-          return [
-            ...names,
+          let match = [
             address,
             balance.toString()
           ].some(text => text.includes(this.filters.searchQuery))
+
+          if (!match) {
+            const alternativeName = this.wallet_name(address)
+            const names = alternativeName
+              ? [name, alternativeName]
+              : [name]
+
+            const query = this.filters.searchQuery.toLowerCase()
+            match = names.some(name => name.toLowerCase().includes(query))
+          }
+
+          return match
         })
       }
 


### PR DESCRIPTION
## Proposed changes
The case of addresses wouldn't be ignored.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
- [x] Test (adding missing tests or fixing existing tests)

## Checklist
- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works