### PR TITLE
fix: vendorField transaction assignment

### DIFF
--- a/src/renderer/services/client.js
+++ b/src/renderer/services/client.js
@@ -710,7 +710,8 @@ export default class ClientService {
       .amount(amount)
       .fee(fee)
       .recipientId(recipientId)
-      .vendorField(vendorField)
+
+    transaction.data.vendorField = vendorField
 
     passphrase = this.normalizePassphrase(passphrase)
     secondPassphrase = this.normalizePassphrase(secondPassphrase)


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

There is functionality in the crypto library that checks that the vendor field length is within the current milestone's value. This is with 2.3.22 of the crypto library. The desktop wallet currently uses 2.2.2, which hardcodes a 64 character limit, but neither work because of the lack of config.

Because the forms already do the validation of the length, we now simply set the vendor field value when building the transaction object.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
