### PR TITLE
fix: port used from github peer list

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@arkecosystem/client": "^1.0.1",
     "@arkecosystem/crypto": "^2.5.7",
     "@arkecosystem/ledger-transport": "^0.1.0",
-    "@arkecosystem/peers": "^0.2.0",
+    "@arkecosystem/peers": "^0.2.1",
     "@babel/runtime": "^7.4.2",
     "@fortawesome/fontawesome-svg-core": "^1.2.21",
     "@fortawesome/free-solid-svg-icons": "^5.10.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -57,10 +57,10 @@
     "@ledgerhq/hw-transport" "^4.7.3"
     babel-runtime "^6.26.0"
 
-"@arkecosystem/peers@^0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@arkecosystem/peers/-/peers-0.2.0.tgz#ba69af987355d64d3e632b4acae3b64917264199"
-  integrity sha512-dnk12Ghkrerh8Y55F2rTUIlluKAeVu0pguTFVrtDgsnKn4bo4H1UKi3HYrwYuuH7knQaURMtMtu+dw7esChuTA==
+"@arkecosystem/peers@^0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@arkecosystem/peers/-/peers-0.2.1.tgz#980c56dd20cb91afef16985e83af92f7bbaceea1"
+  integrity sha512-26qdArNjgX2nJEiVQOaAVd2taA3y4HNGTyzj/4/7Zu7n8QTn2PDDjn2zOdWNeKeMMDQFmnBYHrPtGjOWONLOWQ==
   dependencies:
     got "^9.6.0"
     is-url-superb "^3.0.0"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->

On a fresh setup of the desktop wallet, the peer list is pulled from GitHub. This peer list only contains the p2p port. Version 0.2.0 of `@arkecosystem/peers` took the p2p port as the public API port, which is incorrect.

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Does this PR release a new version?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch
- [x] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
