### PR TITLE
fix: language selection on profile creation

### DIFF
--- a/src/renderer/components/Input/InputLanguage.vue
+++ b/src/renderer/components/Input/InputLanguage.vue
@@ -117,6 +117,7 @@ export default {
 
     select (language) {
       this.selected = language
+      this.emitInput()
     },
 
     emitInput () {


### PR DESCRIPTION
## Proposed changes
Selecting a language was ignored:
 - It didn't change the UI when the language changed
 - It didn't create the profile with the selected language

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes