### PR TITLE
perf: cache rendered pages that are not tied to the current session profile

### DIFF
--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -49,7 +49,9 @@
             v-if="hasAnyProfile"
             class="hidden md:block"
           />
-          <RouterView class="flex-1 overflow-y-auto" />
+          <KeepAlive :include="keepAliveRoutes">
+            <RouterView class="flex-1 overflow-y-auto" />
+          </KeepAlive>
         </div>
 
         <AppFooter />
@@ -126,6 +128,9 @@ export default {
     },
     hasSeenIntroduction () {
       return this.$store.getters['app/hasSeenIntroduction']
+    },
+    keepAliveRoutes () {
+      return ['Announcements', 'NetworkOverview', 'ProfileAll']
     },
     isWindows () {
       return process.platform === 'win32'

--- a/src/renderer/router/index.js
+++ b/src/renderer/router/index.js
@@ -17,11 +17,11 @@ const router = new Router({
       name: 'announcements',
       component: require('@/pages/Announcements').default
     },
-    {
-      path: '/search',
-      name: 'search',
-      component: require('@/pages/Search').default
-    },
+    // {
+    //   path: '/search',
+    //   name: 'search',
+    //   component: require('@/pages/Search').default
+    // },
     {
       path: '/contacts/all',
       name: 'contacts',

--- a/src/renderer/router/index.js
+++ b/src/renderer/router/index.js
@@ -3,6 +3,8 @@ import Router from 'vue-router'
 
 Vue.use(Router)
 
+// NOTE: when adding a route here, check the `KeepAliveRoutes` computed property
+// of `App.vue`: only routes that do not depend on params or the profile should be kept alive
 const router = new Router({
   routes: [
     {


### PR DESCRIPTION
## Proposed changes
This PR caches the pages that have been visited that are not tied to the current profile and they don't change when switching profiles (announcements, networks, profiles).

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes