### PR TITLE
fix: don't switch twice when selecting wallet on WalletSidebar

### DIFF
--- a/src/renderer/components/Menu/MenuNavigation/MenuNavigation.vue
+++ b/src/renderer/components/Menu/MenuNavigation/MenuNavigation.vue
@@ -10,7 +10,7 @@ export default {
 
   provide () {
     return {
-      switchToId: this.switchToId
+      switchToItem: this.switchToItem
     }
   },
 
@@ -33,8 +33,10 @@ export default {
   }),
 
   watch: {
-    id (val) {
-      this.switchToId(val)
+    id (value) {
+      if (this.activeId !== value) {
+        this.activateItem(value)
+      }
     }
   },
 
@@ -42,7 +44,7 @@ export default {
     this.collectItems()
 
     if (this.activeId) {
-      this.switchToId(this.activeId)
+      this.activateItem(this.activeId)
     }
   },
 
@@ -51,11 +53,14 @@ export default {
       this.items = this.collections_filterChildren('MenuNavigationItem') || []
     },
 
-    switchToId (id) {
-      this.items.forEach(item => item.toggle(item.id === id))
+    activateItem (itemId) {
+      this.items.forEach(item => item.toggle(item.id === itemId))
+      this.activeId = itemId
+    },
 
-      if (this.activeId !== id) {
-        this.activeId = id
+    switchToItem (itemId) {
+      if (this.activeId !== itemId) {
+        this.activateItem(itemId)
         this.$emit('input', this.activeId)
       }
     }

--- a/src/renderer/components/Menu/MenuNavigation/MenuNavigationItem.vue
+++ b/src/renderer/components/Menu/MenuNavigation/MenuNavigationItem.vue
@@ -43,7 +43,7 @@ import SvgIcon from '@/components/SvgIcon'
 export default {
   name: 'MenuNavigationItem',
 
-  inject: ['switchToId'],
+  inject: ['switchToItem'],
 
   components: {
     SvgIcon
@@ -93,7 +93,7 @@ export default {
   methods: {
     onClick () {
       if (this.canActivate) {
-        this.switchToId(this.id)
+        this.switchToItem(this.id)
       }
 
       this.$emit('click', this.id)

--- a/src/renderer/components/Wallet/WalletSidebar/WalletSidebar.vue
+++ b/src/renderer/components/Wallet/WalletSidebar/WalletSidebar.vue
@@ -365,6 +365,10 @@ export default {
     },
 
     onSelect (address) {
+      if (!address) {
+        throw new Error('Selecting an address is required')
+      }
+
       this.$router.push({ name: 'wallet-show', params: { address } })
       this.$emit('select', address)
     },
@@ -451,7 +455,7 @@ export default {
       if (!hasCurrentWallet || this.currentWallet.isLedger) {
         if (this.$refs.MenuNavigation && this.$route.name === 'wallet-show') {
           if (this.selectableWallets.length) {
-            this.$refs.MenuNavigation.switchToId(this.selectableWallets[0].address)
+            this.$refs.MenuNavigation.switchToItem(this.selectableWallets[0].address)
           } else {
             this.$router.push({ name: 'wallets' })
           }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->

Fixes https://github.com/ArkEcosystem/desktop-wallet/issues/1237

This measure avoids a subsequent race-condition that was pushing an additional
entry to the navigation history. The result was that, when navigating from the
wallet page to the profiles section, the route was ignored.
Since, it was trying to load a wallet page with no address, the router
was redirecting to the wallets section. So the history was:

 1 - /wallets/:address
 2 - /profiles
 3 - /wallets/:address (address = null)

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Does this PR release a new version?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch
- [x] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
