### PR TITLE
fix: static fee default if fee statistics empty

### DIFF
--- a/__tests__/unit/components/Input/InputFee.spec.js
+++ b/__tests__/unit/components/Input/InputFee.spec.js
@@ -304,6 +304,18 @@ describe('InputFee', () => {
         expect(wrapper.vm.feeChoices.MAXIMUM).toBeWithin(0.03, 0.03000001)
       })
     })
+
+    describe('when the network returns no statistics', () => {
+      beforeEach(() => {
+        mockNetwork.feeStatistics = []
+      })
+
+      it('should use it as maximum', () => {
+        const wrapper = mountComponent()
+
+        expect(wrapper.vm.feeChoices.MAXIMUM).toBe(0.1)
+      })
+    })
   })
 
   describe('insufficientFundsError', () => {

--- a/src/renderer/components/Input/InputFee.vue
+++ b/src/renderer/components/Input/InputFee.vue
@@ -169,7 +169,15 @@ export default {
       }
 
       const { feeStatistics } = this.feeNetwork
-      return feeStatistics.find(feeConfig => feeConfig.type === this.transactionType).fees
+      const transactionStatistics = feeStatistics.find(feeConfig => feeConfig.type === this.transactionType)
+      if (transactionStatistics) {
+        return transactionStatistics.fees
+      }
+
+      return {
+        avgFee: this.maxV1fee * 1e8,
+        maxFee: this.maxV1fee * 1e8
+      }
     },
     feeChoiceMin () {
       return this.feeChoices.MINIMUM


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

If fee statistics from a network are empty, an error occurrs with the InputFee component which resulted in the component failing to load. This was noticed when using v2.3 of the wallet with newly deployed chains.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
