### PR TITLE
fix: screenshot protection

### DIFF
--- a/src/renderer/components/App/AppSidemenu/AppSidemenuSettings.vue
+++ b/src/renderer/components/App/AppSidemenu/AppSidemenuSettings.vue
@@ -136,8 +136,8 @@
           :continue-button="$t('APP_SIDEMENU.SETTINGS.SCREENSHOT_PROTECTION.PERMANENTLY')"
           container-classes="max-w-md"
           @close="toggleScreenshotProtectionModal"
-          @cancel="onToggleScreenshotProtection"
-          @continue="onToggleScreenshotProtection(true)"
+          @cancel="onDisableScreenshotProtection"
+          @continue="onDisableScreenshotProtection(true)"
         />
 
         <ModalConfirmation
@@ -337,7 +337,7 @@ export default {
       this.electron_reload()
     },
 
-    onToggleScreenshotProtection (saveOnProfile = false) {
+    onDisableScreenshotProtection (saveOnProfile = false) {
       this.saveOnProfile = saveOnProfile
       this.hasScreenshotProtection = false
       this.toggleScreenshotProtectionModal()

--- a/src/renderer/components/App/AppSidemenu/AppSidemenuSettings.vue
+++ b/src/renderer/components/App/AppSidemenu/AppSidemenuSettings.vue
@@ -253,7 +253,7 @@ export default {
       set (protection) {
         this.$store.dispatch('session/setScreenshotProtection', protection)
 
-        if (!this.screenshotProtection || this.saveOnProfile) {
+        if (protection || this.saveOnProfile) {
           this.$store.dispatch('profile/update', {
             ...this.session_profile,
             screenshotProtection: protection


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->

Fixes a bug where disabling the protection is saved regardless of if it's for the local session or permanent. 

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Does this PR release a new version?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch
- [x] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
