### PR TITLE
fix: localised timestamps in chart tooltips

### DIFF
--- a/src/renderer/components/MarketChart/MarketChart.vue
+++ b/src/renderer/components/MarketChart/MarketChart.vue
@@ -20,7 +20,7 @@
 </template>
 
 <script>
-import dayjs from 'dayjs'
+import moment from 'moment'
 import LineChart from '@/components/utils/LineChart'
 import Loader from '@/components/utils/Loader'
 import cryptoCompare from '@/services/crypto-compare'
@@ -251,6 +251,7 @@ export default {
 
                 if (this.period === 'day') {
                   const midnight = data.labels.indexOf('00:00')
+                  // title = this.formatHour(title)
                   if (index < midnight) {
                     return this.$t('MARKET_CHART.YESTERDAY_AT', { hour: title })
                   }
@@ -261,10 +262,7 @@ export default {
                   return this.$t(`MARKET_CHART.WEEK.LONG.${title.toUpperCase()}`)
                 } else {
                   const days = values.length
-                  const today = dayjs()
-                  today.date(values[days - 1])
-                  title = today.subtract(days - index - 1, 'day')
-                  return this.$d(title)
+                  return moment(new Date()).subtract(days - index - 1, 'days').format('L')
                 }
               }
             }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->

The tooltips of the market chart now show localised timestamps, i.e.

 - on the daily chart: respect the 12h/24h settings
 - on the monthly chart: format the date using the current locale

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Does this PR release a new version?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch
- [x] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
