### PR TITLE
feat: allow use of the loader spinner in plugins

### DIFF
--- a/src/renderer/services/plugin-manager.js
+++ b/src/renderer/services/plugin-manager.js
@@ -12,6 +12,7 @@ import * as CollapseComponents from '@/components/Collapse'
 import * as InputComponents from '@/components/Input'
 import * as ListDividedComponents from '@/components/ListDivided'
 import * as MenuComponents from '@/components/Menu'
+import Loader from '@/components/utils/Loader'
 
 let rootPath = path.resolve(__dirname, '../../../')
 if (process.env.NODE_ENV === 'production') {
@@ -649,6 +650,7 @@ class PluginManager {
         Collapse: CollapseComponents,
         Input: InputComponents,
         ListDivided: ListDividedComponents,
+        Loader,
         Menu: MenuComponents
       }
     }


### PR DESCRIPTION
Adds the ability to use the loader spinner in plugins via `<Loader />` like in other areas of the wallet if the `UI_COMPONENTS` permission is granted. I only exposed the `Loader` from `utils` as the other components in `utils` did not seem appropriate for plugins, although the PR can be revised to expose them as `UtilsComponents` if necessary.

Reason for adding: Plugins can communicate with external servers and these responses can sometimes take a while to be received. Showing the loading spinner provides visual feedback that the operation is ongoing and has not crashed. Using the wallet's spinner makes the design coherent and more native.

## What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Does this PR release a new version?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch
- [ ] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)