### PR TITLE
refactor: show tooltips only when value truncated

### DIFF
--- a/src/renderer/components/Wallet/WalletHeading/WalletHeadingInfo.vue
+++ b/src/renderer/components/Wallet/WalletHeading/WalletHeadingInfo.vue
@@ -31,14 +31,14 @@
         class="flex flex-row text-lg font-semibold text-theme-heading-text"
       >
         <span
+          v-tooltip="name.length > 12 ? name : ''"
           class="block xl:hidden"
-          v-tooltip="name"
         >
           {{ name | truncate(12) }}
         </span>
         <span
+          v-tooltip="name.length > 30 ? name : ''"
           class="hidden xl:block"
-          v-tooltip="name"
         >
           {{ name | truncate(30) }}
         </span>
@@ -53,13 +53,13 @@
 
       <p class="WalletHeading__address tracking-wide mb-3 flex items-center text-sm font-semibold">
         <span
-          v-tooltip="label"
+          v-tooltip="label.length > 12 ? label : ''"
           class="block xl:hidden"
         >
           {{ wallet_truncate(label, 12) }}
         </span>
         <span
-          v-tooltip="label"
+          v-tooltip="label.length > 40 ? label : ''"
           class="hidden xl:block"
         >
           {{ showPublicKey ? wallet_truncate(label, 40) : label }}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->

Extension of #1309. Only show a tooltip if the value is truncated.

A summary of what changes this PR introduces and why they were made.

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [x] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Does this PR release a new version?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch
- [x] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
