### PR TITLE
fix: other network fees when higher than ARK static fees

### DIFF
--- a/__tests__/unit/services/client.spec.js
+++ b/__tests__/unit/services/client.spec.js
@@ -774,7 +774,7 @@ describe('Services > Client', () => {
   describe('buildSecondSignatureRegistration', () => {
     describe('when the fee is bigger than V1 fee', () => {
       it('should throw an Error', async () => {
-        const fee = V1.fees[2] + 0.01
+        const fee = V1.fees[1] + 0.01
         expect(await errorCapturer(client.buildSecondSignatureRegistration({ fee }))).toThrow(/fee/)
       })
     })

--- a/__tests__/unit/services/client.spec.js
+++ b/__tests__/unit/services/client.spec.js
@@ -19,6 +19,16 @@ jest.mock('@/store', () => ({
           publicKey: '034da006f958beba78ec54443df4a3f52237253f7ae8cbdb17dccf3feaa57f3126'
         }
       }
+    },
+    'transaction/staticFee': (type) => {
+      const fees = [
+        0.1 * 1e8,
+        5 * 1e8,
+        25 * 1e8,
+        1 * 1e8
+      ]
+
+      return fees[type]
     }
   },
   watch: jest.fn()

--- a/src/renderer/services/client.js
+++ b/src/renderer/services/client.js
@@ -672,7 +672,6 @@ export default class ClientService {
    */
   async buildTransfer ({ amount, fee, recipientId, vendorField, passphrase, secondPassphrase, wif }, isAdvancedFee = false, returnObject = false) {
     const staticFee = store.getters['transaction/staticFee'](0) || V1.fees[0]
-    // To ensure that transfers cannot be build with a bigger fee than V1
     if (!isAdvancedFee && fee > staticFee) {
       throw new Error(`Transfer fee should be smaller than ${staticFee}`)
     }

--- a/src/renderer/services/client.js
+++ b/src/renderer/services/client.js
@@ -603,8 +603,9 @@ export default class ClientService {
    * @returns {Object}
    */
   async buildVote ({ votes, fee, passphrase, secondPassphrase, wif }, isAdvancedFee = false, returnObject = false) {
-    if (!isAdvancedFee && fee > V1.fees[3]) {
-      throw new Error(`Vote fee should be smaller than ${V1.fees[3]}`)
+    const staticFee = store.getters['transaction/staticFee'](3) || V1.fees[3]
+    if (!isAdvancedFee && fee > staticFee) {
+      throw new Error(`Vote fee should be smaller than ${staticFee}`)
     }
 
     const transaction = transactionBuilder
@@ -635,8 +636,9 @@ export default class ClientService {
    * @returns {Object}
    */
   async buildDelegateRegistration ({ username, fee, passphrase, secondPassphrase, wif }, isAdvancedFee = false, returnObject = false) {
-    if (!isAdvancedFee && fee > V1.fees[2]) {
-      throw new Error(`Delegate registration fee should be smaller than ${V1.fees[2]}`)
+    const staticFee = store.getters['transaction/staticFee'](2) || V1.fees[2]
+    if (!isAdvancedFee && fee > staticFee) {
+      throw new Error(`Delegate registration fee should be smaller than ${staticFee}`)
     }
 
     const transaction = transactionBuilder
@@ -669,9 +671,10 @@ export default class ClientService {
    * @returns {Object}
    */
   async buildTransfer ({ amount, fee, recipientId, vendorField, passphrase, secondPassphrase, wif }, isAdvancedFee = false, returnObject = false) {
+    const staticFee = store.getters['transaction/staticFee'](0) || V1.fees[0]
     // To ensure that transfers cannot be build with a bigger fee than V1
-    if (!isAdvancedFee && fee > V1.fees[0]) {
-      throw new Error(`Transfer fee should be smaller than ${V1.fees[0]}`)
+    if (!isAdvancedFee && fee > staticFee) {
+      throw new Error(`Transfer fee should be smaller than ${staticFee}`)
     }
 
     const transaction = transactionBuilder
@@ -703,8 +706,9 @@ export default class ClientService {
    * @returns {Object}
    */
   async buildSecondSignatureRegistration ({ fee, passphrase, secondPassphrase, wif }, isAdvancedFee = false, returnObject = false) {
-    if (!isAdvancedFee && fee > V1.fees[1]) {
-      throw new Error(`Second signature fee should be smaller than ${V1.fees[1]}`)
+    const staticFee = store.getters['transaction/staticFee'](1) || V1.fees[1]
+    if (!isAdvancedFee && fee > staticFee) {
+      throw new Error(`Second signature fee should be smaller than ${staticFee}`)
     }
 
     const transaction = transactionBuilder


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

Resolves an issue with non-ARK chains, where the fee greater than ARK's static fees resulted in not being able to send transactions.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
