### PR TITLE
fix: provide default port when adding custom network

### DIFF
--- a/src/renderer/components/App/AppSidemenu/AppSidemenuNetworkStatus.vue
+++ b/src/renderer/components/App/AppSidemenu/AppSidemenuNetworkStatus.vue
@@ -212,7 +212,7 @@ export default {
       }
 
       return bestPeers.reduce((map, peer, index) => {
-        map[index] = `http://${peer.ip}`
+        map[index] = `${peer.isHttps ? 'https' : 'http'}://${peer.ip}`
 
         return map
       }, {})

--- a/src/renderer/components/Network/NetworkModal.vue
+++ b/src/renderer/components/Network/NetworkModal.vue
@@ -422,7 +422,7 @@ export default {
     async validateSeed () {
       this.showLoadingModal = true
 
-      let { href: host, port, protocol } = new URL(this.form.server)
+      let { origin: host, port, protocol } = new URL(this.form.server)
 
       if (!port) {
         port = protocol === 'https:' ? 443 : 80

--- a/src/renderer/components/Network/NetworkModal.vue
+++ b/src/renderer/components/Network/NetworkModal.vue
@@ -422,9 +422,11 @@ export default {
     async validateSeed () {
       this.showLoadingModal = true
 
-      const matches = /(https?:\/\/[a-zA-Z0-9.-_]+):([0-9]+)/.exec(this.form.server)
-      const host = matches[1]
-      const port = matches[2]
+      let { href: host, port, protocol } = new URL(this.form.server)
+
+      if (!port) {
+        port = protocol === 'https:' ? 443 : 80
+      }
 
       const response = await this.$store.dispatch('peer/validatePeer', {
         host,
@@ -470,8 +472,14 @@ export default {
       customNetwork.knownWallets = {}
 
       if (this.showFull && this.hasFetched) {
-        const { hostname: ip, port, protocol } = new URL(this.form.server)
+        let { hostname: ip, port, protocol } = new URL(this.form.server)
+
         const isHttps = protocol === 'https:'
+
+        if (!port) {
+          port = isHttps ? 443 : 80
+        }
+
         const peer = {
           version: '0',
           height: 0,
@@ -480,6 +488,7 @@ export default {
           ip,
           isHttps
         }
+
         await this.$store.dispatch('network/addCustomNetwork', customNetwork)
         await this.$store.dispatch('peer/setToNetwork', { peers: [peer], networkId: customNetwork.id })
       } else {

--- a/src/renderer/services/client.js
+++ b/src/renderer/services/client.js
@@ -462,16 +462,12 @@ export default class ClientService {
     const matches = /(https?:\/\/)([a-zA-Z0-9.-_]+):([0-9]+)/.exec(this.host)
     const scheme = matches[1]
     const ip = matches[2]
-    const isHttps = scheme === 'https://'
-    let port = isHttps ? 443 : 80
-    if (matches[3]) {
-      port = matches[3]
-    }
+    const port = matches[3]
 
     return {
       ip,
       port,
-      isHttps
+      isHttps: scheme === 'https://'
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->


## Summary

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

Adding a custom network fails if the seed server has no port. This PR provides default values if the port is missing.

Regarding the changes made to: 
```
__parseCurrentPeer () {
    const matches = /(https?:\/\/)([a-zA-Z0-9.-_]+):([0-9]+)/.exec(this.host)
    const scheme = matches[1]
    const ip = matches[2]
    const isHttps = scheme === 'https://'
    let port = isHttps ? 443 : 80
    if (matches[3]) {
      port = matches[3]
    }

    return {
      ip,
      port,
      isHttps
    }
```

If `this.host` contains no port, `matches` is `null` and `const scheme = matches[1]` throws a type error. Checking against `matches[3]` afterwards is useless at this point.

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
