### PR TITLE
fix: profile model validation to use letter avatar

### DIFF
--- a/src/renderer/models/profile.js
+++ b/src/renderer/models/profile.js
@@ -9,16 +9,26 @@ export default new BaseModel({
       maxLength: 16
     },
     avatar: {
-      type: ['string', 'object'],
-      minLength: 1,
-      properties: {
-        avatarName: {
-          type: 'string'
+      anyOf: [
+        {
+          type: 'string',
+          minLength: 1
         },
-        pluginId: {
-          type: 'string'
+        {
+          type: 'object',
+          properties: {
+            avatarName: {
+              type: 'string'
+            },
+            pluginId: {
+              type: 'string'
+            }
+          }
+        },
+        {
+          type: 'null'
         }
-      }
+      ]
     },
     background: {
       type: 'string',


### PR DESCRIPTION
## Proposed changes

- The `avatar` property in the profile model was merging the specifications of two types;
- Used the JSON Schema directive `anyOf` to set the specs separately.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)