### PR TITLE
fix: do not use getStruct in ledger transactions

### DIFF
--- a/src/renderer/services/transaction.js
+++ b/src/renderer/services/transaction.js
@@ -29,7 +29,8 @@ export default class TransactionService {
    */
   static async ledgerSign (wallet, transactionObject, vm) {
     transactionObject.senderPublicKey(wallet.publicKey)
-    const transaction = transactionObject.data
+    transactionObject.sign('passphrase') // Sign with a "fake" passphrase to get the transaction structure
+    const transaction = transactionObject.getStruct()
 
     if (transactionObject.data.type === TRANSACTION_TYPES.VOTE) {
       transaction.recipientId = wallet.address

--- a/src/renderer/services/transaction.js
+++ b/src/renderer/services/transaction.js
@@ -29,7 +29,7 @@ export default class TransactionService {
    */
   static async ledgerSign (wallet, transactionObject, vm) {
     transactionObject.senderPublicKey(wallet.publicKey)
-    const transaction = transactionObject.getStruct()
+    const transaction = transactionObject.data
 
     if (transactionObject.data.type === TRANSACTION_TYPES.VOTE) {
       transaction.recipientId = wallet.address


### PR DESCRIPTION
## Proposed changes

The latest version of the crypto package does not allow to get struct without a signature and a sender: https://github.com/ArkEcosystem/core/blob/master/packages/crypto/src/builder/transactions/transaction.ts#L178-L180

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)