### PR TITLE
fix: main sidebar menus (settings and peers/networks)

### DIFF
--- a/src/renderer/directives/click-outside.js
+++ b/src/renderer/directives/click-outside.js
@@ -8,9 +8,9 @@ export default {
       }
     }
 
-    document.documentElement.addEventListener('click', element.clickOutsideEvent, false)
+    document.documentElement.addEventListener('click', element.clickOutsideEvent, true)
   },
   unbind (element) {
-    document.documentElement.removeEventListener('click', element.clickOutsideEvent, false)
+    document.documentElement.removeEventListener('click', element.clickOutsideEvent, true)
   }
 }


### PR DESCRIPTION
## Proposed changes
The menus on the main sidebar (settings and peers/networks) weren't working since the upgrade of dependencies.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes