### PR TITLE
feat: timers in plugins

### DIFF
--- a/__tests__/unit/services/plugin-manager/timers.spec.js
+++ b/__tests__/unit/services/plugin-manager/timers.spec.js
@@ -1,0 +1,103 @@
+import PluginManager from '@/services/plugin-manager'
+
+const routerNext = jest.fn()
+let router
+let sandboxWithTimers
+let sandboxWithoutTimers
+
+beforeEach(() => {
+  const routeCallbacks = []
+  PluginManager.app = {
+    $router: {
+      beforeEach: jest.fn(callback => {
+        routeCallbacks.push(callback)
+      }),
+
+      push () {
+        for (const callback of routeCallbacks) {
+          callback(null, null, routerNext)
+        }
+      }
+    }
+  }
+  router = PluginManager.app.$router
+
+  sandboxWithTimers = PluginManager.loadSandbox({ permissions: ['TIMERS'] })
+  sandboxWithoutTimers = PluginManager.loadSandbox({ permissions: [] })
+})
+
+describe('Timers', () => {
+  it('should not expose functions without TIMERS permission', () => {
+    expect(sandboxWithoutTimers.walletApi.timers).toEqual(undefined)
+  })
+
+  it('should expose functions with TIMERS permission', () => {
+    expect(sandboxWithTimers.walletApi.timers.clearInterval).toBeTruthy()
+    expect(sandboxWithTimers.walletApi.timers.clearTimeout).toBeTruthy()
+    expect(sandboxWithTimers.walletApi.timers.setInterval).toBeTruthy()
+    expect(sandboxWithTimers.walletApi.timers.setTimeout).toBeTruthy()
+  })
+
+  it('should clear timer once setTimeout executed', (done) => {
+    sandboxWithTimers.walletApi.timers.setTimeout(() => {
+      console.log('This is an execution of setTimeout')
+      setTimeout(() => {
+        expect(sandboxWithTimers.walletApi.timers.timeouts.length).toEqual(0)
+
+        done()
+      }, 100)
+    }, 1000)
+    expect(sandboxWithTimers.walletApi.timers.timeouts.length).toEqual(1)
+  })
+
+  it('should clear timer if clearTimeout called', (done) => {
+    expect(sandboxWithTimers.walletApi.timers.timeouts.length).toEqual(0)
+    const id = sandboxWithTimers.walletApi.timers.setTimeout(() => {
+      console.log('This setTimeout call will never execute')
+    }, 1000)
+    sandboxWithTimers.walletApi.timers.setTimeout(() => {
+      console.log('This is an execution of setTimeout')
+
+      done()
+    }, 1000)
+    expect(sandboxWithTimers.walletApi.timers.timeouts.length).toEqual(2)
+    sandboxWithTimers.walletApi.timers.clearTimeout(id)
+    expect(sandboxWithTimers.walletApi.timers.timeouts.length).toEqual(1)
+  })
+
+  it('should clear timer if clearInterval called', (done) => {
+    expect(sandboxWithTimers.walletApi.timers.intervals.length).toEqual(0)
+    let counter = 0
+    const id = sandboxWithTimers.walletApi.timers.setInterval(() => {
+      counter++
+      console.log(`This is execution #${counter} of setInterval`)
+      if (counter === 5) {
+        sandboxWithTimers.walletApi.timers.clearInterval(id)
+        setTimeout(() => {
+          expect(sandboxWithTimers.walletApi.timers.intervals.length).toEqual(0)
+          expect(counter).toEqual(5)
+          done()
+        }, 500)
+      }
+    }, 100)
+    expect(sandboxWithTimers.walletApi.timers.intervals.length).toEqual(1)
+  })
+
+  it('should clear timers on route change', () => {
+    sandboxWithTimers.walletApi.timers.setTimeout(() => {
+      console.log('This setTimeout call will never execute')
+    }, 10000)
+
+    sandboxWithTimers.walletApi.timers.setInterval(() => {
+      console.log('This setInterval call will never execute')
+    }, 10000)
+
+    expect(sandboxWithTimers.walletApi.timers.timeouts.length).toEqual(1)
+    expect(sandboxWithTimers.walletApi.timers.intervals.length).toEqual(1)
+    expect(router.beforeEach).toHaveBeenCalledTimes(1)
+    router.push()
+    expect(routerNext).toHaveBeenCalledTimes(1)
+    expect(sandboxWithTimers.walletApi.timers.timeouts.length).toEqual(0)
+    expect(sandboxWithTimers.walletApi.timers.intervals.length).toEqual(0)
+  })
+})

--- a/src/renderer/services/plugin-manager.js
+++ b/src/renderer/services/plugin-manager.js
@@ -742,22 +742,20 @@ class PluginManager {
           return timerArrays.timeouts
         },
 
-        setInterval (...args) {
-          const functionArgs = args.splice(2)
+        setInterval (method, interval, ...args) {
           const id = setInterval(function () {
-            args[0](...functionArgs)
-          }, args[1])
+            method(...args)
+          }, interval)
           timerArrays.intervals.push(id)
           return id
         },
 
-        setTimeout (...args) {
-          const functionArgs = args.splice(2)
+        setTimeout (method, interval, ...args) {
           const id = setTimeout(function () {
-            args[0](...functionArgs)
-          }, args[1])
+            method(...args)
+          }, interval)
           timerArrays.timeouts.push(id)
-          timerArrays.timeoutWatchdog[id] = setTimeout(() => timers.clearTimeout(id), args[1])
+          timerArrays.timeoutWatchdog[id] = setTimeout(() => timers.clearTimeout(id), interval)
           return id
         }
       }

--- a/src/renderer/services/plugin-manager.js
+++ b/src/renderer/services/plugin-manager.js
@@ -743,13 +743,19 @@ class PluginManager {
         },
 
         setInterval (...args) {
-          const id = setInterval(...args)
+          const functionArgs = args.splice(2)
+          const id = setInterval(function () {
+            args[0](...functionArgs)
+          }, args[1])
           timerArrays.intervals.push(id)
           return id
         },
 
         setTimeout (...args) {
-          const id = setTimeout(...args)
+          const functionArgs = args.splice(2)
+          const id = setTimeout(function () {
+            args[0](...functionArgs)
+          }, args[1])
           timerArrays.timeouts.push(id)
           timerArrays.timeoutWatchdog[id] = setTimeout(() => timers.clearTimeout(id), args[1])
           return id


### PR DESCRIPTION
Resolves #1446 by implementing a `TIMERS` permission that exposes `clearInterval`, `clearTimeout`, `setInterval` and `setTimeout`.

It uses internal arrays to store the IDs of any timeouts and intervals to make sure they are all cleared once the route navigation changes and it also works with nested timers. A watchdog object is used to keep track of pending timeouts so they are immediately removed from the array once executed in order to prevent excessive memory usage that could potentially arise by repeatedly executing timeouts. The IDs are also removed from their respective arrays when `clearInterval` or `clearTimeout` are called. It also includes appropriate tests.

The reason for adding the feature was outlined in #1446.

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Does this PR release a new version?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch
- [x] All tests are passing
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
