### PR TITLE
feat: do not create wallet if fails encryption of password

### DIFF
--- a/src/renderer/pages/Wallet/mixin-on-create.js
+++ b/src/renderer/pages/Wallet/mixin-on-create.js
@@ -25,17 +25,23 @@ export default {
           wif: this.session_network.wif
         }
 
+        let failed = false
         const bip38 = new Bip38()
         try {
           const { bip38key } = await bip38.encrypt(dataToEncrypt)
           this.wallet.passphrase = bip38key
         } catch (_error) {
           this.$error(this.$t('ENCRYPTION.FAILED_ENCRYPT'))
+          failed = true
         } finally {
           bip38.quit()
         }
 
         this.showEncryptLoader = false
+
+        if (failed) {
+          return
+        }
       } else {
         this.wallet.passphrase = null
       }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->

There was a scenario where there was a problem with the crypto package on the develop branch. When importing or creating wallets with an Encryption Password, the wallets weren't being stored correctly. This would have caused problems because it would have resulted in not being able to send transactions from those wallets (would mean re-importing from the passphrase without an Encryption Password).

This change prevents wallets from being created when the password encryption fails (e.g. due to high load on a machine which can't talk to the BIP38 worker)

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Does this PR release a new version?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch
- [x] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
