### PR TITLE
fix: show the pointer cursor on letter avatars

### DIFF
--- a/src/renderer/components/Profile/ProfileAvatar.vue
+++ b/src/renderer/components/Profile/ProfileAvatar.vue
@@ -17,7 +17,7 @@
       :has-custom-style="true"
       :size="letterSize"
       tag="div"
-      class="ProfileAvatar__letter bg-theme-feature-item-selected text-theme-feature-item-selected-text"
+      class="ProfileAvatar__letter bg-theme-feature-item-selected text-theme-feature-item-selected-text select-none"
     >
       <slot />
     </ButtonLetter>

--- a/src/renderer/pages/Profile/ProfileAll.vue
+++ b/src/renderer/pages/Profile/ProfileAll.vue
@@ -213,8 +213,8 @@ export default {
   width: calc(var(--profile-avatar-xl) * 0.66);
 }
 .ProfileAll .ProfileAvatar__image {
-  @apply .flex .cursor-pointer .self-center;
+  @apply .flex .self-center .cursor-pointer;
 }
 .ProfileAll .ProfileAvatar__letter {
-  @apply .mx-auto .self-center
+  @apply .mx-auto .self-center .cursor-pointer
 } </style>


### PR DESCRIPTION
## Proposed changes
It was weird that image avatars used 1 kind of cursor, to show that they are clickable, but letter avatars not.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes