### PR TITLE
refactor: synch dynamic fees only when `InputFee` is active

### DIFF
--- a/__tests__/unit/components/Input/InputFee.spec.js
+++ b/__tests__/unit/components/Input/InputFee.spec.js
@@ -11,16 +11,15 @@ import store from '@/store'
 jest.mock('@/store', () => {
   return {
     getters: {
-      'session/network': jest.fn(),
       'transaction/staticFee': jest.fn(type => {
         switch (type) {
           case 0:
             return 10000000
           case 3:
             return 100000000
+          default:
+            return null
         }
-
-        return null
       })
     }
   }
@@ -38,7 +37,21 @@ describe('InputFee', () => {
       market: {
         enabled: true
       },
-      feeStatistics: [],
+      feeStatistics: [{
+        type: 0,
+        fees: {
+          avgFee: 0.1,
+          maxFee: 0.4,
+          minFee: 0.01
+        }
+      }, {
+        type: 3,
+        fees: {
+          avgFee: 0.1,
+          maxFee: 0.4,
+          minFee: 0.01
+        }
+      }],
       fractionDigits: 8
     }
 
@@ -58,6 +71,10 @@ describe('InputFee', () => {
         session_network: mockNetwork,
         wallet_fromRoute: { balance: 10 },
         $store: store,
+        $synchronizer: {
+          focus: jest.fn(),
+          pause: jest.fn()
+        },
         $v: {
           fee: {
             $touch: jest.fn()
@@ -93,26 +110,28 @@ describe('InputFee', () => {
   })
 
   describe('rangePercentage', () => {
-    it('should calculate the current fee percentage related to the minimum and maximum', () => {
-      const wrapper = mountComponent()
+    const mockedComponent = (min, max) => {
+      return mountComponent({
+        computed: {
+          feeChoiceMin: () => min,
+          feeChoiceMax: () => max
+        }
+      })
+    }
 
-      wrapper.vm.feeChoices.MINIMUM = 1
-      wrapper.vm.feeChoices.MAXIMUM = 11
+    it('should calculate the current fee percentage related to the minimum and maximum', () => {
+      let wrapper = mockedComponent(1, 11)
       wrapper.vm.fee = 6
       expect(wrapper.vm.rangePercentage).toEqual(50)
 
-      wrapper.vm.feeChoices.MINIMUM = 0.00000001
-      wrapper.vm.feeChoices.MAXIMUM = 25
+      wrapper = mockedComponent(0.00000001, 25)
       wrapper.vm.fee = 12.5
       expect(wrapper.vm.rangePercentage).toEqual(49.99999998)
     })
 
     describe('when the fee is smaller than the minimum', () => {
       it('should return 0%', () => {
-        const wrapper = mountComponent()
-
-        wrapper.vm.feeChoices.MINIMUM = 1
-        wrapper.vm.feeChoices.MAXIMUM = 10
+        const wrapper = mockedComponent(1, 10)
         wrapper.vm.fee = 0.3
         expect(wrapper.vm.rangePercentage).toEqual(0)
       })
@@ -120,10 +139,7 @@ describe('InputFee', () => {
 
     describe('when the fee is bigger than the maximum', () => {
       it('should return 100%', () => {
-        const wrapper = mountComponent()
-
-        wrapper.vm.feeChoices.MINIMUM = 0.1
-        wrapper.vm.feeChoices.MAXIMUM = 1
+        const wrapper = mockedComponent(0.1, 1)
         wrapper.vm.fee = 2
         expect(wrapper.vm.rangePercentage).toEqual(100)
       })
@@ -131,23 +147,48 @@ describe('InputFee', () => {
   })
 
   describe('isStaticFee', () => {
+    const mockedComponent = fees => {
+      return mountComponent({
+        computed: {
+          feeChoices: () => ({
+            MINIMUM: 1e-8,
+            INPUT: 1e-8,
+            ADVANCED: 1e-8,
+            ...fees
+          })
+        }
+      })
+    }
+
     it('should be `true` if the current fee matches, average and maximum fee are the same', () => {
-      let wrapper = mountComponent()
-
+      const wrapper = mockedComponent({
+        AVERAGE: 1,
+        MAXIMUM: 1
+      })
       wrapper.vm.fee = 1
-      wrapper.vm.feeChoices.AVERAGE = 1
-      wrapper.vm.feeChoices.MAXIMUM = 1
       expect(wrapper.vm.isStaticFee).toBeTrue()
+    })
 
-      wrapper.vm.feeChoices.AVERAGE = 2
+    it('should be `false` if the current fee matches, average and maximum fee are not the same', () => {
+      let wrapper = mockedComponent({
+        AVERAGE: 2,
+        MAXIMUM: 1
+      })
+      wrapper.vm.fee = 1
       expect(wrapper.vm.isStaticFee).toBeFalse()
 
+      wrapper = mockedComponent({
+        AVERAGE: 1,
+        MAXIMUM: 2
+      })
+      wrapper.vm.fee = 1
+
+      expect(wrapper.vm.isStaticFee).toBeFalse()
+      wrapper = mockedComponent({
+        AVERAGE: 1,
+        MAXIMUM: 1
+      })
       wrapper.vm.fee = 2
-      wrapper.vm.feeChoices.AVERAGE = 1
-      expect(wrapper.vm.isStaticFee).toBeFalse()
-
-      wrapper.vm.feeChoices.MINIMUM = 1
-      wrapper.vm.feeChoices.MAXIMUM = 2
       expect(wrapper.vm.isStaticFee).toBeFalse()
     })
   })
@@ -275,11 +316,11 @@ describe('InputFee', () => {
 
       describe('when the balance is smaller than the fee', () => {
         it('should return the message about funds', () => {
-          wrapper.vm.wallet_fromRoute.balance = 10000
+          wrapper.vm.wallet_fromRoute.balance = 50000
           wrapper.vm.fee = 20e8
           expect(wrapper.vm.insufficientFundsError).toEqual('TRANSACTION_FORM.ERROR.NOT_ENOUGH_BALANCE')
 
-          wrapper.vm.wallet_fromRoute.balance = '10000'
+          wrapper.vm.wallet_fromRoute.balance = '50000'
           wrapper.vm.fee = '20e8'
           expect(wrapper.vm.insufficientFundsError).toEqual('TRANSACTION_FORM.ERROR.NOT_ENOUGH_BALANCE')
         })
@@ -290,11 +331,11 @@ describe('InputFee', () => {
           // NOTE: Balance is in arktoshi, while fee is in ARK
           wrapper.vm.wallet_fromRoute.balance = 20e8
           wrapper.vm.fee = 1
-          expect(wrapper.vm.insufficientFundsError).toEqual('')
+          expect(wrapper.vm.insufficientFundsError).toBeNull()
 
           wrapper.vm.wallet_fromRoute.balance = '20e8'
           wrapper.vm.fee = '1'
-          expect(wrapper.vm.insufficientFundsError).toEqual('')
+          expect(wrapper.vm.insufficientFundsError).toBeNull()
         })
       })
     })

--- a/__tests__/unit/components/Input/InputFee.spec.js
+++ b/__tests__/unit/components/Input/InputFee.spec.js
@@ -12,7 +12,6 @@ jest.mock('@/store', () => {
   return {
     getters: {
       'session/network': jest.fn(),
-      'network/feeStatisticsByType': jest.fn(),
       'transaction/staticFee': jest.fn(type => {
         switch (type) {
           case 0:
@@ -39,15 +38,11 @@ describe('InputFee', () => {
       market: {
         enabled: true
       },
+      feeStatistics: [],
       fractionDigits: 8
     }
 
     store.getters['session/network'] = mockNetwork
-    store.getters['network/feeStatisticsByType'] = type => ({
-      avgFee: 0.0048 * 1e8,
-      maxFee: 0.012 * 1e8,
-      minFee: 0.0006 * 1e8
-    })
     store.getters['network/byToken'] = () => mockNetwork
   })
 
@@ -195,11 +190,14 @@ describe('InputFee', () => {
   describe('prepareFeeStatistics', () => {
     describe('when the average fee of the network is more than the V1 fee', () => {
       beforeEach(() => {
-        store.getters['network/feeStatisticsByType'] = type => ({
-          avgFee: 1000 * 1e8,
-          maxFee: 0.03 * 1e8,
-          minFee: 0.0006 * 1e8
-        })
+        mockNetwork.feeStatistics = [{
+          type: 0,
+          fees: {
+            avgFee: 1000 * 1e8,
+            maxFee: 0.03 * 1e8,
+            minFee: 0.0006 * 1e8
+          }
+        }]
       })
 
       it('should use the V1 fee as average always', () => {
@@ -211,11 +209,14 @@ describe('InputFee', () => {
 
     describe('when the average fee of the network is less than the V1 fee', () => {
       beforeEach(() => {
-        store.getters['network/feeStatisticsByType'] = type => ({
-          avgFee: 0.0048 * 1e8,
-          maxFee: 0.03 * 1e8,
-          minFee: 0.0006 * 1e8
-        })
+        mockNetwork.feeStatistics = [{
+          type: 0,
+          fees: {
+            avgFee: 0.0048 * 1e8,
+            maxFee: 0.03 * 1e8,
+            minFee: 0.0006 * 1e8
+          }
+        }]
       })
 
       it('should use it as average', () => {
@@ -227,11 +228,14 @@ describe('InputFee', () => {
 
     describe('when the maximum fee of the network is more than the V1 fee', () => {
       beforeEach(() => {
-        store.getters['network/feeStatisticsByType'] = type => ({
-          avgFee: 0.0048 * 1e8,
-          maxFee: 1000 * 1e8,
-          minFee: 0.0006 * 1e8
-        })
+        mockNetwork.feeStatistics = [{
+          type: 0,
+          fees: {
+            avgFee: 0.0048 * 1e8,
+            maxFee: 1000 * 1e8,
+            minFee: 0.0006 * 1e8
+          }
+        }]
       })
 
       it('should use the V1 fee as maximum always', () => {
@@ -243,11 +247,14 @@ describe('InputFee', () => {
 
     describe('when the maximum fee of the network is less than the V1 fee', () => {
       beforeEach(() => {
-        store.getters['network/feeStatisticsByType'] = type => ({
-          avgFee: 0.0048 * 1e8,
-          maxFee: 0.03 * 1e8,
-          minFee: 0.0006 * 1e8
-        })
+        mockNetwork.feeStatistics = [{
+          type: 0,
+          fees: {
+            avgFee: 0.0048 * 1e8,
+            maxFee: 0.03 * 1e8,
+            minFee: 0.0006 * 1e8
+          }
+        }]
       })
 
       it('should use it as maximum', () => {

--- a/__tests__/unit/services/synchronizer.spec.js
+++ b/__tests__/unit/services/synchronizer.spec.js
@@ -11,7 +11,7 @@ describe('Services > Synchronizer', () => {
     const actionId = 'example'
     const actionFn = jest.fn()
 
-    it('requires the `default` mode configuration', () => {
+    it('should require the `default` mode configuration', () => {
       const config = {
         focus: { interval: 1000 }
       }
@@ -19,7 +19,7 @@ describe('Services > Synchronizer', () => {
       expect(() => synchronizer.define(actionId, config, actionFn)).not.toThrow(/default.*mode/)
     })
 
-    it('requires the `focus` mode configuration', () => {
+    it('should require the `focus` mode configuration', () => {
       const config = {
         default: { interval: 10000 }
       }
@@ -27,7 +27,25 @@ describe('Services > Synchronizer', () => {
       expect(() => synchronizer.define(actionId, config, actionFn)).not.toThrow(/focus.*mode/)
     })
 
-    it('stores the action by ID', () => {
+    it('should not allow using 0 as interval', () => {
+      const config = {
+        default: { interval: 0 },
+        focus: { interval: 0 }
+      }
+
+      expect(() => synchronizer.define(actionId, config, actionFn)).toThrow(/interval/)
+    })
+
+    it('should allow using `null` as interval', () => {
+      const config = {
+        default: { interval: null },
+        focus: { interval: null }
+      }
+
+      expect(() => synchronizer.define(actionId, config, actionFn)).not.toThrow()
+    })
+
+    it('should store the action by ID', () => {
       const config = {
         default: { interval: 10000 },
         focus: { interval: 1000 }

--- a/src/renderer/components/Input/InputFee.vue
+++ b/src/renderer/components/Input/InputFee.vue
@@ -95,7 +95,7 @@ export default {
     showInsufficientFunds: {
       type: Boolean,
       required: false,
-      default: false
+      default: true
     },
 
     isDisabled: {

--- a/src/renderer/components/Input/InputFee.vue
+++ b/src/renderer/components/Input/InputFee.vue
@@ -172,7 +172,7 @@ export default {
       return feeStatistics.find(feeConfig => feeConfig.type === this.transactionType).fees
     },
     feeChoiceMin () {
-      return this.isAdvancedFee ? 1 / 1e8 : this.feeChoices.MINIMUM
+      return this.feeChoices.MINIMUM
     },
     feeChoiceMax () {
       return this.isAdvancedFee ? this.feeChoices.MAXIMUM * 10 : this.feeChoices.MAXIMUM
@@ -185,7 +185,7 @@ export default {
       // Even if the network provides average or maximum fees higher than V1, they will be corrected
       const average = avgFee < this.maxV1fee ? avgFee : this.maxV1fee
       return {
-        MINIMUM: 1 / 1e8,
+        MINIMUM: 1e-8,
         AVERAGE: average,
         MAXIMUM: maxFee < this.maxV1fee ? maxFee : this.maxV1fee,
         INPUT: average,
@@ -193,7 +193,7 @@ export default {
       }
     },
     minimumError () {
-      const min = !this.isAdvancedFee ? this.feeChoices.MINIMUM : 1 / 1e8
+      const min = this.feeChoices.MINIMUM
       const fee = this.currency_format(min, { currency: this.currency, currencyDisplay: 'code' })
       return this.$t('INPUT_FEE.ERROR.LESS_THAN_MINIMUM', { fee })
     },

--- a/src/renderer/components/Input/InputFee.vue
+++ b/src/renderer/components/Input/InputFee.vue
@@ -182,7 +182,7 @@ export default {
       avgFee = avgFee * 1e-8
       maxFee = maxFee * 1e-8
 
-      // Even if the network provides a fees higher than V1, it will be corrected
+      // Even if the network provides average or maximum fees higher than V1, they will be corrected
       const average = avgFee < this.maxV1fee ? avgFee : this.maxV1fee
       return {
         MINIMUM: 1 / 1e8,

--- a/src/renderer/services/client.js
+++ b/src/renderer/services/client.js
@@ -78,18 +78,11 @@ export default class ClientService {
   }
 
   static async fetchFeeStatistics (server, apiVersion, timeout) {
-    // This is only for v2 networks
     if (apiVersion === 1) {
-      return
+      throw new Error('Fee statistics are only available on V2 networks')
     }
-    const client = new ApiClient(server, apiVersion)
-    if (timeout) {
-      client.http.timeout = timeout
-    }
-    const { data } = await client.resource('node').configuration()
-    if (data.data && data.data.feeStatistics) {
-      return data.data.feeStatistics
-    }
+    const { feeStatistics } = await ClientService.fetchNetworkConfig(server, apiVersion, timeout)
+    return feeStatistics
   }
 
   constructor (watchProfile = true) {

--- a/src/renderer/services/synchronizer.js
+++ b/src/renderer/services/synchronizer.js
@@ -99,8 +99,8 @@ export default class Synchronizer {
     }
     ;['default', 'focus'].forEach(mode => {
       const { interval } = config[mode]
-      if (!interval) {
-        throw new Error(`[$synchronizer] \`interval\` for \`${mode}\` mode should be a number bigger than 0`)
+      if (!interval && interval !== null) {
+        throw new Error(`[$synchronizer] \`interval\` for \`${mode}\` mode should be a Number bigger than 0 (or \`null\` to ignore it)`)
       }
     })
 
@@ -185,11 +185,15 @@ export default class Synchronizer {
             } else {
               const mode = includes(this.focused, actionId) ? 'focus' : 'default'
               const { interval } = action[mode]
-              const nextCall = action.calledAt + interval
-              const now = (new Date()).getTime()
 
-              if (nextCall <= now) {
-                this.call(actionId)
+              // `null` is used to not run the action
+              if (interval !== null) {
+                const nextCall = action.calledAt + interval
+                const now = (new Date()).getTime()
+
+                if (nextCall <= now) {
+                  this.call(actionId)
+                }
               }
             }
           }
@@ -216,6 +220,7 @@ export default class Synchronizer {
       await announcements(this)
     })
 
+    // TODO focus on contacts only (currently wallets and contacts are the same)
     // this.define('contacts', this.config.contacts, async () => {
     //   console.log('defined CONTACTS')
     // })
@@ -236,7 +241,7 @@ export default class Synchronizer {
       await peer(this)
     })
 
-    // TODO allow focusing on 1 wallet alone
+    // TODO allow focusing on 1 wallet alone, while using the normal mode for the rest
     this.define('wallets', this.config.wallets, async () => {
       await wallets(this)
     })

--- a/src/renderer/services/synchronizer.js
+++ b/src/renderer/services/synchronizer.js
@@ -55,8 +55,8 @@ export default class Synchronizer {
         focus: { interval: longer }
       },
       fees: {
-        default: { interval: longer },
-        focus: { interval: longer }
+        default: { interval: null },
+        focus: { interval: shorter }
       },
       peer: {
         default: { interval: longer },

--- a/src/renderer/services/synchronizer.js
+++ b/src/renderer/services/synchronizer.js
@@ -30,6 +30,44 @@ export default class Synchronizer {
     return intervals
   }
 
+  get config () {
+    const { block, shorter, medium, longer, longest } = this.intervals
+
+    const config = {
+      announcements: {
+        default: { interval: longest },
+        focus: { interval: medium }
+      },
+      market: {
+        default: { interval: shorter },
+        focus: { interval: block }
+      },
+      wallets: {
+        default: { interval: shorter },
+        focus: { interval: block }
+      },
+      ledgerWallets: {
+        default: { interval: shorter },
+        focus: { interval: block }
+      },
+      delegates: {
+        default: { interval: longer },
+        focus: { interval: longer }
+      },
+      fees: {
+        default: { interval: longer },
+        focus: { interval: longer }
+      },
+      peer: {
+        default: { interval: longer },
+        focus: { interval: shorter }
+      }
+    }
+    config.contacts = config.wallets
+
+    return config
+  }
+
   get $client () {
     return this.scope.$client
   }
@@ -42,8 +80,8 @@ export default class Synchronizer {
    * @param {Object} config
    * @param {Vue} config.scope - Vue instance that would be synchronized
    */
-  constructor (config) {
-    this.scope = config.scope
+  constructor ({ scope }) {
+    this.scope = scope
     this.actions = {}
     this.focused = []
     this.paused = []
@@ -174,70 +212,36 @@ export default class Synchronizer {
   }
 
   defineAll () {
-    const { block, shorter, medium, longer, longest } = this.intervals
-
-    const config = {
-      announcements: {
-        default: { interval: longest },
-        focus: { interval: medium }
-      },
-      market: {
-        default: { interval: shorter },
-        focus: { interval: block }
-      },
-      wallets: {
-        default: { interval: shorter },
-        focus: { interval: block }
-      },
-      ledgerWallets: {
-        default: { interval: shorter },
-        focus: { interval: block }
-      },
-      delegates: {
-        default: { interval: longer },
-        focus: { interval: longer }
-      },
-      fees: {
-        default: { interval: longer },
-        focus: { interval: longer }
-      },
-      peer: {
-        default: { interval: medium },
-        focus: { interval: shorter }
-      }
-    }
-    config.contacts = config.wallets
-
-    this.define('announcements', config.announcements, async () => {
+    this.define('announcements', this.config.announcements, async () => {
       await announcements(this)
     })
 
-    // this.define('contacts', config.contacts, async () => {
+    // this.define('contacts', this.config.contacts, async () => {
     //   console.log('defined CONTACTS')
     // })
 
-    this.define('delegates', config.delegates, async () => {
+    this.define('delegates', this.config.delegates, async () => {
       await delegates(this)
     })
 
-    this.define('fees', config.fees, async () => {
+    this.define('fees', this.config.fees, async () => {
       await fees(this)
     })
 
-    this.define('market', config.market, async () => {
+    this.define('market', this.config.market, async () => {
       await market(this)
     })
 
-    this.define('peer', config.peer, async () => {
+    this.define('peer', this.config.peer, async () => {
       await peer(this)
     })
 
     // TODO allow focusing on 1 wallet alone
-    this.define('wallets', config.wallets, async () => {
+    this.define('wallets', this.config.wallets, async () => {
       await wallets(this)
     })
 
-    this.define('wallets:ledger', config.ledgerWallets, async () => {
+    this.define('wallets:ledger', this.config.ledgerWallets, async () => {
       await ledger(this)
     })
   }

--- a/src/renderer/store/index.js
+++ b/src/renderer/store/index.js
@@ -36,6 +36,7 @@ const modules = {
   wallet: WalletModule
 }
 
+// Modules that should not be persisted
 const ignoreModules = []
 
 const vuexMigrations = new VuexPersistMigrations({

--- a/src/renderer/store/modules/network.js
+++ b/src/renderer/store/modules/network.js
@@ -92,14 +92,17 @@ export default new BaseModule(NetworkModel, {
      */
     async fetchFees ({ commit, rootGetters }) {
       const network = rootGetters['session/network']
+
       if (network.apiVersion === 2) {
         try {
-          network.feeStatistics = await Client.fetchFeeStatistics(network.server, network.apiVersion)
+          const feeStatistics = await Client.fetchFeeStatistics(network.server, network.apiVersion)
+          commit('UPDATE', {
+            ...network,
+            feeStatistics
+          })
         } catch (error) {
           // Fees couldn't be updated
         }
-
-        commit('UPDATE', network)
       }
     },
 

--- a/src/renderer/store/modules/network.js
+++ b/src/renderer/store/modules/network.js
@@ -23,27 +23,9 @@ export default new BaseModule(NetworkModel, {
     byName: state => name => {
       return state.all.find(network => network.name === name)
     },
-
-    feeStatisticsByType: (_, __, ___, rootGetters) => type => {
-      const network = rootGetters['session/network']
-
-      if (!network) {
-        throw new Error('[network/feeStatisticsByType] No active network.')
-      }
-
-      if (network.apiVersion === 1) {
-        throw new Error('[network/feeStatisticsByType] Supported only by v2 networks.')
-      }
-
-      const { feeStatistics } = network
-      const data = feeStatistics.find(transactionType => transactionType.type === type)
-      return data ? data.fees : []
-    },
-
     customNetworkById: state => id => {
       return state.customNetworks[id]
     },
-
     customNetworks: state => state.customNetworks
   },
 

--- a/src/renderer/store/modules/network.js
+++ b/src/renderer/store/modules/network.js
@@ -87,25 +87,20 @@ export default new BaseModule(NetworkModel, {
       commit('SET_ALL', NETWORKS)
     },
 
-    // Updates the feeStatistics for the available networks
-    async fetchFees ({ commit, getters }) {
-      let networks = getters['all']
-      let updatedNetworks = cloneDeep(networks)
-      if (networks) {
-        let i
-        for (i = 0; i < updatedNetworks.length; i++) {
-          let network = updatedNetworks[i]
-          try {
-            let feeStats = await Client.fetchFeeStatistics(network.server, network.apiVersion)
-            if (feeStats) {
-              network.feeStatistics = feeStats
-            }
-          } catch (error) {
-            //
-          }
+    /*
+     * Update the fee statistics of the current network
+     */
+    async fetchFees ({ commit, rootGetters }) {
+      const network = rootGetters['session/network']
+      if (network.apiVersion === 2) {
+        try {
+          network.feeStatistics = await Client.fetchFeeStatistics(network.server, network.apiVersion)
+        } catch (error) {
+          // Fees couldn't be updated
         }
+
+        commit('UPDATE', network)
       }
-      commit('SET_ALL', updatedNetworks)
     },
 
     addCustomNetwork ({ dispatch, commit }, network) {

--- a/src/renderer/store/modules/peer.js
+++ b/src/renderer/store/modules/peer.js
@@ -282,6 +282,8 @@ export default {
         await getApiPort(peer)
         this._vm.$client.host = getBaseUrl(peer)
         this._vm.$client.capabilities = peer.version
+
+        // TODO only when necessary (when / before sending) (if no dynamic)
         await dispatch('transaction/updateStaticFees', null, { root: true })
       }
       commit('SET_CURRENT_PEER', {
@@ -307,10 +309,13 @@ export default {
         'ark.mainnet': 'mainnet',
         'ark.devnet': 'devnet'
       }
-      let peers = await this._vm.$client.fetchPeers(networkLookup[network.id], getters['all']())
+
+      const peers = await this._vm.$client.fetchPeers(networkLookup[network.id], getters['all']())
+
       if (peers.length) {
         for (const peer of peers) {
           peer.height = +peer.height
+
           if (getApiVersion(peer) === 2) {
             if (peer.latency) {
               peer.delay = peer.latency
@@ -318,6 +323,7 @@ export default {
             }
             if (peer.port && !peer.p2pPort) {
               peer.p2pPort = peer.port
+              // TODO why?
               peer.port = null
             }
           }
@@ -379,6 +385,7 @@ export default {
       if (skipIfCustom) {
         const currentPeer = getters['current']()
         if (currentPeer && currentPeer.isCustom) {
+          // TODO only when necessary (when / before sending) (if no dynamic)
           await dispatch('transaction/updateStaticFees', null, { root: true })
 
           return null
@@ -534,7 +541,7 @@ export default {
         host: baseUrl,
         port: +port,
         height: peerStatus.height,
-        version: `${version}.0.0`,
+        version: `${version}.0.0`, // TODO why does it ignore the exact version?
         status: 'OK',
         delay: 0,
         isHttps: schemeUrl && schemeUrl[1] === 'https://'

--- a/src/renderer/store/modules/session.js
+++ b/src/renderer/store/modules/session.js
@@ -40,7 +40,7 @@ export default {
       }
 
       const { networkId } = getters['profile']
-      var network = rootGetters['network/byId'](networkId)
+      let network = rootGetters['network/byId'](networkId)
 
       if (!network) {
         network = rootGetters['network/customNetworkById'](networkId)

--- a/src/renderer/store/modules/transaction.js
+++ b/src/renderer/store/modules/transaction.js
@@ -18,6 +18,7 @@ export default {
 
   state: {
     transactions: {},
+    // TODO This should not be stored here: it depends on the network, not the transactions
     staticFees: {}
   },
 


### PR DESCRIPTION
## Proposed changes
These changes avoid making requests at the beginning to fetch the fee statistics of every network, and then, periodically to have them updated.
Now, only the current network is checked, but just in the case that `InputFee` component is active, because they are only used there.

This also improves the `Synchronizer` service, so, from now on, we could disable completely some actions until needed.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [x] Test (adding missing tests or fixing existing tests)

## Checklist
- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works