### PR TITLE
fix: truncate wallet name in grid view, scroll on InputText and reload wallets after rename

### DIFF
--- a/src/renderer/components/Input/InputText.vue
+++ b/src/renderer/components/Input/InputText.vue
@@ -190,7 +190,7 @@ export default {
 
 <style lang="postcss" scoped>
 .InputText__input {
-  @apply bg-transparent text-theme-page-text
+  @apply .bg-transparent .text-theme-page-text .h-full
 }
 
 .InputText__input::placeholder {

--- a/src/renderer/components/Wallet/WalletGrid.vue
+++ b/src/renderer/components/Wallet/WalletGrid.vue
@@ -39,7 +39,12 @@
                     }"
                     class="WalletGrid__wallet__name font-semibold text-base truncate block pr-1"
                   >
-                    {{ wallet.name || wallet_name(wallet.address) || wallet_truncate(wallet.address) }}
+                    <template v-if="wallet.name">
+                      {{ wallet.name | truncate(20) }}
+                    </template>
+                    <template v-else>
+                      {{ wallet_name(wallet.address) || wallet_truncate(wallet.address) }}
+                    </template>
                   </span>
                   <span
                     v-if="wallet.isLedger"

--- a/src/renderer/pages/Wallet/WalletAll.vue
+++ b/src/renderer/pages/Wallet/WalletAll.vue
@@ -349,7 +349,7 @@ export default {
 
     onWalletRenamed () {
       this.hideRenameModal()
-      this.selectableWallets = this.wallets
+      this.loadWallets()
     },
 
     onSortChange (sortParams) {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->

- truncates the wallet name on the wallet grid view
- stops scrolling on InputText component
- reloads all wallets after renaming a wallet (previously the Ledger wallets would disappear)
- ~removes the additional space between currency symbol and value which is added by `vue-i18n`~

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Does this PR release a new version?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch
- [x] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
