### PR TITLE
feat: highlight the wallet sidebar filters button when they are active

### DIFF
--- a/src/renderer/components/Wallet/WalletSidebar/WalletSidebar.vue
+++ b/src/renderer/components/Wallet/WalletSidebar/WalletSidebar.vue
@@ -19,6 +19,7 @@
           content: $t('WALLET_SIDEBAR.FILTER')
         }"
         class="WalletSidebar__menu__button"
+        :class="areFiltersActive ? 'WalletSidebar__menu__button--active' : ''"
         @click="toggleFilters"
       >
         <SvgIcon
@@ -202,7 +203,7 @@
 </template>
 
 <script>
-import { filter, sortBy, uniqBy } from 'lodash'
+import { clone, filter, isEqual, sortBy, uniqBy } from 'lodash'
 import Loader from '@/components/utils/Loader'
 import { MenuNavigation, MenuNavigationItem } from '@/components/Menu'
 import { WalletIdenticon, WalletIdenticonPlaceholder } from '../'
@@ -235,21 +236,27 @@ export default {
     }
   },
 
-  data: () => ({
+  data: vm => ({
     hasBeenExpanded: false,
     isFiltersVisible: false,
     isResizing: false,
-    filters: {
-      hideEmpty: false,
-      hideLedger: false,
-      searchQuery: ''
-    },
+    filters: clone(vm.$options.defaultFilters),
     sort: {
       order: 'name-asc'
     }
   }),
 
+  defaultFilters: Object.freeze({
+    hideEmpty: false,
+    hideLedger: false,
+    searchQuery: ''
+  }),
+
   computed: {
+    areFiltersActive () {
+      return !isEqual(this.filters, this.$options.defaultFilters)
+    },
+
     currentWallet () {
       return this.wallet_fromRoute || {}
     },
@@ -447,6 +454,9 @@ export default {
 }
 .WalletSidebar__menu__button span {
   @apply .pl-3 .font-bold;
+}
+.WalletSidebar__menu__button--active {
+  @apply .text-theme-feature-item-indicator;
 }
 .WalletSidebar__menu__separator__line {
   border-right: 0.08rem solid var(--theme-feature-item-alternative);


### PR DESCRIPTION
## Proposed changes
This is a measure to avoid that users forget that they have activated some filters and start wondering where are their wallets.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes