### PR TITLE
refactor: request wallets data and transactions in parallel during synchronization

### DIFF
--- a/__tests__/unit/services/synchronizer/wallets.spec.js
+++ b/__tests__/unit/services/synchronizer/wallets.spec.js
@@ -3,6 +3,7 @@ import { Action } from '@/services/synchronizer/wallets'
 describe('Services > Synchronizer > Wallets', () => {
   let action
   let wallets
+  let addresses
   let contacts
   let walletUpdate
   let transactionDeleteBulk
@@ -50,6 +51,7 @@ describe('Services > Synchronizer > Wallets', () => {
       { address: 'A3', transactions: {} },
       { address: 'A4', transactions: {} }
     ]
+    addresses = wallets.map(wallet => wallet.address)
     contacts = [
       { address: 'Acon1', transactions: {} },
       { address: 'Acon2', transactions: {} }
@@ -171,7 +173,7 @@ describe('Services > Synchronizer > Wallets', () => {
 
       await action.refresh(wallets)
 
-      expect(action.refreshTransactions).toHaveBeenCalledWith(wallets)
+      expect(action.refreshTransactions).toHaveBeenCalledWith(wallets, addresses)
     })
   })
 
@@ -233,7 +235,7 @@ describe('Services > Synchronizer > Wallets', () => {
         return {}
       })
 
-      await action.refreshTransactions(wallets)
+      await action.refreshTransactions(wallets, addresses)
       expect(action.$client.fetchTransactionsForWallets).toHaveBeenCalledWith(wallets.map(wallet => wallet.address))
     })
 
@@ -252,7 +254,7 @@ describe('Services > Synchronizer > Wallets', () => {
       })
 
       it('should not call processWalletTransactions', async () => {
-        await action.refreshTransactions(wallets)
+        await action.refreshTransactions(wallets, addresses)
 
         wallets.forEach(walletCheck => {
           if (walletCheck.address === wallet.address) {
@@ -264,12 +266,12 @@ describe('Services > Synchronizer > Wallets', () => {
       })
 
       it('should not dispatch the `update/wallet` Vuex action', async () => {
-        await action.refreshTransactions(wallets)
+        await action.refreshTransactions(wallets, addresses)
         expect(walletUpdate).not.toHaveBeenCalled()
       })
 
       it('should not dispatch the `transaction/deleteBulk` Vuex action', async () => {
-        await action.refreshTransactions(wallets)
+        await action.refreshTransactions(wallets, addresses)
         expect(transactionDeleteBulk).not.toHaveBeenCalled()
       })
     })
@@ -289,7 +291,7 @@ describe('Services > Synchronizer > Wallets', () => {
       })
 
       it('should call processWalletTransactions', async () => {
-        await action.refreshTransactions(wallets)
+        await action.refreshTransactions(wallets, addresses)
 
         wallets.forEach(walletCheck => {
           if (walletCheck.address === wallet.address) {

--- a/__tests__/unit/services/synchronizer/wallets.spec.js
+++ b/__tests__/unit/services/synchronizer/wallets.spec.js
@@ -7,6 +7,7 @@ describe('Services > Synchronizer > Wallets', () => {
   let contacts
   let walletUpdate
   let transactionDeleteBulk
+  let transactions
   const throwError = jest.fn()
 
   beforeEach(() => {
@@ -55,6 +56,12 @@ describe('Services > Synchronizer > Wallets', () => {
     contacts = [
       { address: 'Acon1', transactions: {} },
       { address: 'Acon2', transactions: {} }
+    ]
+    transactions = [
+      { id: 'tx1', timestamp: 300 * 1000 },
+      { id: 'tx2', timestamp: 400 * 1000 },
+      { id: 'tx3', timestamp: 200 * 1000 },
+      { id: 'tx4', timestamp: 110 * 1000 }
     ]
   })
 
@@ -131,49 +138,143 @@ describe('Services > Synchronizer > Wallets', () => {
   })
 
   describe('refresh', () => {
+    let walletsData
+    let transactionsByWallet
+
     beforeEach(() => {
-      action.processWalletData = jest.fn()
+      walletsData = [
+        wallets[0],
+        wallets[2],
+        { address: wallets[1].address }
+      ]
+
+      transactionsByWallet = {}
+      wallets.forEach(wallet => {
+        transactionsByWallet[wallet.address] = []
+      })
+
+      action.refreshWalletsData = jest.fn()
       action.refreshTransactions = jest.fn()
+      action.fetchWalletsData = jest.fn()
+      action.fetchWalletsTransactions = jest.fn()
+
+      action.fetchWalletsData.mockImplementation(addresses => {
+        return walletsData
+      })
+      action.fetchWalletsTransactions.mockImplementation(addresses => {
+        return transactionsByWallet
+      })
+    })
+
+    it('should fetch the data of all wallets', async () => {
+      await action.refresh(wallets)
+      expect(action.fetchWalletsData).toHaveBeenCalledWith(addresses)
+    })
+
+    it('should fetch the transactions of all wallets', async () => {
+      await action.refresh(wallets)
+      expect(action.fetchWalletsTransactions).toHaveBeenCalledWith(addresses)
+    })
+
+    it('should refresh the data of all wallets', async () => {
+      await action.refresh(wallets)
+
+      expect(action.refreshWalletsData).toHaveBeenCalledWith(wallets, walletsData)
+    })
+
+    it('should refresh all transactions of all wallets', async () => {
+      await action.refresh(wallets)
+
+      expect(action.refreshTransactions).toHaveBeenCalledWith(wallets, transactionsByWallet)
+    })
+  })
+
+  describe('fetchWalletsData', () => {
+    beforeEach(() => {
       action.$client.fetchWallets = jest.fn()
     })
 
-    it('should refresh each wallet', async () => {
-      action.$client.fetchWallets.mockImplementation(addresses => {
-        return wallets
-      })
+    it('should fetch the data of each wallet address', async () => {
+      await action.fetchWalletsData(addresses)
+      expect(action.$client.fetchWallets).toHaveBeenCalledWith(addresses)
+    })
+  })
 
-      await action.refresh(wallets)
-
-      wallets.forEach(wallet => {
-        expect(action.processWalletData).toHaveBeenCalledWith(wallet, wallet)
-      })
+  describe('fetchWalletsTransactions', () => {
+    beforeEach(() => {
+      action.$client.fetchTransactionsForWallets = jest.fn()
     })
 
-    it('should not refresh wallet if empty or cold response', async () => {
-      const coldWallet = { ...wallets[0], balance: 0, publicKey: null }
-      action.$client.fetchWallets.mockImplementation(addresses => {
-        return [
-          coldWallet,
-          {},
-          null,
-          wallets[2]
-        ]
-      })
+    it('should fetch the transactions of each wallet address', async () => {
+      await action.fetchWalletsTransactions(addresses)
+      expect(action.$client.fetchTransactionsForWallets).toHaveBeenCalledWith(addresses)
+    })
+  })
 
-      await action.refresh(wallets)
+  describe('refreshWalletsData', () => {
+    beforeEach(() => {
+      action.processWalletData = jest.fn()
+      action.fetchWalletsData = jest.fn()
+    })
+
+    it('should not process wallet if empty or cold', async () => {
+      const coldWallet = { ...wallets[0], balance: 0, publicKey: null }
+      const walletsData = [
+        coldWallet,
+        {},
+        null,
+        wallets[2]
+      ]
+      action.fetchWalletsData.mockImplementation(addresses => walletsData)
+
+      await action.refreshWalletsData(wallets, walletsData)
 
       expect(action.processWalletData).toHaveBeenCalledWith(wallets[2], wallets[2])
       expect(action.processWalletData).not.toHaveBeenCalledWith(wallets[0], coldWallet)
+      expect(action.processWalletData).not.toHaveBeenCalledWith(wallets[0], {})
+      expect(action.processWalletData).not.toHaveBeenCalledWith(wallets[0], null)
+    })
+  })
+
+  describe('refreshTransactions', () => {
+    let transactionsByWallet
+
+    beforeEach(() => {
+      action.processWalletTransactions = jest.fn()
     })
 
-    it('should update transactions when finished', async () => {
-      action.$client.fetchWallets.mockImplementation(addresses => {
-        return wallets
+    describe('when a wallet doest not have transactions', () => {
+      beforeEach(() => {
+        transactionsByWallet = {}
+        wallets.forEach(wallet => {
+          transactionsByWallet[wallet.address] = []
+        })
       })
 
-      await action.refresh(wallets)
+      it('should not try to process them', async () => {
+        await action.refreshTransactions(wallets, transactionsByWallet)
 
-      expect(action.refreshTransactions).toHaveBeenCalledWith(wallets, addresses)
+        wallets.forEach(wallet => {
+          expect(action.processWalletTransactions).not.toHaveBeenCalled()
+        })
+      })
+    })
+
+    describe('when wallets have transactions', () => {
+      beforeEach(() => {
+        transactionsByWallet = {}
+        wallets.forEach(wallet => {
+          transactionsByWallet[wallet.address] = transactions
+        })
+      })
+
+      it('should process them', async () => {
+        await action.refreshTransactions(wallets, transactionsByWallet)
+
+        wallets.forEach(wallet => {
+          expect(action.processWalletTransactions).toHaveBeenCalledWith(wallet, transactions)
+        })
+      })
     })
   })
 
@@ -182,9 +283,6 @@ describe('Services > Synchronizer > Wallets', () => {
 
     beforeEach(() => {
       wallet = wallets[2]
-
-      action.$client.fetchWallets = jest.fn()
-      action.refreshTransactions = jest.fn()
     })
 
     describe('when there is wallet data', () => {
@@ -213,105 +311,8 @@ describe('Services > Synchronizer > Wallets', () => {
     })
   })
 
-  describe('refreshTransactions', () => {
-    let wallet
-    const transactions = [
-      { id: 'tx1', timestamp: 300 * 1000 },
-      { id: 'tx2', timestamp: 400 * 1000 },
-      { id: 'tx3', timestamp: 200 * 1000 },
-      { id: 'tx4', timestamp: 110 * 1000 }
-    ]
-
-    beforeEach(() => {
-      wallet = wallets[2]
-
-      action.$client.fetchTransactionsForWallets = jest.fn()
-      action.processWalletTransactions = jest.fn()
-      action.displayNewTransaction = jest.fn()
-    })
-
-    it('should fetch the transactions of all wallets', async () => {
-      action.$client.fetchTransactionsForWallets.mockImplementation(addresses => {
-        return {}
-      })
-
-      await action.refreshTransactions(wallets, addresses)
-      expect(action.$client.fetchTransactionsForWallets).toHaveBeenCalledWith(wallets.map(wallet => wallet.address))
-    })
-
-    describe('when there are no transactions', () => {
-      beforeEach(() => {
-        action.$client.fetchTransactionsForWallets.mockImplementation(addresses => {
-          if (addresses.includes(wallet.address)) {
-            const response = {}
-            response[wallet.address] = []
-
-            return response
-          }
-
-          return {}
-        })
-      })
-
-      it('should not call processWalletTransactions', async () => {
-        await action.refreshTransactions(wallets, addresses)
-
-        wallets.forEach(walletCheck => {
-          if (walletCheck.address === wallet.address) {
-            expect(action.processWalletTransactions).toHaveBeenCalledWith(walletCheck, [])
-          } else {
-            expect(action.processWalletTransactions).not.toHaveBeenCalledWith(walletCheck, [])
-          }
-        })
-      })
-
-      it('should not dispatch the `update/wallet` Vuex action', async () => {
-        await action.refreshTransactions(wallets, addresses)
-        expect(walletUpdate).not.toHaveBeenCalled()
-      })
-
-      it('should not dispatch the `transaction/deleteBulk` Vuex action', async () => {
-        await action.refreshTransactions(wallets, addresses)
-        expect(transactionDeleteBulk).not.toHaveBeenCalled()
-      })
-    })
-
-    describe('when there are transactions', () => {
-      beforeEach(() => {
-        action.$client.fetchTransactionsForWallets.mockImplementation(addresses => {
-          if (addresses.includes(wallet.address)) {
-            const response = {}
-            response[wallet.address] = transactions
-
-            return response
-          }
-
-          return {}
-        })
-      })
-
-      it('should call processWalletTransactions', async () => {
-        await action.refreshTransactions(wallets, addresses)
-
-        wallets.forEach(walletCheck => {
-          if (walletCheck.address === wallet.address) {
-            expect(action.processWalletTransactions).toHaveBeenCalledWith(walletCheck, transactions)
-          } else {
-            expect(action.processWalletTransactions).not.toHaveBeenCalledWith(walletCheck, transactions)
-          }
-        })
-      })
-    })
-  })
-
   describe('processWalletTransactions', () => {
     let wallet
-    const transactions = [
-      { id: 'tx1', timestamp: 300 * 1000 },
-      { id: 'tx2', timestamp: 400 * 1000 },
-      { id: 'tx3', timestamp: 200 * 1000 },
-      { id: 'tx4', timestamp: 110 * 1000 }
-    ]
 
     beforeEach(() => {
       wallet = wallets[2]
@@ -381,13 +382,6 @@ describe('Services > Synchronizer > Wallets', () => {
 
   describe('findLatestTransaction', () => {
     it('returns the transaction with bigger `timestamp`', () => {
-      const transactions = [
-        { id: 'tx1', timestamp: 300 * 1000 },
-        { id: 'tx2', timestamp: 400 * 1000 },
-        { id: 'tx3', timestamp: 200 * 1000 },
-        { id: 'tx4', timestamp: 110 * 1000 }
-      ]
-
       expect(action.findLatestTransaction(transactions)).toBe(transactions[1])
     })
   })

--- a/__tests__/unit/services/synchronizer/wallets.spec.js
+++ b/__tests__/unit/services/synchronizer/wallets.spec.js
@@ -58,7 +58,7 @@ describe('Services > Synchronizer > Wallets', () => {
 
   describe('run', () => {
     beforeEach(() => {
-      action.refreshWallets = jest.fn()
+      action.refresh = jest.fn()
     })
 
     describe('when there is not a session profile', () => {
@@ -86,7 +86,7 @@ describe('Services > Synchronizer > Wallets', () => {
 
         it('should not try to refresh them', async () => {
           await action.run()
-          expect(action.refreshWallets).not.toHaveBeenCalled()
+          expect(action.refresh).not.toHaveBeenCalled()
         })
       })
 
@@ -99,7 +99,7 @@ describe('Services > Synchronizer > Wallets', () => {
         describe('when none of them have been checked', () => {
           it('should refresh all', async () => {
             await action.run()
-            expect(action.refreshWallets).toHaveBeenCalledWith([
+            expect(action.refresh).toHaveBeenCalledWith([
               ...wallets,
               ...contacts
             ])
@@ -117,7 +117,7 @@ describe('Services > Synchronizer > Wallets', () => {
 
           it('should refresh those that have not been checked', async () => {
             await action.run()
-            expect(action.refreshWallets).toHaveBeenCalledWith([
+            expect(action.refresh).toHaveBeenCalledWith([
               wallets[1],
               wallets[3],
               contacts[1]
@@ -128,10 +128,10 @@ describe('Services > Synchronizer > Wallets', () => {
     })
   })
 
-  describe('refreshWallets', () => {
+  describe('refresh', () => {
     beforeEach(() => {
       action.processWalletData = jest.fn()
-      action.fetchTransactionsForWallets = jest.fn()
+      action.refreshTransactions = jest.fn()
       action.$client.fetchWallets = jest.fn()
     })
 
@@ -140,7 +140,7 @@ describe('Services > Synchronizer > Wallets', () => {
         return wallets
       })
 
-      await action.refreshWallets(wallets)
+      await action.refresh(wallets)
 
       wallets.forEach(wallet => {
         expect(action.processWalletData).toHaveBeenCalledWith(wallet, wallet)
@@ -158,7 +158,7 @@ describe('Services > Synchronizer > Wallets', () => {
         ]
       })
 
-      await action.refreshWallets(wallets)
+      await action.refresh(wallets)
 
       expect(action.processWalletData).toHaveBeenCalledWith(wallets[2], wallets[2])
       expect(action.processWalletData).not.toHaveBeenCalledWith(wallets[0], coldWallet)
@@ -169,9 +169,9 @@ describe('Services > Synchronizer > Wallets', () => {
         return wallets
       })
 
-      await action.refreshWallets(wallets)
+      await action.refresh(wallets)
 
-      expect(action.fetchTransactionsForWallets).toHaveBeenCalledWith(wallets)
+      expect(action.refreshTransactions).toHaveBeenCalledWith(wallets)
     })
   })
 
@@ -182,7 +182,7 @@ describe('Services > Synchronizer > Wallets', () => {
       wallet = wallets[2]
 
       action.$client.fetchWallets = jest.fn()
-      action.fetchTransactionsForWallets = jest.fn()
+      action.refreshTransactions = jest.fn()
     })
 
     describe('when there is wallet data', () => {
@@ -211,7 +211,7 @@ describe('Services > Synchronizer > Wallets', () => {
     })
   })
 
-  describe('fetchTransactionsForWallets', () => {
+  describe('refreshTransactions', () => {
     let wallet
     const transactions = [
       { id: 'tx1', timestamp: 300 * 1000 },
@@ -233,7 +233,7 @@ describe('Services > Synchronizer > Wallets', () => {
         return {}
       })
 
-      await action.fetchTransactionsForWallets(wallets)
+      await action.refreshTransactions(wallets)
       expect(action.$client.fetchTransactionsForWallets).toHaveBeenCalledWith(wallets.map(wallet => wallet.address))
     })
 
@@ -252,7 +252,7 @@ describe('Services > Synchronizer > Wallets', () => {
       })
 
       it('should not call processWalletTransactions', async () => {
-        await action.fetchTransactionsForWallets(wallets)
+        await action.refreshTransactions(wallets)
 
         wallets.forEach(walletCheck => {
           if (walletCheck.address === wallet.address) {
@@ -264,12 +264,12 @@ describe('Services > Synchronizer > Wallets', () => {
       })
 
       it('should not dispatch the `update/wallet` Vuex action', async () => {
-        await action.fetchTransactionsForWallets(wallets)
+        await action.refreshTransactions(wallets)
         expect(walletUpdate).not.toHaveBeenCalled()
       })
 
       it('should not dispatch the `transaction/deleteBulk` Vuex action', async () => {
-        await action.fetchTransactionsForWallets(wallets)
+        await action.refreshTransactions(wallets)
         expect(transactionDeleteBulk).not.toHaveBeenCalled()
       })
     })
@@ -289,7 +289,7 @@ describe('Services > Synchronizer > Wallets', () => {
       })
 
       it('should call processWalletTransactions', async () => {
-        await action.fetchTransactionsForWallets(wallets)
+        await action.refreshTransactions(wallets)
 
         wallets.forEach(walletCheck => {
           if (walletCheck.address === wallet.address) {

--- a/src/renderer/services/synchronizer/wallets.js
+++ b/src/renderer/services/synchronizer/wallets.js
@@ -112,6 +112,7 @@ class Action {
       this.fetchWalletsTransactions(addresses)
     ])
 
+    // NOTE: this has to be run in order to avoid race conditions when updating the wallet store
     await this.refreshWalletsData(wallets, walletsData)
     await this.refreshTransactions(wallets, walletsTransactions)
   }
@@ -151,18 +152,19 @@ class Action {
    */
   async refreshTransactions (wallets, walletsTransactions) {
     for (const wallet of wallets) {
-      if (walletsTransactions[wallet.address]) {
-        this.processWalletTransactions(wallet, walletsTransactions[wallet.address])
+      const transactions = walletsTransactions[wallet.address]
+      if (transactions && transactions.length) {
+        this.processWalletTransactions(wallet, transactions)
       }
     }
 
-    // TODO: this should be remove later, when the transactions are stored, to take advantage of the reactivity
+    // TODO: this should be removed later, when the transactions are stored, to take advantage of the reactivity
     eventBus.emit(`transactions:fetched`, walletsTransactions)
   }
 
   /**
    * Update cached wallet data.
-   * TODO dispatch only 1 wallet/update
+   * TODO dispatch only 1 wallet store update
    *
    * @param  {Object} wallet
    * @param  {Object} walletData Wallet data fetched from API
@@ -186,7 +188,7 @@ class Action {
 
   /**
    * Processes the transaction of a wallet:
-   * TODO dispatch only 1 wallet/update
+   * TODO dispatch only 1 wallet store update
    *
    *  - Updates the last time that the transactions of a wallet were checked
    *  - If any of the transaction is new, display a toast


### PR DESCRIPTION
## Proposed changes
This is another step towards a faster app.

In this case, requesting the wallet data and transactions in parallel should save those 1 or 2 seconds, at minimum, of getting first the wallet data. This is not really perceptible on the first load because it's too slow yet, but it would be saved every time that the wallet or transactions are checked.

## Types of changes
- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [x] Test (adding missing tests or fixing existing tests)

## Checklist
- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works