### PR TITLE
fix: duplicated key warning on new wallet page

### DIFF
--- a/src/renderer/pages/Wallet/WalletNew.vue
+++ b/src/renderer/pages/Wallet/WalletNew.vue
@@ -108,7 +108,7 @@
                 </li>
 
                 <div
-                  :key="address"
+                  :key="`seprator-${address}`"
                   class="WalletNew__wallets__address__separator"
                 />
               </template>

--- a/src/renderer/pages/Wallet/WalletNew.vue
+++ b/src/renderer/pages/Wallet/WalletNew.vue
@@ -108,7 +108,7 @@
                 </li>
 
                 <div
-                  :key="`seprator-${address}`"
+                  :key="`separator-${address}`"
                   class="WalletNew__wallets__address__separator"
                 />
               </template>


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->

The wallet creation page throws several errors on the console tagged as Vue warnings.

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Does this PR release a new version?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch
- [x] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
