### PR TITLE
fix: parse uri

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -115,12 +115,12 @@ if (!gotTheLock) {
   app.on('second-instance', (_, argv) => {
     // Someone tried to run a second instance, we should focus our window.
     // argv: An array of the second instance’s (command line / deep linked) arguments
-    if (process.platform === 'linux') {
-      deeplinkingUrl = argv[1]
-      broadcastURL(deeplinkingUrl)
-    } else if (process.platform !== 'darwin') {
-      deeplinkingUrl = argv[2]
-      broadcastURL(deeplinkingUrl)
+    for (const arg of argv) {
+      if (arg.startsWith('ark:')) {
+        deeplinkingUrl = arg
+        broadcastURL(deeplinkingUrl)
+        break
+      }
     }
 
     if (mainWindow) {
@@ -131,12 +131,12 @@ if (!gotTheLock) {
     }
   })
 
-  if (process.platform === 'linux') {
-    deeplinkingUrl = process.argv[1]
-    broadcastURL(deeplinkingUrl)
-  } else if (process.platform !== 'darwin') {
-    deeplinkingUrl = process.argv[2]
-    broadcastURL(deeplinkingUrl)
+  for (const arg of process.argv) {
+    if (arg.startsWith('ark:')) {
+      deeplinkingUrl = arg
+      broadcastURL(deeplinkingUrl)
+      break
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

The issue in #1520 only occurred if the desktop wallet was already open (i.e. the `second-instance` event was called). It was caused by `--original-process-start-time` being added as `argv[2]` on Windows systems, meaning the URI handler received that string instead of the actual URI. Presumably there was a change to Electron or Chromium to either add that switch or it rearranged the order they were presented in `argv`.

This PR resolves #1520 by iterating through all the `argv` array elements to find the URI. This should be more resilient in case any future Electron/Chromium changes modify the order again.

Now works for me on Linux, macOS and Windows both when the wallet is closed and when it's already open.

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
