### PR TITLE
fix: do not override the state when updating wallets at once

### DIFF
--- a/__tests__/unit/store/modules/ledger.spec.js
+++ b/__tests__/unit/store/modules/ledger.spec.js
@@ -350,4 +350,25 @@ describe('ledger store module', () => {
       expect(store.getters['ledger/cachedWallets']('A1')).toEqual([])
     })
   })
+
+  describe('updateWallets', () => {
+    it('should set wallets when the state is empty', async () => {
+      expect(store.getters['ledger/wallets']).toBeArrayOfSize(0)
+      const wallets = { A1: { address: 'A1' } }
+      await store.dispatch('ledger/updateWallets', wallets)
+      expect(store.getters['ledger/walletsObject']).toMatchObject(wallets)
+    })
+
+    it('should not remove existing wallets in the state', async () => {
+      expect(store.getters['ledger/wallets']).toBeArrayOfSize(0)
+      const wallets = { A1: { address: 'A1', balance: 0 }, A2: { address: 'A2', balance: 1 } }
+      await store.dispatch('ledger/updateWallets', wallets)
+      expect(store.getters['ledger/wallet']('A2').balance).toBe(1)
+
+      const walletsToUpdate = { A2: { address: 'A2', balance: 0 } }
+      await store.dispatch('ledger/updateWallets', walletsToUpdate)
+      expect(store.getters['ledger/wallet']('A2').balance).toBe(0)
+      expect(store.getters['ledger/wallet']('A1')).toBeObject()
+    })
+  })
 })

--- a/src/renderer/pages/Wallet/WalletAll.vue
+++ b/src/renderer/pages/Wallet/WalletAll.vue
@@ -376,6 +376,7 @@ export default {
   },
 
   created () {
+    this.loadWallets()
     this.$eventBus.on('ledger:wallets-updated', this.includeLedgerWallets)
     this.$eventBus.on('ledger:disconnected', this.ledgerDisconnected)
   },
@@ -390,18 +391,22 @@ export default {
    * should include the Ledger wallets, if they are available, to the list of wallets
    */
   activated () {
-    this.isLoading = true
-
-    if (this.$store.getters['ledger/isConnected']) {
-      this.includeLedgerWallets()
-    } else {
-      this.selectableWallets = this.wallets
-    }
-
-    this.isLoading = false
+    this.loadWallets()
   },
 
   methods: {
+    loadWallets () {
+      this.isLoading = true
+
+      if (this.$store.getters['ledger/isConnected']) {
+        this.includeLedgerWallets()
+      } else {
+        this.selectableWallets = this.wallets
+      }
+
+      this.isLoading = false
+    },
+
     hideRemovalConfirmation () {
       this.walletToRemove = null
     },

--- a/src/renderer/store/modules/ledger.js
+++ b/src/renderer/store/modules/ledger.js
@@ -357,7 +357,10 @@ export default {
      * Store several Ledger wallets at once and cache them.
      */
     async updateWallets ({ commit, dispatch, getters, rootGetters }, walletsToUpdate) {
-      commit('SET_WALLETS', walletsToUpdate)
+      commit('SET_WALLETS', {
+        ...getters['walletsObject'],
+        ...walletsToUpdate
+      })
       eventBus.emit('ledger:wallets-updated', getters['walletsObject'])
       dispatch('cacheWallets')
     },


### PR DESCRIPTION
## Proposed changes

#1124 introduced a bug because the endpoint to search for multiple addresses does not return cold wallets in the response.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)