### PR TITLE
feat(plugins): warn about using the plugin system

### DIFF
--- a/src/renderer/components/App/AppSidemenu/AppSidemenu.vue
+++ b/src/renderer/components/App/AppSidemenu/AppSidemenu.vue
@@ -61,7 +61,7 @@
             :can-activate="false"
             class="AppSidemenu__item"
             icon="plugins"
-            @click="redirect($event)"
+            @click="showPlugins"
           />
 
           <!-- Plugin pages -->
@@ -159,6 +159,13 @@
         </div>
       </div>
     </div>
+
+    <AppSidemenuPluginConfirmation
+      v-if="isPluginConfirmationVisible"
+      @enable="enablePlugins"
+      @ignore="closePluginConfirmation"
+      @close="closePluginConfirmation"
+    />
   </MenuNavigation>
 </template>
 
@@ -170,6 +177,7 @@ import AppSidemenuPlugins from './AppSidemenuPlugins'
 import AppSidemenuSettings from './AppSidemenuSettings'
 import AppSidemenuNetworkStatus from './AppSidemenuNetworkStatus'
 import AppSidemenuImportantNotification from './AppSidemenuImportantNotification'
+import AppSidemenuPluginConfirmation from './AppSidemenuPluginConfirmation'
 import { MenuNavigation, MenuNavigationItem } from '@/components/Menu'
 import { ProfileAvatar } from '@/components/Profile'
 import SvgIcon from '@/components/SvgIcon'
@@ -182,6 +190,7 @@ export default {
     AppSidemenuSettings,
     AppSidemenuNetworkStatus,
     AppSidemenuImportantNotification,
+    AppSidemenuPluginConfirmation,
     MenuNavigation,
     MenuNavigationItem,
     ProfileAvatar,
@@ -200,6 +209,7 @@ export default {
     isNetworkStatusVisible: false,
     isImportantNotificationVisible: true,
     isPluginMenuVisible: false,
+    isPluginConfirmationVisible: false,
     isSettingsVisible: false,
     activeItem: vm.$route.name
   }),
@@ -267,6 +277,25 @@ export default {
 
     closeShowNetworkStatus () {
       this.isNetworkStatusVisible = false
+    },
+
+    closePluginConfirmation () {
+      this.isPluginConfirmationVisible = false
+    },
+    showPlugins ($event) {
+      if (this.session_profile.showPluginConfirmation) {
+        this.isPluginConfirmationVisible = true
+      } else {
+        this.redirect($event)
+      }
+    },
+    async enablePlugins () {
+      this.isPluginConfirmationVisible = false
+      await this.$store.dispatch('profile/update', {
+        ...this.session_profile,
+        showPluginConfirmation: false
+      })
+      this.redirect('plugins')
     }
   }
 }

--- a/src/renderer/components/App/AppSidemenu/AppSidemenu.vue
+++ b/src/renderer/components/App/AppSidemenu/AppSidemenu.vue
@@ -171,6 +171,7 @@
 
 <script>
 import semver from 'semver'
+import { isUndefined } from 'lodash'
 import { mapGetters } from 'vuex'
 import releaseService from '@/services/release'
 import AppSidemenuPlugins from './AppSidemenuPlugins'
@@ -283,7 +284,10 @@ export default {
       this.isPluginConfirmationVisible = false
     },
     showPlugins ($event) {
-      if (this.session_profile.showPluginConfirmation) {
+      const showConfirmation = isUndefined(this.session_profile.showPluginConfirmation) ||
+        this.session_profile.showPluginConfirmation
+
+      if (showConfirmation) {
         this.isPluginConfirmationVisible = true
       } else {
         this.redirect($event)

--- a/src/renderer/components/App/AppSidemenu/AppSidemenu.vue
+++ b/src/renderer/components/App/AppSidemenu/AppSidemenu.vue
@@ -64,6 +64,7 @@
             @click="redirect($event)"
           />
 
+          <!-- Plugin pages -->
           <MenuNavigationItem
             v-if="hasPluginMenuItems"
             id="plugin-pages"
@@ -72,11 +73,11 @@
             :can-activate="false"
             class="AppSidemenu__item"
             icon="more"
-            @click="toggleShowPlugins"
+            @click="toggleShowPluginMenu"
           />
 
           <AppSidemenuPlugins
-            v-if="hasPluginMenuItems && isPluginsVisible"
+            v-if="hasPluginMenuItems && isPluginMenuVisible"
             :outside-click="true"
             :is-horizontal="isHorizontal"
             @close="closeShowPlugins"
@@ -198,7 +199,7 @@ export default {
   data: vm => ({
     isNetworkStatusVisible: false,
     isImportantNotificationVisible: true,
-    isPluginsVisible: false,
+    isPluginMenuVisible: false,
     isSettingsVisible: false,
     activeItem: vm.$route.name
   }),
@@ -244,8 +245,8 @@ export default {
       this.isImportantNotificationVisible = false
     },
 
-    toggleShowPlugins () {
-      this.isPluginsVisible = !this.isPluginsVisible
+    toggleShowPluginMenu () {
+      this.isPluginMenuVisible = !this.isPluginMenuVisible
     },
 
     toggleShowSettings () {
@@ -257,7 +258,7 @@ export default {
     },
 
     closeShowPlugins () {
-      this.isPluginsVisible = false
+      this.isPluginMenuVisible = false
     },
 
     closeShowSettings () {

--- a/src/renderer/components/App/AppSidemenu/AppSidemenuPluginConfirmation.vue
+++ b/src/renderer/components/App/AppSidemenu/AppSidemenuPluginConfirmation.vue
@@ -1,0 +1,62 @@
+<template>
+  <ModalConfirmation
+    :question="$t('APP_SIDEMENU_PLUGIN_CONFIRMATION.QUESTION')"
+    :note="$t('APP_SIDEMENU_PLUGIN_CONFIRMATION.NOTICE')"
+    :cancel-button="$t('APP_SIDEMENU_PLUGIN_CONFIRMATION.NO')"
+    :continue-button="$t('APP_SIDEMENU_PLUGIN_CONFIRMATION.YES')"
+    :footer="$t('APP_SIDEMENU_PLUGIN_CONFIRMATION.WARNING')"
+    container-classes="AppSidemenuPluginConfirmation"
+    @close="emitClose"
+    @cancel="emitIgnore"
+    @continue="emitEnable"
+  />
+</template>
+
+<script>
+import { ModalConfirmation } from '@/components/Modal'
+
+export default {
+  name: 'AppSidemenuPluginConfirmation',
+
+  components: {
+    ModalConfirmation
+  },
+
+  methods: {
+    emitIgnore () {
+      this.$emit('ignore')
+    },
+
+    emitEnable () {
+      this.$emit('enable')
+    },
+
+    emitClose () {
+      this.$emit('close')
+    }
+  }
+}
+</script>
+
+<style>
+.AppSidemenuPluginConfirmation .ModalConfirmation__container {
+  min-width: calc(10rem + 74px * 2 + 80px);
+  max-width: calc(10rem + 74px * 2 + 120px)
+}
+.AppSidemenuPluginConfirmation .ModalConfirmation__container > div:first-child {
+  @apply .mb-0
+}
+.AppSidemenuPluginConfirmation__container__name {
+  margin-top: calc(3rem);
+  margin-left: 2rem;
+  margin-right: 2rem;
+}
+.AppSidemenuPluginConfirmation__container__arrow {
+  width: 74px;
+  height: 75px;
+  margin-top: calc(var(--profile-avatar-xl) - 75px)
+}
+.AppSidemenuPluginConfirmation__container__arrow--reverse {
+  transform: scaleX(-1)
+}
+</style>

--- a/src/renderer/components/Modal/ModalConfirmation.vue
+++ b/src/renderer/components/Modal/ModalConfirmation.vue
@@ -2,6 +2,7 @@
   <ModalWindow
     :container-classes="containerClasses"
     :title="title"
+    :message="footer"
     :portal-target="portalTarget"
     @close="emitClose"
   >
@@ -17,6 +18,7 @@
         <div
           v-if="note"
           class="mt-3 text-grey-darker text-lg"
+          :class="note ? 'mb-8' : ''"
         >
           {{ note }}
         </div>
@@ -72,6 +74,11 @@ export default {
       default () {
         return this.$t('MODAL_CONFIRMATION.CONTINUE')
       }
+    },
+    footer: {
+      type: String,
+      required: false,
+      default: ''
     },
     note: {
       type: String,

--- a/src/renderer/i18n/locales/en-US.js
+++ b/src/renderer/i18n/locales/en-US.js
@@ -252,6 +252,14 @@ export default {
     TOOLTIP: 'New version ({version}) has been released!'
   },
 
+  APP_SIDEMENU_PLUGIN_CONFIRMATION: {
+    QUESTION: 'Are you sure you want to enable the plugin system?',
+    NO: 'No, keep it disabled',
+    YES: 'Yes, enable it',
+    NOTICE: 'WARNING: This system is currently in BETA. All non-official plugins are used at your own risk. We cannot verify the safety or security of any 3rd party plugins at this time and all security testing and vulnerability discovery is the responsibility of the plugin author. By accepting this notice, you acknowledge that you are using 3rd party plugins at your own risk.',
+    WARNING: 'Please be careful and pay close attention when installing plugins!'
+  },
+
   MARKET_CHART: {
     TODAY: 'Today',
     TODAY_AT: 'Today at {hour}',

--- a/src/renderer/models/profile.js
+++ b/src/renderer/models/profile.js
@@ -1,4 +1,4 @@
-import isBoolean from 'lodash'
+import { isBoolean } from 'lodash'
 import BaseModel from './base'
 
 export default new BaseModel({

--- a/src/renderer/models/profile.js
+++ b/src/renderer/models/profile.js
@@ -1,3 +1,4 @@
+import isBoolean from 'lodash'
 import BaseModel from './base'
 
 export default new BaseModel({
@@ -82,7 +83,7 @@ export default new BaseModel({
     },
     showPluginConfirmation: {
       type: 'boolean',
-      format: data => data.showPluginConfirmation !== undefined ? data.showPluginConfirmation : true
+      format: data => isBoolean(data.showPluginConfirmation) ? data.showPluginConfirmation : true
     },
     transactionTableRowCount: {
       type: 'integer',

--- a/src/renderer/models/profile.js
+++ b/src/renderer/models/profile.js
@@ -80,6 +80,10 @@ export default new BaseModel({
       type: 'boolean',
       format: data => data.ledgerCache || false
     },
+    showPluginConfirmation: {
+      type: 'boolean',
+      format: data => data.showPluginConfirmation !== undefined ? data.showPluginConfirmation : true
+    },
     transactionTableRowCount: {
       type: 'integer',
       format: data => data.transactionTableRowCount || 10


### PR DESCRIPTION
## Proposed changes
When the user tries to navigate to the plugins section, a modal would surge with a warning. If the user decides to enable them, that modal doesn't appear again.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist
- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes