### PR TITLE
chore: change Node version to 11.10.1 to avoid problems on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   test-node-11:
     working_directory: ~/new-desktop-wallet
     docker:
-      - image: circleci/node:11-browsers
+      - image: circleci/node:11.10.1-browsers
     steps:
       - checkout
       - run:


### PR DESCRIPTION
## Proposed changes
This PR changes the Node version to avoid some bugs that are blocking some PRs.
This should be later replaced by upgrading dependencies and restoring the version to `11`.

## Types of changes
- [x] Build (changes that affect the build system)

## Checklist
- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes