### PR TITLE
fix: disable market chart setting if market not enabled

### DIFF
--- a/src/renderer/components/ListDivided/ListDividedItem.vue
+++ b/src/renderer/components/ListDivided/ListDividedItem.vue
@@ -7,9 +7,10 @@
       class="flex justify-between"
     >
       <span
-        :class="{
-          'font-semibold text-xs mb-1': isFloatingLabel
-        }"
+        :class="[
+          { 'font-semibold text-xs mb-1': isFloatingLabel },
+          itemLabelClass
+        ]"
         class="ListDividedItem__label text-theme-page-text-light mr-5"
       >
         {{ label }}
@@ -57,6 +58,11 @@ export default {
       type: [String, Number],
       required: false,
       default: null
+    },
+    itemLabelClass: {
+      type: String,
+      required: false,
+      default: ''
     },
     itemValueClass: {
       type: String,

--- a/src/renderer/pages/Profile/ProfileEdition.vue
+++ b/src/renderer/pages/Profile/ProfileEdition.vue
@@ -214,6 +214,7 @@
                 class="ProfileEdition__market-chart"
               >
                 <ButtonSwitch
+                  :is-disabled="!isMarketEnabled"
                   :is-active="isMarketChartEnabled"
                   @change="selectIsMarketChartEnabled"
                 />
@@ -396,6 +397,9 @@ export default {
     },
     isMarketChartEnabled () {
       return this.modified.isMarketChartEnabled || this.profile.isMarketChartEnabled
+    },
+    isMarketEnabled () {
+      return this.session_network && this.session_network.market && this.session_network.market.enabled
     },
     isProfileTab () {
       return this.tab === 'profile'

--- a/src/renderer/pages/Profile/ProfileEdition.vue
+++ b/src/renderer/pages/Profile/ProfileEdition.vue
@@ -211,6 +211,8 @@
             <ListDivided>
               <ListDividedItem
                 :label="$t('COMMON.IS_MARKET_CHART_ENABLED')"
+                :item-label-class="{ 'opacity-50': !isMarketEnabled }"
+                :item-value-class="{ 'opacity-50 cursor-not-allowed': !isMarketEnabled }"
                 class="ProfileEdition__market-chart"
               >
                 <ButtonSwitch

--- a/src/renderer/pages/Profile/ProfileEdition.vue
+++ b/src/renderer/pages/Profile/ProfileEdition.vue
@@ -211,8 +211,8 @@
             <ListDivided>
               <ListDividedItem
                 :label="$t('COMMON.IS_MARKET_CHART_ENABLED')"
-                :item-label-class="{ 'opacity-50': !isMarketEnabled }"
-                :item-value-class="{ 'opacity-50 cursor-not-allowed': !isMarketEnabled }"
+                :item-label-class="!isMarketEnabled ? 'opacity-50' : ''"
+                :item-value-class="!isMarketEnabled ? 'opacity-50 cursor-not-allowed' : ''"
                 class="ProfileEdition__market-chart"
               >
                 <ButtonSwitch


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

The profile edition page allows to change the value for the market chart display even if no market is available, for instance on devnet.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
