### PR TITLE
fix: stop hover from displacing address container

### DIFF
--- a/src/renderer/pages/Wallet/WalletNew.vue
+++ b/src/renderer/pages/Wallet/WalletNew.vue
@@ -75,37 +75,43 @@
               name="WalletNew__wallets--transition"
               tag="ul"
             >
-              <li
-                v-for="(passphrase, address) in wallets"
-                :key="address"
-                :class="[
-                  isSelected(address) ? 'WalletNew__wallets__address--selected' : 'WalletNew__wallets__address--unselected',
-                ]"
-                class="WalletNew__wallets__address py-4 w-full truncate cursor-pointer"
-                @click="selectWallet(address, passphrase)"
-              >
-                <div class="WalletNew__wallets__address__mask flex items-center">
-                  <div class="relative">
-                    <WalletIdenticon
-                      :value="address"
-                      :size="35"
-                      class="flex-no-shrink identicon"
-                    />
-                    <span
-                      v-if="isSelected(address)"
-                      class="WalletNew_wallets__check absolute rounded-full flex items-center justify-center -mb-1 w-6 h-6 bg-green border-4 border-theme-feature text-white"
-                    >
-                      <SvgIcon
-                        name="checkmark"
-                        view-box="0 0 8 7"
+              <template v-for="(passphrase, address) in wallets">
+                <li
+                  :key="address"
+                  :class="[
+                    isSelected(address) ? 'WalletNew__wallets__address--selected' : 'WalletNew__wallets__address--unselected',
+                  ]"
+                  class="WalletNew__wallets__address py-4 w-full truncate cursor-pointer"
+                  @click="selectWallet(address, passphrase)"
+                >
+                  <div class="WalletNew__wallets__address__mask flex items-center">
+                    <div class="relative">
+                      <WalletIdenticon
+                        :value="address"
+                        :size="35"
+                        class="flex-no-shrink identicon"
                       />
+                      <span
+                        v-if="isSelected(address)"
+                        class="WalletNew_wallets__check absolute rounded-full flex items-center justify-center -mb-1 w-6 h-6 bg-green border-4 border-theme-feature text-white"
+                      >
+                        <SvgIcon
+                          name="checkmark"
+                          view-box="0 0 8 7"
+                        />
+                      </span>
+                    </div>
+                    <span class="WalletNew__wallets--address text-theme-page-text ml-2 flex-no-shrink font-semibold text-sm">
+                      {{ address }}
                     </span>
                   </div>
-                  <span class="WalletNew__wallets--address text-theme-page-text ml-2 flex-no-shrink font-semibold text-sm">
-                    {{ address }}
-                  </span>
-                </div>
-              </li>
+                </li>
+
+                <div
+                  :key="address"
+                  class="WalletNew__wallets__address__separator"
+                />
+              </template>
             </TransitionGroup>
           </MenuStepItem>
 
@@ -539,8 +545,11 @@ export default {
   @apply opacity-100;
 }
 
-.WalletNew__wallets__address + .WalletNew__wallets__address {
-  @apply border-t border-dashed border-theme-line-separator
+.WalletNew__wallets__address__separator {
+  @apply block border-t border-dashed border-theme-line-separator
+}
+.WalletNew__wallets__address__separator:last-of-type {
+  @apply hidden
 }
 
 .WalletNew__ButtonReload-colorClass {


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

When hovering over the shown addresses in the `Create Wallet` page there is a slight vertical displacement of the containers.

![flicker](https://user-images.githubusercontent.com/6547002/57604733-356d1a00-7565-11e9-9876-e20dcfb68ee6.gif)

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build (changes that affect the build system)
- [ ] Docs (documentation only changes)
- [ ] Test (adding missing tests or fixing existing tests)
- [ ] Other... Please describe:

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
