### PR TITLE
fix(plugins): use light theme if plugin is removed before disabling

### DIFF
--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -171,7 +171,13 @@ export default {
       return this.$store.getters['plugin/themes']
     },
     theme () {
-      return this.$store.getters['session/theme']
+      const theme = this.$store.getters['session/theme']
+      const defaultThemes = ['light', 'dark']
+
+      // Ensure that the plugin theme is available (not deleted from the file system)
+      return defaultThemes.includes(theme) || this.pluginThemes[theme]
+        ? theme
+        : defaultThemes[0]
     },
     themeClass () {
       return `theme-${this.theme}`

--- a/src/renderer/components/MarketChart/MarketChart.vue
+++ b/src/renderer/components/MarketChart/MarketChart.vue
@@ -72,8 +72,11 @@ export default {
 
       let themeColour = coloursByTheme[this.theme]
       if (!themeColour) {
+        let mode = 'light'
         const pluginTheme = this.pluginThemes[this.theme]
-        const mode = pluginTheme.darkMode ? 'dark' : 'light'
+        if (pluginTheme) {
+          mode = pluginTheme.darkMode ? 'dark' : 'light'
+        }
         themeColour = coloursByTheme[mode]
       }
 

--- a/src/renderer/mixins/session.js
+++ b/src/renderer/mixins/session.js
@@ -1,3 +1,5 @@
+import logger from 'electron-log'
+
 export default {
   computed: {
     session_currency () {
@@ -15,7 +17,10 @@ export default {
         return pluginThemes[theme].darkMode
       }
 
-      throw new Error(`Theme "${theme}" was not found`)
+      logger.error(`Theme "${theme}" was not found`)
+
+      // Fallback to the `light` theme
+      return false
     },
     session_network () {
       return this.$store.getters['session/network']


### PR DESCRIPTION
## Proposed changes
If the theme is being used, but the user removes the code of the plugin, it uses the default theme instead.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes