### PR TITLE
refactor: make complete back button clickable and use localized text

### DIFF
--- a/src/renderer/components/App/AppBackButton.vue
+++ b/src/renderer/components/App/AppBackButton.vue
@@ -13,7 +13,7 @@
       <span
         class="text-bold text-lg ml-2"
       >
-        Back
+        {{ $t('COMMON.BACK') }}
       </span>
     </button>
   </div>
@@ -45,9 +45,10 @@ export default {
 
 <style lang="postcss" scoped>
 .AppBackButton {
-  @apply .rounded-lg .py-4 .w-22 .mx-6
+  @apply .rounded-lg .w-22 .mx-6
 }
 .AppBackButton button {
+  @apply .py-4;
   transition: all .5s;
 }
 .AppBackButton:hover button {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->

Sets the padding on the back button itself rather than the container, thus making the complete button clickable. Also changes the text to use the localized string instead of the hardcoded `Back`.

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [x] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Does this PR release a new version?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch
- [x] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
