### PR TITLE
ci: set shell to `cmd` on windows build steps

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -140,9 +140,11 @@ jobs:
 
       - name: Install
         run: yarn global add node-gyp && yarn install --frozen-lockfile && npm rebuild
+        shell: cmd
 
       - name: Build
         run: node .electron-vue/build.js && node ./node_modules/electron-builder/out/cli/cli.js --win --x64 --ia32
+        shell: cmd
 
       - name: Upload .exe
         uses: actions/upload-artifact@master


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

The default shell for windows has changed to PowerShell, causing the build steps to fail.

See https://github.blog/changelog/2019-10-17-github-actions-default-shell-on-windows-runners-is-changing-to-powershell/

This PR sets the shell to `cmd` instead.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
