### PR TITLE
fix: enable the translation of empty transaction table message

### DIFF
--- a/src/renderer/components/Dashboard/DashboardTransactions.vue
+++ b/src/renderer/components/Dashboard/DashboardTransactions.vue
@@ -4,6 +4,7 @@
     :rows="lastTransactions"
     :is-dashboard="true"
     :is-loading="isLoading"
+    :no-data-message="$t('TABLE.NO_TRANSACTIONS')"
   />
 </template>
 

--- a/src/renderer/components/Transaction/TransactionTable.vue
+++ b/src/renderer/components/Transaction/TransactionTable.vue
@@ -4,6 +4,7 @@
       v-bind="$attrs"
       :columns="columns"
       :row-style-class="formatRow"
+      :no-data-message="$t('TABLE.NO_TRANSACTIONS')"
       v-on="$listeners"
       @on-row-click="onRowClick"
       @on-sort-change="onSortChange"


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
If another language is chosen, the 

> No transactions have been found. The latest transactions will be displayed here.

messages translations are not working.

Adds:
`:no-data-message="$t('TABLE.NO_TRANSACTIONS')"` 

in:
1. `src/renderer/components/Dashboard/DashboardTransactions.vue` 

2. `src/renderer/components/Transaction/TransactionTable.vue`

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x ] Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation

<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
