### PR TITLE
feat(plugins): button to open the plugin installation folder

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -1,3 +1,6 @@
+const os = require('os')
+const path = require('path')
+
 exports.APP = {
   website: 'https://ark.io',
   transactionExpiryMinutes: 45
@@ -94,7 +97,8 @@ exports.MARKET = {
 }
 
 exports.PLUGINS = {
-  discoverUrl: 'https://github.com/ark-ecosystem-desktop-plugins'
+  discoverUrl: 'https://github.com/ark-ecosystem-desktop-plugins',
+  path: path.resolve(os.homedir(), '.ark-desktop/plugins')
 }
 
 exports.THEMES = [

--- a/src/renderer/i18n/locales/en-US.js
+++ b/src/renderer/i18n/locales/en-US.js
@@ -502,7 +502,8 @@ export default {
 
     PLUGINS: {
       HEADER: 'Plugins',
-      DISCOVER: 'Discover more plugins'
+      DISCOVER: 'Discover plugins',
+      OPEN: 'Open plugins'
     },
 
     PROFILE_ALL: {

--- a/src/renderer/i18n/locales/en-US.js
+++ b/src/renderer/i18n/locales/en-US.js
@@ -502,8 +502,8 @@ export default {
 
     PLUGINS: {
       HEADER: 'Plugins',
-      DISCOVER: 'Discover plugins',
-      OPEN: 'Open plugins'
+      DISCOVER: 'Discover Plugins',
+      OPEN: 'Open Plugins'
     },
 
     PROFILE_ALL: {

--- a/src/renderer/pages/Plugins.vue
+++ b/src/renderer/pages/Plugins.vue
@@ -7,8 +7,22 @@
 
       <div class="flex flex-row items-center">
         <a
-          class="font-bold text-center cursor-pointer"
+          class="font-bold text-center cursor-pointer pr-6 border-r border-theme-feature-item-alternative"
           @click="discover"
+        >
+          <span class="rounded-full bg-theme-button h-8 w-8 mb-3 mx-auto flex items-center justify-center">
+            <SvgIcon
+              name="world"
+              class="text-center"
+              view-box="0 0 9 9"
+            />
+          </span>
+
+          {{ $t('PAGES.PLUGINS.DISCOVER') }}
+        </a>
+        <a
+          class="font-bold text-center cursor-pointer pl-6"
+          @click="open"
         >
           <span class="rounded-full bg-theme-button h-8 w-8 mb-3 mx-auto flex items-center justify-center">
             <SvgIcon
@@ -18,7 +32,7 @@
             />
           </span>
 
-          {{ $t('PAGES.PLUGINS.DISCOVER') }}
+          {{ $t('PAGES.PLUGINS.OPEN') }}
         </a>
       </div>
     </div>
@@ -47,6 +61,7 @@
 </template>
 
 <script>
+import electron from 'electron'
 import { clone, some, sortBy } from 'lodash'
 import { PLUGINS } from '@config'
 import { PluginEnableConfirmation, PluginTable } from '@/components/Plugin'
@@ -125,6 +140,9 @@ export default {
 
     discover () {
       this.electron_openExternal(PLUGINS.discoverUrl)
+    },
+    open () {
+      electron.shell.openItem(PLUGINS.path)
     },
 
     disablePlugin (plugin) {

--- a/src/renderer/services/plugin-manager.js
+++ b/src/renderer/services/plugin-manager.js
@@ -1,9 +1,9 @@
 import * as fs from 'fs-extra'
-import * as os from 'os'
 import * as path from 'path'
 import * as vm2 from 'vm2'
 import { ipcRenderer } from 'electron'
 import { camelCase, isBoolean, isEmpty, isObject, isString, partition, uniq, upperFirst } from 'lodash'
+import { PLUGINS } from '@config'
 
 const rootPath = path.resolve(__dirname, '../../../')
 
@@ -35,7 +35,7 @@ class PluginManager {
     await this.app.$store.dispatch('plugin/init')
 
     // await this.fetchPluginsFromPath(`${__dirname}/../../../plugins`)
-    await this.fetchPluginsFromPath(path.resolve(os.homedir(), '.ark-desktop/plugins'))
+    await this.fetchPluginsFromPath(PLUGINS.path)
 
     this.hasInit = true
 


### PR DESCRIPTION
## Proposed changes
Add a button to open the folder which contains the installed plugins

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes