### PR TITLE
feat: truncate the transaction block ID on the transaction show modal if necessary

### DIFF
--- a/src/renderer/components/Transaction/TransactionShow.vue
+++ b/src/renderer/components/Transaction/TransactionShow.vue
@@ -45,7 +45,16 @@
         :label="$t('TRANSACTION.BLOCK_ID')"
         item-value-class="flex items-center"
       >
-        {{ transaction.blockId }}
+        <span
+          v-tooltip="{
+            content: transaction.blockId,
+            trigger: 'hover',
+            classes: 'text-xs'
+          }"
+          class="cursor-default"
+        >
+          {{ transaction.blockId | truncateMiddle(30) }}
+        </span>
         <button
           v-tooltip="{
             content: `${$t('TRANSACTION.OPEN_IN_EXPLORER')}`,

--- a/src/renderer/components/Transaction/TransactionShow.vue
+++ b/src/renderer/components/Transaction/TransactionShow.vue
@@ -17,7 +17,7 @@
           }"
           class="cursor-default"
         >
-          {{ transaction.id | truncateMiddle }}
+          {{ transaction.id | truncateMiddle(30) }}
         </span>
         <ButtonClipboard
           :value="transaction.id"


### PR DESCRIPTION
## Proposed changes
Block ID is going to change to sha256, so in some cases, it will be too long to display it on the transaction show modal.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes