### PR TITLE
fix(plugins): position of the arrow of the plugin items menu

### DIFF
--- a/src/renderer/components/App/AppSidemenu/AppSidemenuPlugins.vue
+++ b/src/renderer/components/App/AppSidemenu/AppSidemenuPlugins.vue
@@ -86,7 +86,7 @@ export default {
 }
 
 .AppSidemenuPlugins .MenuOptions--vertical:after {
-  top: 2rem;
+  top: 6.5rem;
 }
 
 .AppSidemenuPlugins--horizontal {


### PR DESCRIPTION
## Proposed changes
The arrow of the items menu that allow navigating to plugin pages wasn't correctly positioned. This fix changes that, so in case there are only a few items the arrow points to the correct icon and, in case, there lots of them too, although it wouldn't be in the exact same position (the same issue is applicable to the other menus).

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes