### PR TITLE
fix: show the market chart when enabling it on the profile

### DIFF
--- a/src/renderer/components/MarketChart/MarketChart.vue
+++ b/src/renderer/components/MarketChart/MarketChart.vue
@@ -2,15 +2,16 @@
   <section class="MarketChart w-full flex-column">
     <slot />
     <LineChart
+      v-if="isActive"
       v-show="isReady"
       ref="chart"
       :chart-data="chartData"
       :options="options"
       :height="315"
-      @ready="show"
+      @ready="setReady"
     />
     <div
-      v-if="!isReady"
+      v-if="isActive && !isReady"
       class="MarketChart__Loader__Container"
     >
       <Loader />
@@ -40,6 +41,7 @@ export default {
   },
 
   props: {
+    // Should the chart be rendered?
     isActive: {
       type: Boolean,
       required: false,
@@ -94,24 +96,18 @@ export default {
 
     ticker () {
       this.renderChart()
-    },
-
-    isActive (val) {
-      if (!val) return // Render the chart when open the component
-
-      this.renderChart()
     }
   },
 
-  mounted () {
-    // Avoid creating the gradient when the element is not built
-    if (this.isActive) {
+  activated () {
+    // Only if it's not already rendered
+    if (this.isActive && !this.isReady) {
       this.renderChart()
     }
   },
 
   methods: {
-    show () {
+    setReady () {
       this.isReady = true
     },
     async renderChart () {
@@ -303,17 +299,17 @@ export default {
       if (this.session_profile.timeFormat !== '12h') {
         return time
       } else {
+        let meridiem = 'PM'
         const [hours, minutes] = time.split(':')
         let hour = parseInt(hours)
-        let am = false
         if (hour === 0) {
           hour = 12
         } else if (hour > 12) {
           hour -= 12
         } else {
-          am = true
+          meridiem = 'AM'
         }
-        return `${hour}:${minutes} ${am ? 'AM' : 'PM'}`
+        return `${hour}:${minutes} ${meridiem}`
       }
     }
   }

--- a/src/renderer/components/utils/LineChart.js
+++ b/src/renderer/components/utils/LineChart.js
@@ -22,7 +22,7 @@ export default {
   },
 
   mounted () {
-    this.$on('chart:render', () => {
+    this.$once('chart:render', () => {
       this.$emit('ready')
     })
     this.render()

--- a/src/renderer/pages/Dashboard.vue
+++ b/src/renderer/pages/Dashboard.vue
@@ -2,7 +2,7 @@
   <div class="Dashboard relative flex flex-row h-full w-full">
     <main class="bg-theme-feature rounded-lg lg:mr-4 flex-1 w-full flex-col overflow-y-auto">
       <div
-        v-if="!isChartEnabled && isMarketEnabled"
+        v-if="!isChartEnabledOnProfile && isMarketEnabled"
         class="pt-10 px-10 rounded-t-lg text-lg font-semibold mt-1 text-theme-chart-price"
       >
         <span v-if="price">
@@ -13,10 +13,10 @@
       </div>
 
       <div
-        v-if="isChartEnabled && isMarketEnabled"
+        v-if="isChartEnabledOnProfile && isMarketEnabled"
         class="bg-theme-chart-background pt-10 px-10 pb-4 rounded-t-lg"
       >
-        <MarketChart :is-active="isMarketEnabled">
+        <MarketChart :is-active="isActive">
           <MarketChartHeader class="mb-5" />
         </MarketChart>
       </div>
@@ -34,8 +34,8 @@
 
     <div class="Dashboard__wallets relative bg-theme-feature rounded-lg w-88 overflow-y-auto hidden lg:block">
       <div class="flex flex-row text-theme-feature-item-alternative-text mt-2">
-        <WalletButtonCreate class="mt-6 mb-6 w-1/2" />
-        <WalletButtonImport class="mt-6 mb-6 w-1/2" />
+        <WalletButtonCreate class="Dashboard__wallets__button" />
+        <WalletButtonImport class="Dashboard__wallets__button" />
       </div>
       <WalletSidebar
         :show-expanded="true"
@@ -64,10 +64,11 @@ export default {
     WalletButtonImport
   },
 
+  data: () => ({
+    isActive: true
+  }),
+
   computed: {
-    isChartEnabled () {
-      return this.$store.getters['session/isMarketChartEnabled']
-    },
     isMarketEnabled () {
       return this.session_network && this.session_network.market && this.session_network.market.enabled
     },
@@ -79,6 +80,15 @@ export default {
     },
     ticker () {
       return this.session_network.market.ticker
+    },
+    isChartEnabledOnProfile () {
+      return this.session_profile.isMarketChartEnabled
+    }
+  },
+
+  watch: {
+    isChartEnabledOnProfile () {
+      this.isActive = this.isChartEnabledOnProfile
     }
   },
 
@@ -104,6 +114,10 @@ export default {
     store._IS_READY
       ? chooseNext()
       : store._vm.$root.$on('vuex-persist:ready', chooseNext)
+  },
+
+  activated () {
+    this.isActive = this.isChartEnabledOnProfile
   }
 }
 </script>
@@ -126,5 +140,8 @@ export default {
 }
 .Dashboard__wallets__list .WalletSidebar__wallet__ledger-loader .v-spinner {
   @apply mr-3;
+}
+.Dashboard__wallets__button {
+  @apply .mt-6 .mb-6 .w-1/2
 }
 </style>


### PR DESCRIPTION
## Proposed changes
The market chart wasn't properly enabled or disabled when the related setting was changed on the profile edition.

## Types of changes
- [X] Bugfix (non-breaking change which fixes an issue)

## Checklist
- [X] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [X] Lint and unit tests pass locally with my changes