### PR TITLE
feat: show remaining bytes in vendorfield helper text

### DIFF
--- a/src/renderer/components/Transaction/TransactionForm/TransactionFormTransfer.vue
+++ b/src/renderer/components/Transaction/TransactionForm/TransactionFormTransfer.vue
@@ -248,8 +248,15 @@ export default {
       return `${this.$t('TRANSACTION.VENDOR_FIELD')} - ${this.$t('VALIDATION.MAX_LENGTH', [this.vendorFieldMaxLength])}`
     },
     vendorFieldHelperText () {
-      if (this.form.vendorField.length === this.vendorFieldMaxLength) {
+      const vendorFieldLength = this.form.vendorField.length
+
+      if (vendorFieldLength === this.vendorFieldMaxLength) {
         return this.$t('VALIDATION.VENDOR_FIELD.LIMIT_REACHED', [this.vendorFieldMaxLength])
+      } else if (vendorFieldLength) {
+        return this.$t('VALIDATION.VENDOR_FIELD.LIMIT_REMAINING', [
+          this.vendorFieldMaxLength - vendorFieldLength,
+          this.vendorFieldMaxLength
+        ])
       }
       return null
     },

--- a/src/renderer/i18n/locales/en-US.js
+++ b/src/renderer/i18n/locales/en-US.js
@@ -162,7 +162,8 @@ export default {
       INVALID_LENGTH: 'The public key must be 66 characters long'
     },
     VENDOR_FIELD: {
-      LIMIT_REACHED: 'You can enter maximum {0} characters only'
+      LIMIT_REACHED: 'You can enter a maximum of {0} characters only',
+      LIMIT_REMAINING: '{0}/{1} Remaining'
     },
     REQUIRED: 'The \'{0}\' is required',
     SEND_NOT_ENABLED: 'Sending is not enabled for the selected wallet',


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

Adds a helper text to the vendorField input showing how many chars/bytes can be still entered.

![limit](https://user-images.githubusercontent.com/6547002/58053354-8e394580-7b57-11e9-8dff-327cd0c7e829.gif)

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build (changes that affect the build system)
- [ ] Docs (documentation only changes)
- [ ] Test (adding missing tests or fixing existing tests)
- [ ] Other... Please describe:

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!--

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
