### PR TITLE
feat(plugins): button to reload plugins

### DIFF
--- a/src/renderer/i18n/locales/en-US.js
+++ b/src/renderer/i18n/locales/en-US.js
@@ -503,7 +503,8 @@ export default {
     PLUGINS: {
       HEADER: 'Plugins',
       DISCOVER: 'Discover Plugins',
-      OPEN: 'Open Plugins'
+      OPEN: 'Open Plugins',
+      RELOAD: 'Reload Plugins'
     },
 
     PROFILE_ALL: {

--- a/src/renderer/pages/Plugins.vue
+++ b/src/renderer/pages/Plugins.vue
@@ -21,7 +21,7 @@
           {{ $t('PAGES.PLUGINS.DISCOVER') }}
         </a>
         <a
-          class="font-bold text-center cursor-pointer pl-6"
+          class="font-bold text-center cursor-pointer px-6 border-r border-theme-feature-item-alternative"
           @click="open"
         >
           <span class="rounded-full bg-theme-button h-8 w-8 mb-3 mx-auto flex items-center justify-center">

--- a/src/renderer/pages/Plugins.vue
+++ b/src/renderer/pages/Plugins.vue
@@ -34,6 +34,20 @@
 
           {{ $t('PAGES.PLUGINS.OPEN') }}
         </a>
+        <a
+          class="font-bold text-center cursor-pointer pl-6"
+          @click="refresh"
+        >
+          <span class="rounded-full bg-theme-button h-8 w-8 mb-3 mx-auto flex items-center justify-center">
+            <SvgIcon
+              name="update"
+              class="text-center"
+              view-box="0 0 9 9"
+            />
+          </span>
+
+          {{ $t('PAGES.PLUGINS.RELOAD') }}
+        </a>
       </div>
     </div>
 
@@ -143,6 +157,9 @@ export default {
     },
     open () {
       electron.shell.openItem(PLUGINS.path)
+    },
+    refresh () {
+      this.electron_reload()
     },
 
     disablePlugin (plugin) {


### PR DESCRIPTION
## Proposed changes
This button would reload the application. In the future it could be changed to reload the plugins solely.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes