### PR TITLE
fix: don't display loading on the dashboard if there are no wallets

### DIFF
--- a/src/renderer/components/Dashboard/DashboardTransactions.vue
+++ b/src/renderer/components/Dashboard/DashboardTransactions.vue
@@ -49,7 +49,9 @@ export default {
   },
 
   created () {
-    this.isLoading = true
+    if (this.wallets.length) {
+      this.isLoading = true
+    }
 
     this.$eventBus.on('transactions:fetched', transactionsByWallet => {
       const transactions = flatten(Object.values(transactionsByWallet))


### PR DESCRIPTION
## Proposed changes

The loader is being displayed even if there are no wallets.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)