### PR TITLE
fix: add margin only when confirmations truthy & chores

### DIFF
--- a/__tests__/unit/__utils__/setup.js
+++ b/__tests__/unit/__utils__/setup.js
@@ -27,7 +27,7 @@ VueTestUtils.config.mocks.$client = {
 }
 
 VueTestUtils.config.mocks.assets_loadImage = jest.fn()
-VueTestUtils.config.mocks.collections_filterChilds = jest.fn()
+VueTestUtils.config.mocks.collections_filterChildren = jest.fn()
 VueTestUtils.config.mocks.currency_subToUnit = jest.fn()
 VueTestUtils.config.mocks.currency_format = jest.fn()
 VueTestUtils.config.mocks.session_network = jest.fn()

--- a/__tests__/unit/components/Menu/MenuStep.spec.js
+++ b/__tests__/unit/components/Menu/MenuStep.spec.js
@@ -11,7 +11,7 @@ describe('MenuStep', () => {
         step: 1
       },
       mocks: {
-        collections_filterChilds: jest.fn()
+        collections_filterChildren: jest.fn()
       }
     })
     expect(wrapper.contains('.MenuStep')).toBeTruthy()

--- a/src/renderer/components/Collapse/CollapseAccordion.vue
+++ b/src/renderer/components/Collapse/CollapseAccordion.vue
@@ -30,7 +30,7 @@ export default {
     items: {
       type: Array,
       required: false,
-      default: () => this.collections_filterChilds('Collapse') || []
+      default: () => this.collections_filterChildren('Collapse') || []
     }
   },
 

--- a/src/renderer/components/Menu/MenuNavigation/MenuNavigation.vue
+++ b/src/renderer/components/Menu/MenuNavigation/MenuNavigation.vue
@@ -48,7 +48,7 @@ export default {
 
   methods: {
     collectItems () {
-      this.items = this.collections_filterChilds('MenuNavigationItem') || []
+      this.items = this.collections_filterChildren('MenuNavigationItem') || []
     },
 
     switchToId (id) {

--- a/src/renderer/components/Menu/MenuStep/MenuStep.vue
+++ b/src/renderer/components/Menu/MenuStep/MenuStep.vue
@@ -54,7 +54,7 @@ export default {
 
   methods: {
     collectItems () {
-      const steps = this.collections_filterChilds('MenuStepItem', this.$refs.accordion) || []
+      const steps = this.collections_filterChildren('MenuStepItem', this.$refs.accordion) || []
       const collapses = map(steps, step => step.$refs.collapse)
 
       // The first and last items has a different style and text on the default footer

--- a/src/renderer/components/Transaction/TransactionShow.vue
+++ b/src/renderer/components/Transaction/TransactionShow.vue
@@ -21,11 +21,11 @@
         </span>
         <ButtonClipboard
           :value="transaction.id"
-          :class="{ 'mx-2': transaction.confirmations }"
-          class="text-theme-page-text-light"
+          :class="{ 'mr-2': transaction.confirmations }"
+          class="text-theme-page-text-light ml-2"
         />
         <button
-          v-if="transaction.confirmations > 0"
+          v-if="transaction.confirmations"
           v-tooltip="{
             content: `${$t('TRANSACTION.OPEN_IN_EXPLORER')}`,
             trigger: 'hover'
@@ -65,7 +65,7 @@
             content: `${$t('TRANSACTION.OPEN_IN_EXPLORER')}`,
             trigger: 'hover'
           }"
-          class="flex items-center ml-2"
+          class="flex items-center"
           @click="openBlock"
         >
           <SvgIcon

--- a/src/renderer/components/Transaction/TransactionShow.vue
+++ b/src/renderer/components/Transaction/TransactionShow.vue
@@ -21,7 +21,8 @@
         </span>
         <ButtonClipboard
           :value="transaction.id"
-          class="text-theme-page-text-light mx-2"
+          :class="{ 'mx-2': transaction.confirmations }"
+          class="text-theme-page-text-light"
         />
         <button
           v-if="transaction.confirmations > 0"
@@ -55,6 +56,10 @@
         >
           {{ transaction.blockId | truncateMiddle(30) }}
         </span>
+        <ButtonClipboard
+          :value="transaction.blockId"
+          class="text-theme-page-text-light mx-2"
+        />
         <button
           v-tooltip="{
             content: `${$t('TRANSACTION.OPEN_IN_EXPLORER')}`,

--- a/src/renderer/components/Wallet/WalletTable.vue
+++ b/src/renderer/components/Wallet/WalletTable.vue
@@ -66,12 +66,6 @@
         </div>
 
         <div
-          v-else-if="data.column.field === 'votedDelegate'"
-        >
-          {{ data.row.votedDelegate ? data.row.votedDelegate.username : '' }}
-        </div>
-
-        <div
           v-else-if="data.column.field === 'actions'"
           class="flex items-center justify-center"
         >

--- a/src/renderer/mixins/collections.js
+++ b/src/renderer/mixins/collections.js
@@ -1,6 +1,6 @@
 export default {
   methods: {
-    collections_filterChilds (childName, ref = this) {
+    collections_filterChildren (childName, ref = this) {
       return ref.$children.filter(child => {
         return child.$options.name === childName
       })


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

Additional changes to #1129 which can either be merged into that branch or I'll rebase this PR if #1129 gets merged first.

This PR adds a clipboard button for the block id and adds a condition to the clipboard button of the transaction id, so there is no right margin when the explorer link is missing.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Other... Please describe: chores

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
