### PR TITLE
refactor: use spread operator instead of lodash's clone before updating profile

### DIFF
--- a/src/renderer/components/App/AppSidemenu/AppSidemenuSettings.vue
+++ b/src/renderer/components/App/AppSidemenu/AppSidemenuSettings.vue
@@ -158,7 +158,7 @@
 import { ModalConfirmation } from '@/components/Modal'
 import { MenuNavigationItem, MenuOptions, MenuOptionsItem, MenuDropdown } from '@/components/Menu'
 import { ButtonSwitch } from '@/components/Button'
-import { clone, isEmpty, isString } from 'lodash'
+import { isEmpty, isString } from 'lodash'
 const os = require('os')
 
 export default {
@@ -213,9 +213,11 @@ export default {
       },
       set (currency) {
         this.$store.dispatch('session/setCurrency', currency)
-        const profile = clone(this.session_profile)
-        profile.currency = currency
-        this.$store.dispatch('profile/update', profile)
+
+        this.$store.dispatch('profile/update', {
+          ...this.session_profile,
+          currency
+        })
       }
     },
     sessionBroadcastPeers: {
@@ -224,9 +226,11 @@ export default {
       },
       set (broadcast) {
         this.$store.dispatch('session/setBroadcastPeers', broadcast)
-        const profile = clone(this.session_profile)
-        profile.broadcastPeers = broadcast
-        this.$store.dispatch('profile/update', profile)
+
+        this.$store.dispatch('profile/update', {
+          ...this.session_profile,
+          broadcastPeers: broadcast
+        })
       }
     },
     sessionTheme: {
@@ -235,9 +239,11 @@ export default {
       },
       set (theme) {
         this.$store.dispatch('session/setTheme', theme)
-        const profile = clone(this.session_profile)
-        profile.theme = theme
-        this.$store.dispatch('profile/update', profile)
+
+        this.$store.dispatch('profile/update', {
+          ...this.session_profile,
+          theme
+        })
       }
     },
     hasScreenshotProtection: {
@@ -246,10 +252,12 @@ export default {
       },
       set (protection) {
         this.$store.dispatch('session/setScreenshotProtection', protection)
+
         if (!this.screenshotProtection || this.saveOnProfile) {
-          const profile = clone(this.session_profile)
-          profile.screenshotProtection = protection
-          this.$store.dispatch('profile/update', profile)
+          this.$store.dispatch('profile/update', {
+            ...this.session_profile,
+            screenshotProtection: protection
+          })
         }
       }
     },
@@ -262,9 +270,11 @@ export default {
       },
       set (update) {
         this.$store.dispatch('session/setBackgroundUpdateLedger', update)
-        const profile = clone(this.session_profile)
-        profile.backgroundUpdateLedger = update
-        this.$store.dispatch('profile/update', profile)
+
+        this.$store.dispatch('profile/update', {
+          ...this.session_profile,
+          backgroundUpdateLedger: update
+        })
       }
     },
     pluginThemes () {

--- a/src/renderer/components/Transaction/TransactionModal.vue
+++ b/src/renderer/components/Transaction/TransactionModal.vue
@@ -39,7 +39,7 @@
 </template>
 
 <script>
-import { camelCase, clone, includes, findKey, upperFirst } from 'lodash'
+import { camelCase, includes, findKey, upperFirst } from 'lodash'
 import { TRANSACTION_TYPES } from '@config'
 import WalletService from '@/services/wallet'
 import { ModalLoader, ModalWindow } from '@/components/Modal'
@@ -263,9 +263,14 @@ export default {
 
     updateLastFeeByType ({ fee, type }) {
       this.$store.dispatch('session/setLastFeeByType', { fee, type })
-      const profile = clone(this.session_profile)
-      profile.lastFees[type] = fee
-      this.$store.dispatch('profile/update', profile)
+
+      this.$store.dispatch('profile/update', {
+        ...this.session_profile,
+        lastFees: {
+          ...this.session_profile.lastFees,
+          [type]: fee
+        }
+      })
     }
   }
 }

--- a/src/renderer/components/Wallet/WalletDetails/WalletDetails.vue
+++ b/src/renderer/components/Wallet/WalletDetails/WalletDetails.vue
@@ -158,7 +158,7 @@
 
 <script>
 import electron from 'electron'
-import { at, clone } from 'lodash'
+import at from 'lodash/at'
 /* eslint-disable vue/no-unused-components */
 import { WalletSelectDelegate } from '@/components/Wallet'
 import { ButtonGeneric } from '@/components/Button'
@@ -293,9 +293,11 @@ export default {
       },
       set (votes) {
         this.$store.dispatch('session/setUnconfirmedVotes', votes)
-        const profile = clone(this.session_profile)
-        profile.unconfirmedVotes = votes
-        this.$store.dispatch('profile/update', profile)
+
+        this.$store.dispatch('profile/update', {
+          ...this.session_profile,
+          unconfirmedVotes: votes
+        })
       }
     },
 

--- a/src/renderer/components/Wallet/WalletHeading/WalletHeadingMenuLedger.vue
+++ b/src/renderer/components/Wallet/WalletHeading/WalletHeadingMenuLedger.vue
@@ -48,7 +48,6 @@
 import ModalAdditionalLedgers from '@/components/Modal/ModalAdditionalLedgers'
 import { MenuOptions, MenuOptionsItem } from '@/components/Menu'
 import { ButtonSwitch } from '@/components/Button'
-import { clone } from 'lodash'
 
 export default {
   name: 'AppSidemenuOptionsSettings',
@@ -90,9 +89,12 @@ export default {
       },
       set (enabled) {
         this.$store.dispatch('session/setLedgerCache', enabled)
-        const profile = clone(this.session_profile)
-        profile.ledgerCache = enabled
-        this.$store.dispatch('profile/update', profile)
+
+        this.$store.dispatch('profile/update', {
+          ...this.session_profile,
+          ledgerCache: enabled
+        })
+
         if (enabled) {
           this.$store.dispatch('ledger/cacheWallets')
         } else {

--- a/src/renderer/components/Wallet/WalletSidebar/WalletSidebar.vue
+++ b/src/renderer/components/Wallet/WalletSidebar/WalletSidebar.vue
@@ -324,12 +324,12 @@ export default {
         return this.$store.getters['session/walletSidebarSortParams'] ||
           { field: 'name', type: 'asc' }
       },
-      set (params) {
-        this.$store.dispatch('session/setWalletSidebarSortParams', params)
+      set (sortParams) {
+        this.$store.dispatch('session/setWalletSidebarSortParams', sortParams)
 
         this.$store.dispatch('profile/update', {
           ...this.session_profile,
-          walletSidebarSortParams: params
+          walletSidebarSortParams: sortParams
         })
       }
     }

--- a/src/renderer/components/Wallet/WalletSidebar/WalletSidebar.vue
+++ b/src/renderer/components/Wallet/WalletSidebar/WalletSidebar.vue
@@ -204,7 +204,7 @@
 </template>
 
 <script>
-import { clone, filter, sortBy, uniqBy } from 'lodash'
+import { filter, sortBy, uniqBy } from 'lodash'
 import Loader from '@/components/utils/Loader'
 import { MenuNavigation, MenuNavigationItem } from '@/components/Menu'
 import { WalletIdenticon, WalletIdenticonPlaceholder } from '../'
@@ -311,9 +311,11 @@ export default {
       },
       set (filters) {
         this.$store.dispatch('session/setWalletSidebarFilters', filters)
-        const profile = clone(this.session_profile)
-        profile.walletSidebarFilters = filters
-        this.$store.dispatch('profile/update', profile)
+
+        this.$store.dispatch('profile/update', {
+          ...this.session_profile,
+          walletSidebarFilters: filters
+        })
       }
     },
 
@@ -324,9 +326,11 @@ export default {
       },
       set (params) {
         this.$store.dispatch('session/setWalletSidebarSortParams', params)
-        const profile = clone(this.session_profile)
-        profile.walletSidebarSortParams = params
-        this.$store.dispatch('profile/update', profile)
+
+        this.$store.dispatch('profile/update', {
+          ...this.session_profile,
+          walletSidebarSortParams: params
+        })
       }
     }
   },

--- a/src/renderer/components/Wallet/WalletTransactions/WalletTransactions.vue
+++ b/src/renderer/components/Wallet/WalletTransactions/WalletTransactions.vue
@@ -27,7 +27,7 @@
 </template>
 
 <script>
-import { at, clone } from 'lodash'
+import at from 'lodash/at'
 import mergeTableTransactions from '@/components/utils/merge-table-transactions'
 import TransactionTable from '@/components/Transaction/TransactionTable'
 
@@ -64,9 +64,11 @@ export default {
       },
       set (count) {
         this.$store.dispatch('session/setTransactionTableRowCount', count)
-        const profile = clone(this.session_profile)
-        profile.transactionTableRowCount = count
-        this.$store.dispatch('profile/update', profile)
+
+        this.$store.dispatch('profile/update', {
+          ...this.session_profile,
+          transactionTableRowCount: count
+        })
       }
     }
   },

--- a/src/renderer/pages/Contact/ContactAll.vue
+++ b/src/renderer/pages/Contact/ContactAll.vue
@@ -94,7 +94,7 @@
 </template>
 
 <script>
-import { clone, some } from 'lodash'
+import some from 'lodash/some'
 import { ButtonLayout } from '@/components/Button'
 import { ContactRemovalConfirmation, ContactRenameModal } from '@/components/Contact'
 import { WalletGrid, WalletIdenticonPlaceholder } from '@/components/Wallet'
@@ -135,9 +135,11 @@ export default {
       },
       set (layout) {
         this.$store.dispatch('session/setWalletLayout', layout)
-        const profile = clone(this.session_profile)
-        profile.walletLayout = layout
-        this.$store.dispatch('profile/update', profile)
+
+        this.$store.dispatch('profile/update', {
+          ...this.session_profile,
+          walletLayout: layout
+        })
       }
     },
 
@@ -147,9 +149,11 @@ export default {
       },
       set (sortParams) {
         this.$store.dispatch('session/setContactSortParams', sortParams)
-        const profile = clone(this.session_profile)
-        profile.contactSortParams = sortParams
-        this.$store.dispatch('profile/update', profile)
+
+        this.$store.dispatch('profile/update', {
+          ...this.session_profile,
+          contactSortParams: sortParams
+        })
       }
     },
 

--- a/src/renderer/pages/Dashboard.vue
+++ b/src/renderer/pages/Dashboard.vue
@@ -52,7 +52,6 @@
 import { DashboardTransactions } from '@/components/Dashboard'
 import { MarketChart, MarketChartHeader } from '@/components/MarketChart'
 import { WalletSidebar, WalletButtonCreate, WalletButtonImport } from '@/components/Wallet'
-import { clone } from 'lodash'
 import store from '@/store'
 
 export default {
@@ -95,9 +94,11 @@ export default {
       },
       set (options) {
         this.$store.dispatch('session/setMarketChartOptions', options)
-        const profile = clone(this.session_profile)
-        profile.marketChartOptions = options
-        this.$store.dispatch('profile/update', profile)
+
+        this.$store.dispatch('profile/update', {
+          ...this.session_profile,
+          marketChartOptions: options
+        })
       }
     }
   },

--- a/src/renderer/pages/Plugins.vue
+++ b/src/renderer/pages/Plugins.vue
@@ -75,7 +75,7 @@
 
 <script>
 import electron from 'electron'
-import { clone, sortBy } from 'lodash'
+import sortBy from 'lodash/sortBy'
 import { PLUGINS } from '@config'
 import { PluginEnableConfirmation, PluginTable } from '@/components/Plugin'
 import SvgIcon from '@/components/SvgIcon'
@@ -117,9 +117,11 @@ export default {
       },
       set (sortParams) {
         this.$store.dispatch('session/setPluginSortParams', sortParams)
-        const profile = clone(this.session_profile)
-        profile.pluginSortParams = sortParams
-        this.$store.dispatch('profile/update', profile)
+
+        this.$store.dispatch('profile/update', {
+          ...this.session_profile,
+          pluginSortParams: sortParams
+        })
       }
     }
   },

--- a/src/renderer/pages/Wallet/WalletAll.vue
+++ b/src/renderer/pages/Wallet/WalletAll.vue
@@ -140,7 +140,7 @@
 </template>
 
 <script>
-import { clone, some, uniqBy } from 'lodash'
+import { some, uniqBy } from 'lodash'
 import { ButtonLayout } from '@/components/Button'
 import Loader from '@/components/utils/Loader'
 import { ProfileAvatar } from '@/components/Profile'
@@ -235,9 +235,11 @@ export default {
       },
       set (layout) {
         this.$store.dispatch('session/setWalletLayout', layout)
-        const profile = clone(this.session_profile)
-        profile.walletLayout = layout
-        this.$store.dispatch('profile/update', profile)
+
+        this.$store.dispatch('profile/update', {
+          ...this.session_profile,
+          walletLayout: layout
+        })
       }
     },
 
@@ -247,9 +249,11 @@ export default {
       },
       set (params) {
         this.$store.dispatch('session/setWalletSortParams', params)
-        const profile = clone(this.session_profile)
-        profile.walletSortParams = params
-        this.$store.dispatch('profile/update', profile)
+
+        this.$store.dispatch('profile/update', {
+          ...this.session_profile,
+          walletSortParams: params
+        })
       }
     },
 

--- a/src/renderer/pages/Wallet/WalletAll.vue
+++ b/src/renderer/pages/Wallet/WalletAll.vue
@@ -247,12 +247,12 @@ export default {
       get () {
         return this.$store.getters['session/walletSortParams']
       },
-      set (params) {
-        this.$store.dispatch('session/setWalletSortParams', params)
+      set (sortParams) {
+        this.$store.dispatch('session/setWalletSortParams', sortParams)
 
         this.$store.dispatch('profile/update', {
           ...this.session_profile,
-          walletSortParams: params
+          walletSortParams: sortParams
         })
       }
     },

--- a/src/renderer/services/synchronizer/wallets.js
+++ b/src/renderer/services/synchronizer/wallets.js
@@ -1,4 +1,4 @@
-import { clone, find, groupBy, keyBy, map, maxBy, partition, uniqBy } from 'lodash'
+import { find, groupBy, keyBy, map, maxBy, partition, uniqBy } from 'lodash'
 import config from '@config'
 import eventBus from '@/plugins/event-bus'
 import truncateMiddle from '@/filters/truncate-middle'
@@ -311,9 +311,10 @@ class Action {
 
     this.$dispatch('session/setUnconfirmedVotes', filteredVotes)
 
-    const profile = clone(this.profile)
-    profile.unconfirmedVotes = filteredVotes
-    this.$dispatch('profile/update', profile)
+    this.$dispatch('profile/update', {
+      ...this.profile,
+      unconfirmedVotes: filteredVotes
+    })
   }
 
   // TODO use the eventBus to display transactions


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->

Instead of using lodash's `clone` method this PR relies on the spread operator to perfom shallow clones of the profile object before updating it.

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [x] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Does this PR release a new version?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch
- [x] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
