### PR TITLE
fix: request multiple wallets or transactions at once when the API allows it

### DIFF
--- a/__tests__/unit/services/client.spec.js
+++ b/__tests__/unit/services/client.spec.js
@@ -31,6 +31,12 @@ describe('Services > Client', () => {
     client = new ClientService()
   })
 
+  describe('constructor', () => {
+    it('should use version 1 the capabilities of the API', () => {
+      expect(client.__capabilities).toEqual('1.0.0')
+    })
+  })
+
   describe('set version', () => {
     it('should establish the API client version', () => {
       expect(client.version).toEqual(null)
@@ -197,50 +203,61 @@ describe('Services > Client', () => {
       client.client.resource = jest.fn(resource)
     })
 
-    describe('when version is 1', () => {
+    describe('when version capabilities are at least 2.1.0', () => {
       beforeEach(() => {
-        client.version = 1
+        client.__capabilities = '2.1.0'
       })
 
-      it('should call the accounts endpoint as a fallback', async () => {
-        const walletAddresses = ['address1', 'address2']
-        const fetchedWallets = await client.fetchWallets(walletAddresses)
-        expect(client.client.resource).toHaveBeenNthCalledWith(1, 'accounts')
-        expect(client.client.resource).toHaveBeenNthCalledWith(2, 'accounts')
-        expect(getAccountEndpoint).toHaveBeenNthCalledWith(1, walletAddresses[0])
-        expect(getAccountEndpoint).toHaveBeenNthCalledWith(2, walletAddresses[1])
-        expect(fetchedWallets).toEqual([
-          { ...wallets[0], balance: +wallets[0].balance, isDelegate: false },
-          { ...wallets[1], balance: +wallets[1].balance, isDelegate: false }
-        ])
-      })
-    })
-
-    describe('when version is 2', () => {
-      beforeEach(() => {
-        client.version = 2
-      })
-
-      it('should call the wallets endpoint as a fallback if multi-wallets endpoint unavailable', async () => {
-        const walletAddresses = ['address1', 'address2']
-        const fetchedWallets = await client.fetchWallets(walletAddresses)
-        expect(client.client.resource).toHaveBeenNthCalledWith(1, 'wallets')
-        expect(client.client.resource).toHaveBeenNthCalledWith(2, 'wallets')
-        expect(getWalletEndpoint).toHaveBeenNthCalledWith(1, walletAddresses[0])
-        expect(getWalletEndpoint).toHaveBeenNthCalledWith(2, walletAddresses[1])
-        expect(fetchedWallets).toEqual([
-          generateWalletResponse('address1').data.data,
-          generateWalletResponse('address2').data.data
-        ].map(wallet => ({ ...wallet, balance: +wallet.balance })))
-      })
-
-      it('should call the search endpoint if multi-wallets endpoint available', async () => {
-        client.hasMultiWalletSearch = true
+      it('should call the wallet search endpoint', async () => {
         const walletAddresses = ['address1', 'address2']
         const fetchedWallets = await client.fetchWallets(walletAddresses)
         expect(client.client.resource).toHaveBeenNthCalledWith(1, 'wallets')
         expect(searchWalletEndpoint).toHaveBeenNthCalledWith(1, { addresses: walletAddresses })
         expect(fetchedWallets).toEqual(walletsResponse.data.data)
+      })
+    })
+
+    describe('when version capabilities are not at least 2.1.0', () => {
+      beforeEach(() => {
+        client.__capabilities = '2.0.9'
+      })
+
+      describe('when version is 2', () => {
+        beforeEach(() => {
+          client.version = 2
+        })
+
+        it('should call the wallet endpoint for each wallet', async () => {
+          const walletAddresses = ['address1', 'address2']
+          const fetchedWallets = await client.fetchWallets(walletAddresses)
+          expect(client.client.resource).toHaveBeenNthCalledWith(1, 'wallets')
+          expect(client.client.resource).toHaveBeenNthCalledWith(2, 'wallets')
+          expect(getWalletEndpoint).toHaveBeenNthCalledWith(1, walletAddresses[0])
+          expect(getWalletEndpoint).toHaveBeenNthCalledWith(2, walletAddresses[1])
+          expect(fetchedWallets).toEqual([
+            generateWalletResponse('address1').data.data,
+            generateWalletResponse('address2').data.data
+          ].map(wallet => ({ ...wallet, balance: +wallet.balance })))
+        })
+      })
+
+      describe('when version is 1', () => {
+        beforeEach(() => {
+          client.version = 1
+        })
+
+        it('should call the account endpoint for each wallet', async () => {
+          const walletAddresses = ['address1', 'address2']
+          const fetchedWallets = await client.fetchWallets(walletAddresses)
+          expect(client.client.resource).toHaveBeenNthCalledWith(1, 'accounts')
+          expect(client.client.resource).toHaveBeenNthCalledWith(2, 'accounts')
+          expect(getAccountEndpoint).toHaveBeenNthCalledWith(1, walletAddresses[0])
+          expect(getAccountEndpoint).toHaveBeenNthCalledWith(2, walletAddresses[1])
+          expect(fetchedWallets).toEqual([
+            { ...wallets[0], balance: +wallets[0].balance, isDelegate: false },
+            { ...wallets[1], balance: +wallets[1].balance, isDelegate: false }
+          ])
+        })
       })
     })
   })
@@ -599,110 +616,132 @@ describe('Services > Client', () => {
 
   describe('fetchTransactionsForWallets', () => {
     const { meta } = fixtures.transactions
+    let transactions
+    let getTransactionsEndpoint
+    let searchTransactionsEndpoint
 
-    describe('when version in v1', () => {
-      let getTransactionsEndpoint
-      let transactions
+    describe('when version capabilities are at least 2.1.0', () => {
       beforeEach(() => {
-        client.version = 1
-
-        transactions = cloneDeep(fixtures.transactions.v1)
-        getTransactionsEndpoint = jest.fn(() => {
-          return {
-            data: {
-              transactions, success: true, count: meta.count.toString()
-            }
-          }
-        })
-
-        const resource = resource => {
-          if (resource === 'transactions') {
-            return {
-              all: getTransactionsEndpoint
-            }
-          }
-        }
-
-        client.client.resource = jest.fn(resource)
+        client.__capabilities = '2.1.0'
       })
 
-      it('should call the v1 endpoint as a fallback', async () => {
-        const walletAddresses = ['address1', 'address2']
-        const fetchedWallets = await client.fetchTransactionsForWallets(walletAddresses)
-        expect(client.client.resource).toHaveBeenNthCalledWith(1, 'transactions')
-        expect(client.client.resource).toHaveBeenNthCalledWith(2, 'transactions')
-        expect(getTransactionsEndpoint).toHaveBeenCalledTimes(2)
-        expect(fetchedWallets).toEqual(
-          ['address1', 'address2'].reduce((map, address, index) => {
-            map[address] = transactions
+      describe('when version in v2', () => {
+        beforeEach(() => {
+          transactions = cloneDeep(fixtures.transactions.v2)
+          searchTransactionsEndpoint = jest.fn(() => ({ data: { data: transactions } }))
 
-            return map
-          }, {})
-        )
-      })
-    })
-
-    describe('when version in v2', () => {
-      let getTransactionsEndpoint
-      let searchTransactionsEndpoint
-      let transactions
-      beforeEach(() => {
-        client.version = 2
-
-        transactions = cloneDeep(fixtures.transactions.v2)
-        searchTransactionsEndpoint = jest.fn(() => ({ data: { data: transactions } }))
-        getTransactionsEndpoint = jest.fn(() => {
-          return {
-            data: {
-              data: transactions,
-              meta: {
-                totalCount: meta.count
+          const resource = resource => {
+            if (resource === 'transactions') {
+              return {
+                search: searchTransactionsEndpoint
               }
             }
           }
+
+          client.client.resource = jest.fn(resource)
         })
 
-        const resource = resource => {
-          if (resource === 'wallets') {
-            return {
-              transactions: getTransactionsEndpoint
-            }
-          } else if (resource === 'transactions') {
-            return {
-              search: searchTransactionsEndpoint
-            }
-          }
-        }
+        it('should call the transaction search endpoint', async () => {
+          client.hasMultiWalletSearch = true
+          const walletAddresses = ['address1', 'address2']
+          const fetchedWallets = await client.fetchTransactionsForWallets(walletAddresses)
+          expect(client.client.resource).toHaveBeenNthCalledWith(1, 'transactions')
+          expect(searchTransactionsEndpoint).toHaveBeenNthCalledWith(1, { addresses: walletAddresses })
+          expect(fetchedWallets).toEqual(walletAddresses.reduce((map, address, index) => {
+            map[address] = transactions.filter(transaction => {
+              return [transaction.sender, transaction.recipient].includes(address)
+            })
 
-        client.client.resource = jest.fn(resource)
+            return map
+          }, {}))
+        })
+      })
+    })
+
+    describe('when version capabilities are not at least 2.1.0', () => {
+      beforeEach(() => {
+        client.__capabilities = '2.0.9'
       })
 
-      it('should call the transactions endpoint as a fallback if multi-wallets endpoint unavailable', async () => {
-        const walletAddresses = ['address1', 'address2']
-        const fetchedWallets = await client.fetchTransactionsForWallets(walletAddresses)
-        expect(client.client.resource).toHaveBeenNthCalledWith(1, 'wallets')
-        expect(client.client.resource).toHaveBeenNthCalledWith(2, 'wallets')
-        expect(getTransactionsEndpoint).toHaveBeenCalledTimes(2)
-        expect(fetchedWallets).toEqual(['address1', 'address2'].reduce((map, address, index) => {
-          map[address] = transactions
+      describe('when version in v2', () => {
+        beforeEach(() => {
+          client.version = 2
 
-          return map
-        }, {}))
-      })
-
-      it('should call the search endpoint if multi-wallets endpoint available', async () => {
-        client.hasMultiWalletSearch = true
-        const walletAddresses = ['address1', 'address2']
-        const fetchedWallets = await client.fetchTransactionsForWallets(walletAddresses)
-        expect(client.client.resource).toHaveBeenNthCalledWith(1, 'transactions')
-        expect(searchTransactionsEndpoint).toHaveBeenNthCalledWith(1, { addresses: walletAddresses })
-        expect(fetchedWallets).toEqual(['address1', 'address2'].reduce((map, address, index) => {
-          map[address] = transactions.filter(transaction => {
-            return [transaction.sender, transaction.recipient].includes(address)
+          transactions = cloneDeep(fixtures.transactions.v2)
+          getTransactionsEndpoint = jest.fn(() => {
+            return {
+              data: {
+                data: transactions,
+                meta: {
+                  totalCount: meta.count
+                }
+              }
+            }
           })
 
-          return map
-        }, {}))
+          const resource = resource => {
+            if (resource === 'wallets') {
+              return {
+                transactions: getTransactionsEndpoint
+              }
+            }
+          }
+
+          client.client.resource = jest.fn(resource)
+        })
+
+        it('should call the wallet transactions endpoint for each wallet', async () => {
+          const walletAddresses = ['address1', 'address2']
+          const fetchedWallets = await client.fetchTransactionsForWallets(walletAddresses)
+          expect(client.client.resource).toHaveBeenNthCalledWith(1, 'wallets')
+          expect(client.client.resource).toHaveBeenNthCalledWith(2, 'wallets')
+          expect(getTransactionsEndpoint).toHaveBeenCalledTimes(2)
+          expect(fetchedWallets).toEqual(walletAddresses.reduce((map, address, index) => {
+            map[address] = transactions
+
+            return map
+          }, {}))
+        })
+      })
+
+      describe('when version in v1', () => {
+        beforeEach(() => {
+          client.version = 1
+
+          transactions = cloneDeep(fixtures.transactions.v1)
+          getTransactionsEndpoint = jest.fn(() => {
+            return {
+              data: {
+                transactions, success: true, count: meta.count.toString()
+              }
+            }
+          })
+
+          const resource = resource => {
+            if (resource === 'transactions') {
+              return {
+                all: getTransactionsEndpoint
+              }
+            }
+          }
+
+          client.client.resource = jest.fn(resource)
+        })
+
+        it('should call the v1 transactions endpoint', async () => {
+          const walletAddresses = ['address1', 'address2']
+          const fetchedWallets = await client.fetchTransactionsForWallets(walletAddresses)
+          expect(client.client.resource).toHaveBeenNthCalledWith(1, 'transactions')
+          expect(client.client.resource).toHaveBeenNthCalledWith(2, 'transactions')
+          expect(getTransactionsEndpoint).toHaveBeenCalledTimes(2)
+          expect(fetchedWallets).toEqual(
+            walletAddresses.reduce((map, address, index) => {
+              map[address] = transactions
+
+              return map
+            }, {})
+          )
+        })
       })
     })
   })

--- a/src/renderer/services/client.js
+++ b/src/renderer/services/client.js
@@ -123,6 +123,14 @@ export default class ClientService {
     this.client.setVersion(apiVersion)
   }
 
+  get capabilities () {
+    return this.__capabilities
+  }
+
+  set capabilities (version) {
+    this.__capabilities = semver.coerce(version)
+  }
+
   /**
    * Fetch the peer status.
    * @returns {Object}
@@ -359,7 +367,7 @@ export default class ClientService {
     options = options || {}
 
     let walletData = {}
-    if (semver.gte(this.__capabilities, '2.1.0')) {
+    if (semver.gte(this.capabilities, '2.1.0')) {
       let transactions = []
       let hadFailure = false
 
@@ -478,7 +486,7 @@ export default class ClientService {
   async fetchWallets (addresses) {
     let walletData = []
 
-    if (semver.gte(this.__capabilities, '2.1.0')) {
+    if (semver.gte(this.capabilities, '2.1.0')) {
       for (const addressChunk of chunk(addresses, 20)) {
         const { data } = await this.client.resource('wallets').search({
           addresses: addressChunk
@@ -838,7 +846,7 @@ export default class ClientService {
           const scheme = currentPeer.isHttps ? 'https://' : 'http://'
           this.host = `${scheme}${currentPeer.ip}:${currentPeer.port}`
           this.version = currentPeer.version.match(/^2\./) ? 2 : 1
-          this.__capabilities = currentPeer.version
+          this.capabilities = currentPeer.version
 
         // TODO if we could use the server from network, then, it is a peer and this shouldn't be necessary
         } else {
@@ -860,7 +868,7 @@ export default class ClientService {
             }
           }
 
-          this.__capabilities = semver.coerce(apiVersion)
+          this.capabilities = apiVersion
         }
 
         if (!oldProfile || profile.id !== oldProfile.id) {

--- a/src/renderer/services/client.js
+++ b/src/renderer/services/client.js
@@ -3,11 +3,12 @@ import { crypto, transactionBuilder } from '@arkecosystem/crypto'
 import axios from 'axios'
 import { castArray, chunk, orderBy } from 'lodash'
 import dayjs from 'dayjs'
+import moment from 'moment'
+import logger from 'electron-log'
+import semver from 'semver'
 import { V1 } from '@config'
 import store from '@/store'
 import eventBus from '@/plugins/event-bus'
-import logger from 'electron-log'
-import moment from 'moment'
 
 export default class ClientService {
   /*
@@ -94,8 +95,10 @@ export default class ClientService {
   constructor (watchProfile = true) {
     this.__host = null
     this.__version = null
+    // The API version is imprecise, since new capabilities are being added continuously.
+    // So, this property uses the peer version to know which features are available
+    this.__capabilities = '1.0.0'
     this.client = new ApiClient('http://')
-    this.hasMultiWalletSearch = false
 
     if (watchProfile) {
       this.__watchProfile()
@@ -356,9 +359,10 @@ export default class ClientService {
     options = options || {}
 
     let walletData = {}
-    if (this.version === 2 && this.hasMultiWalletSearch) {
+    if (semver.gte(this.__capabilities, '2.1.0')) {
       let transactions = []
       let hadFailure = false
+
       for (const addressChunk of chunk(addresses, 20)) {
         try {
           const { data } = await this.client.resource('transactions').search({
@@ -474,7 +478,7 @@ export default class ClientService {
   async fetchWallets (addresses) {
     let walletData = []
 
-    if (this.version === 2 && this.hasMultiWalletSearch) {
+    if (semver.gte(this.__capabilities, '2.1.0')) {
       for (const addressChunk of chunk(addresses, 20)) {
         const { data } = await this.client.resource('wallets').search({
           addresses: addressChunk
@@ -712,6 +716,7 @@ export default class ClientService {
       pubKeyHash: network.version
     })
 
+    // TODO replace with dayjs
     const epochTime = moment(network.constants.epoch).utc().valueOf()
     const now = moment().valueOf()
     transaction.data.timestamp = Math.floor((now - epochTime) / 1000)
@@ -816,38 +821,46 @@ export default class ClientService {
     }
   }
 
+  // TODO this shouldn't be responsibility of the client
+  // TODO update client when peer changes
   __watchProfile () {
     store.watch(
       (_, getters) => getters['session/profile'],
-      (profile, oldProfile) => {
+      async (profile, oldProfile) => {
         if (!profile) {
           return
         }
 
         const network = store.getters['network/byId'](profile.networkId)
         const currentPeer = store.getters['peer/current']()
-        if (currentPeer && Object.keys(currentPeer).length > 0) {
+
+        if (currentPeer && currentPeer.ip) {
           const scheme = currentPeer.isHttps ? 'https://' : 'http://'
           this.host = `${scheme}${currentPeer.ip}:${currentPeer.port}`
           this.version = currentPeer.version.match(/^2\./) ? 2 : 1
+          this.__capabilities = currentPeer.version
+
+        // TODO if we could use the server from network, then, it is a peer and this shouldn't be necessary
         } else {
-          const { server, apiVersion } = network
+          let { server, apiVersion } = network
           this.host = server
           this.version = apiVersion
-        }
 
-        try {
-          this.hasMultiWalletSearch = false
-          if (network.apiVersion === 2) {
-            const testAddress = crypto.getAddress(crypto.getKeys('test').publicKey, network.version)
-            this.client.resource('wallets').search({
-              addresses: [testAddress]
-            }).then(() => {
-              this.hasMultiWalletSearch = true
-            })
+          // Infer which are the real capabilities of the peer
+          if (apiVersion === 2) {
+            try {
+              const testAddress = crypto.getAddress(crypto.getKeys('test').publicKey, network.version)
+              const { address } = this.client.resource('wallets').search({
+                addresses: [testAddress]
+              })
+
+              apiVersion = (address === testAddress) ? '2.1.0' : '2.0.0'
+            } catch (_) {
+              // The peer does not have capability to search for multiple wallets or transactions at once
+            }
           }
-        } catch (error) {
-          //
+
+          this.__capabilities = semver.coerce(apiVersion)
         }
 
         if (!oldProfile || profile.id !== oldProfile.id) {

--- a/src/renderer/store/modules/peer.js
+++ b/src/renderer/store/modules/peer.js
@@ -281,6 +281,7 @@ export default {
       if (peer) {
         await getApiPort(peer)
         this._vm.$client.host = getBaseUrl(peer)
+        this._vm.$client.capabilities = peer.version
         await dispatch('transaction/updateStaticFees', null, { root: true })
       }
       commit('SET_CURRENT_PEER', {


### PR DESCRIPTION
## Proposed changes
Using the new endpoints that allow searching multiple wallets or transactions at the same time wasn't correctly triggered on the first load and when changing peers.

Apart from that, I've refactored the client service to make it easier using the new features that are being added to the API, and I've refactor slightly the tests to make them more readable.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [x] Test (adding missing tests or fixing existing tests)

## Checklist
- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works