### PR TITLE
refactor(plugins): support ark uri scheme in webframes

### DIFF
--- a/__tests__/unit/components/utils/WebFrame.spec.js
+++ b/__tests__/unit/components/utils/WebFrame.spec.js
@@ -24,6 +24,16 @@ describe('WebFrame', () => {
     expect(webview.attributes('preload')).toBeTruthy()
   })
 
+  it('should accept ark uri', () => {
+    const wrapper = mount(WebFrame, {
+      propsData: {
+        src: 'ark:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+      }
+    })
+    const webview = wrapper.find('webview')
+    expect(webview.attributes('src')).toBe('ark:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA')
+  })
+
   it('should render http url', () => {
     const wrapper = mount(WebFrame, {
       propsData: {

--- a/src/renderer/components/utils/WebFrame.js
+++ b/src/renderer/components/utils/WebFrame.js
@@ -3,6 +3,7 @@ import logger from 'electron-log'
 import path from 'path'
 
 const allowedProtocols = [
+  'ark:',
   'http:',
   'https:'
 ]


### PR DESCRIPTION
Resolves #1525 by allowing webframes to access `ark:` URIs.

This will allow plugins that are effectively thin clients that render content in WebFrames to create transactions for in-plugin purchases or similar transactions, whose webframe content would not be able to directly access or manipulate modals (assuming modal support will be added to the plugin sandbox in future).

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged