### PR TITLE
fix: value of letter avatar on profile creation

### DIFF
--- a/src/renderer/components/Profile/ProfileAvatar.vue
+++ b/src/renderer/components/Profile/ProfileAvatar.vue
@@ -57,7 +57,7 @@ export default {
 
   computed: {
     hasStandardAvatar () {
-      return this.profile.avatar && (typeof this.profile.avatar === 'string' || this.profile.avatar.letterOnly)
+      return this.profile.avatar && typeof this.profile.avatar === 'string'
     },
 
     pluginAvatar () {

--- a/src/renderer/models/profile.js
+++ b/src/renderer/models/profile.js
@@ -10,10 +10,12 @@ export default new BaseModel({
     },
     avatar: {
       anyOf: [
+        // Images provided by the app
         {
           type: 'string',
           minLength: 1
         },
+        // Images provided by the plugins
         {
           type: 'object',
           properties: {
@@ -25,6 +27,7 @@ export default new BaseModel({
             }
           }
         },
+        // No avatar (use name first character)
         {
           type: 'null'
         }

--- a/src/renderer/pages/Profile/ProfileEdition.vue
+++ b/src/renderer/pages/Profile/ProfileEdition.vue
@@ -492,14 +492,19 @@ export default {
     },
 
     selectAvatar (avatar) {
-      let newAvatar = null
+      let newAvatar
+
       if (typeof avatar === 'string') {
         newAvatar = avatar
+      } else if (avatar.onlyLetter) {
+        newAvatar = null
       } else if (avatar.name) {
         newAvatar = {
           avatarName: avatar.name,
           pluginId: avatar.pluginId
         }
+      } else {
+        throw new Error(`Invalid value for avatar: ${avatar}`)
       }
 
       this.__updateSession('avatar', newAvatar)

--- a/src/renderer/pages/Profile/ProfileNew.vue
+++ b/src/renderer/pages/Profile/ProfileNew.vue
@@ -359,15 +359,17 @@ export default {
     },
 
     selectAvatar (avatar) {
-      if (typeof avatar === 'string' || avatar.onlyLetter) {
+      if (typeof avatar === 'string') {
         this.schema.avatar = avatar
+      } else if (avatar.onlyLetter) {
+        this.schema.avatar = null
       } else if (avatar.name) {
         this.schema.avatar = {
           avatarName: avatar.name,
           pluginId: avatar.pluginId
         }
       } else {
-        this.schema.avatar = null
+        throw new Error(`Invalid value for avatar: ${avatar}`)
       }
     },
 

--- a/src/renderer/store/migrations/2.4.0 - fix letter avatars.js
+++ b/src/renderer/store/migrations/2.4.0 - fix letter avatars.js
@@ -1,0 +1,19 @@
+import { isUndefined } from 'lodash'
+
+// Update the schema of profile avatars to be consistent and use `null` instead
+// of `null` and `undefined` when to establish a "letter" avatar.
+// It also fixes profiles that have been created, incorrectly, using `extraItems`
+// from `SelectionAvatar`
+export default store => {
+  store.getters['profile/all'].forEach(profile => {
+    if (isUndefined(profile.avatar) || (profile.avatar && profile.avatar.onlyLetter)) {
+      store.dispatch('profile/update', {
+        ...profile,
+        avatar: null
+      })
+    }
+  })
+
+  // All successful migrations should update this property
+  store.dispatch('app/setLatestAppliedMigration', '2.4.0')
+}


### PR DESCRIPTION
## Proposed changes
Profile edition wasn't working correctly: profiles with letter avatars were enabling the "save" button even when no modification was done.

The root cause was that some profiles were created or modified incorrectly. This PR fixes that and migrates older profiles to keep the right scheme.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [x] Docs (documentation only changes)

## Checklist
- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes

## Further comments
To generate profile with problematic avatars, they could be created on `develop` and `next` branches.