### PR TITLE
refactor: custom network during onboarding

### DIFF
--- a/src/renderer/components/Selection/SelectionNetwork.vue
+++ b/src/renderer/components/Selection/SelectionNetwork.vue
@@ -12,6 +12,15 @@
     />
 
     <SelectionNetworkButton
+      v-if="addButton"
+      :show-title="false"
+      tag="div"
+      class="flex-none"
+      network-image="networks/add.svg"
+      @click="toggleAddNetwork"
+    />
+
+    <SelectionNetworkButton
       v-if="othersNetworks.length"
       :class="isOtherSelected ? 'SelectionNetworkButton--selected' : null"
       class="SelectionNetworkButton"
@@ -27,6 +36,14 @@
       </div>
     </SelectionNetworkButton>
 
+    <NetworkModal
+      v-if="showAddNetwork"
+      :title="$t('PAGES.NETWORK_OVERVIEW.NEW_NETWORK')"
+      @cancel="toggleAddNetwork"
+      @saved="toggleAddNetwork"
+      @removed="toggleAddNetwork"
+    />
+
     <NetworkSelectionModal
       v-if="isModalOpen"
       :toggle="closeModal"
@@ -37,7 +54,7 @@
 </template>
 
 <script>
-import { NetworkSelectionModal } from '@/components/Network'
+import { NetworkModal, NetworkSelectionModal } from '@/components/Network'
 import SelectionNetworkButton from './SelectionNetworkButton'
 import { pullAllBy } from 'lodash'
 
@@ -48,6 +65,7 @@ export default {
   buttonClasses: '',
 
   components: {
+    NetworkModal,
     NetworkSelectionModal,
     SelectionNetworkButton
   },
@@ -71,11 +89,17 @@ export default {
       type: Boolean,
       required: false,
       default: false
+    },
+    addButton: {
+      type: Boolean,
+      required: false,
+      default: false
     }
   },
 
   data: () => ({
-    isModalOpen: false
+    isModalOpen: false,
+    showAddNetwork: false
   }),
 
   computed: {
@@ -104,6 +128,10 @@ export default {
 
     closeModal () {
       this.isModalOpen = false
+    },
+
+    toggleAddNetwork () {
+      this.showAddNetwork = !this.showAddNetwork
     }
   }
 }

--- a/src/renderer/pages/Profile/ProfileNew.vue
+++ b/src/renderer/pages/Profile/ProfileNew.vue
@@ -111,20 +111,20 @@
                 :networks="defaultNetworks"
                 @select="selectNetwork"
               />
-              <div v-if="availableCustomNetworks.length">
-                <p class="mt-5 mb-1 text-theme-page-text font-semibold">
-                  {{ $t('PAGES.PROFILE_NEW.STEP2.CUSTOM_NETWORK') }}
-                </p>
-                <p class="text-theme-page-text-light mb-5">
-                  {{ $t('PAGES.PROFILE_NEW.STEP2.CUSTOM_NETWORK_EXPLAIN') }}
-                </p>
-                <SelectionNetwork
-                  :selected="selectedNetwork"
-                  :networks="availableCustomNetworks"
-                  :is-custom="true"
-                  @select="selectNetwork"
-                />
-              </div>
+
+              <p class="mt-5 mb-1 text-theme-page-text font-semibold">
+                {{ $t('PAGES.PROFILE_NEW.STEP2.CUSTOM_NETWORK') }}
+              </p>
+              <p class="text-theme-page-text-light mb-5">
+                {{ $t('PAGES.PROFILE_NEW.STEP2.CUSTOM_NETWORK_EXPLAIN') }}
+              </p>
+              <SelectionNetwork
+                :selected="selectedNetwork"
+                :networks="availableCustomNetworks"
+                :is-custom="true"
+                :add-button="true"
+                @select="selectNetwork"
+              />
             </div>
           </MenuStepItem>
 

--- a/src/renderer/services/client.js
+++ b/src/renderer/services/client.js
@@ -38,7 +38,7 @@ export default class ClientService {
     const data = response.body.data
 
     const currentNetwork = store.getters['session/network']
-    if (currentNetwork.nethash === data.nethash) {
+    if (currentNetwork && currentNetwork.nethash === data.nethash) {
       const newLength = data.constants.vendorFieldLength
 
       if (newLength && (!currentNetwork.vendorField || newLength !== currentNetwork.vendorField.maxLength)) {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

When first creating a profile there is no option to add a custom network, which might be required for testing purposes or to connect to a bridgechain. Instead, the user is forced to choose one of the predefined ARK networks and is given the option to create a custom network only then.

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
