### PR TITLE
feat: specify sender wallet and nethash in uri

### DIFF
--- a/__tests__/unit/services/client.spec.js
+++ b/__tests__/unit/services/client.spec.js
@@ -12,6 +12,18 @@ jest.mock('@/store', () => ({
         epoch: '2017-03-21T13:00:00.000Z'
       }
     },
+    'network/byId': (id) => {
+      let version = 23
+      if (id === 'ark.devnet') {
+        version = 30
+      }
+      return {
+        constants: {
+          epoch: '2017-03-21T13:00:00.000Z'
+        },
+        version
+      }
+    },
     'delegate/byAddress': (address) => {
       if (address === 'DTRdbaUW3RQQSL5By4G43JVaeHiqfVp9oh') {
         return {
@@ -552,6 +564,14 @@ describe('Services > Client', () => {
   })
 
   describe('buildTransfer', () => {
+    describe('when a custom network is specified', () => {
+      it('should have the correct version', async () => {
+        const networkId = 'ark.devnet'
+        const transaction = await client.buildTransfer({ fee: new BigNumber(fees[0]), networkId }, false, true)
+        expect(transaction.data.network).toBe(30)
+      })
+    })
+
     describe('when the fee is bigger than the static fee', () => {
       it('should throw an Error', async () => {
         const fee = new BigNumber(fees[0] + 1)

--- a/__tests__/unit/services/uri-handler.spec.js
+++ b/__tests__/unit/services/uri-handler.spec.js
@@ -31,15 +31,17 @@ describe('URI Handler', () => {
   describe('deserialize', () => {
     it('should contain keys', () => {
       const schema = new URIHandler('ark:DNjuJEDQkhrJ7cA9FZ2iVXt5anYiM8Jtc9').deserialize()
-      expect(schema).toContainAllKeys(['address', 'amount', 'label', 'vendorField'])
+      expect(schema).toContainAllKeys(['address', 'amount', 'label', 'nethash', 'vendorField', 'wallet'])
     })
 
     it('should fill params', () => {
-      const schema = new URIHandler('ark:DNjuJEDQkhrJ7cA9FZ2iVXt5anYiM8Jtc9?amount=1.2&label=Hello&vendorField=ARK').deserialize()
+      const schema = new URIHandler('ark:DNjuJEDQkhrJ7cA9FZ2iVXt5anYiM8Jtc9?amount=1.2&label=Hello&vendorField=ARK&nethash=2a44f340d76ffc3df204c5f38cd355b7496c9065a1ade2ef92071436bd72e867&wallet=DSyG9hK9CE8eyfddUoEvsga4kNVQLdw2ve').deserialize()
       expect(schema.address).toBe('DNjuJEDQkhrJ7cA9FZ2iVXt5anYiM8Jtc9')
       expect(schema.amount).toBe(1.2)
       expect(schema.label).toBe('Hello')
+      expect(schema.nethash).toBe('2a44f340d76ffc3df204c5f38cd355b7496c9065a1ade2ef92071436bd72e867')
       expect(schema.vendorField).toBe('ARK')
+      expect(schema.wallet).toBe('DSyG9hK9CE8eyfddUoEvsga4kNVQLdw2ve')
     })
   })
 })

--- a/src/renderer/components/Transaction/TransactionForm/TransactionFormTransfer.vue
+++ b/src/renderer/components/Transaction/TransactionForm/TransactionFormTransfer.vue
@@ -324,7 +324,54 @@ export default {
       this.$set(this.form, 'amount', this.schema.amount || '')
       this.$set(this.form, 'recipientId', this.schema.address || '')
       this.$set(this.form, 'vendorField', this.schema.vendorField || '')
+      if (this.schema.wallet) {
+        const currentProfile = this.$store.getters['session/profileId']
+        const ledgerWallets = this.$store.getters['ledger/isConnected'] ? this.$store.getters['ledger/wallets'] : []
+        const profiles = this.$store.getters['profile/all']
+        const wallets = []
+
+        let foundNetwork = !this.schema.nethash
+
+        if (currentProfile) {
+          if (this.schema.nethash) {
+            const profile = this.$store.getters['profile/byId'](currentProfile)
+            const network = this.$store.getters['network/byId'](profile.networkId)
+            if (network.nethash === this.schema.nethash) {
+              foundNetwork = true
+              wallets.push(...this.$store.getters['wallet/byProfileId'](currentProfile))
+            }
+          } else {
+            wallets.push(...this.$store.getters['wallet/byProfileId'](currentProfile))
+          }
+        }
+        wallets.push(...ledgerWallets)
+        for (const profile of profiles) {
+          if (currentProfile !== profile.id) {
+            if (this.schema.nethash) {
+              const network = this.$store.getters['network/byId'](profile.networkId)
+              if (network.nethash === this.schema.nethash) {
+                foundNetwork = true
+                wallets.push(...this.$store.getters['wallet/byProfileId'](profile.id))
+              }
+            } else {
+              wallets.push(...this.$store.getters['wallet/byProfileId'](profile.id))
+            }
+          }
+        }
+        const wallet = wallets.filter(wallet => wallet.address === this.schema.wallet)
+        if (wallet.length) {
+          this.currentWallet = wallet[0]
+        }
+        if (!foundNetwork) {
+          this.$emit('cancel')
+          this.$error(`${this.$t('TRANSACTION.ERROR.NETWORK_NOT_CONFIGURED')}: ${this.schema.nethash}`)
+        } else if (!wallet.length) {
+          this.$emit('cancel')
+          this.$error(`${this.$t('TRANSACTION.ERROR.WALLET_NOT_IMPORTED')}: ${this.schema.wallet}`)
+        }
+      }
     }
+
     if (this.currentWallet && this.currentWallet.id) {
       this.$set(this, 'wallet', this.currentWallet || null)
       this.$v.wallet.$touch()
@@ -378,12 +425,12 @@ export default {
         passphrase: this.form.passphrase,
         fee: this.currency_unitToSub(this.form.fee),
         wif: this.form.wif,
-        networkWif: this.walletNetwork.wif
+        networkWif: this.walletNetwork.wif,
+        networkId: this.walletNetwork.id
       }
       if (this.currentWallet.secondPublicKey) {
         transactionData.secondPassphrase = this.form.secondPassphrase
       }
-
       let success = true
       let transaction
       if (!this.currentWallet || !this.currentWallet.isLedger) {

--- a/src/renderer/i18n/locales/en-US.js
+++ b/src/renderer/i18n/locales/en-US.js
@@ -820,7 +820,9 @@ export default {
       LOAD_FROM_FILE: 'Failed to load transaction file',
       EXPIRED: 'Transaction expired before it was processed: {transactionId}',
       FEE_TOO_LOW: 'Transaction could not be sent because the fee ({fee}) is too low',
-      NOTHING_SENT: 'The transaction could not be sent. Please check your network connection or change peer'
+      NOTHING_SENT: 'The transaction could not be sent. Please check your network connection or change peer',
+      NETWORK_NOT_CONFIGURED: 'Network not configured',
+      WALLET_NOT_IMPORTED: 'Wallet not imported'
     },
     FOOTER_TEXT: {
       DELEGATE_REGISTRATION: 'Keep in mind that you cannot change the name of your delegate after the registration has been registered on the blockchain.'

--- a/src/renderer/i18n/locales/it-IT.js
+++ b/src/renderer/i18n/locales/it-IT.js
@@ -809,7 +809,9 @@ export default {
       LOAD_FROM_FILE: 'Impossibile caricare il file transazione',
       EXPIRED: 'Transazione scaduta prima di essere proccessata: {transactionId}',
       FEE_TOO_LOW: 'La transazione non può essere inviata perchè la commissione ({fee}) è troppo bassa',
-      NOTHING_SENT: 'La transazione non può essere inviata. Controlla la tua connessione di rete o cambia peer'
+      NOTHING_SENT: 'La transazione non può essere inviata. Controlla la tua connessione di rete o cambia peer',
+      NETWORK_NOT_CONFIGURED: 'Rete non configurata',
+      WALLET_NOT_IMPORTED: 'Wallet non importato'
     },
     FOOTER_TEXT: {
       DELEGATE_REGISTRATION: 'Tieni presente che non è possibile modificare il nome del Delegato dopo che la registrazione è stata registrata sulla blockchain.'

--- a/src/renderer/services/uri-handler.js
+++ b/src/renderer/services/uri-handler.js
@@ -22,7 +22,9 @@ export default class URIHandler {
       address: null,
       amount: null,
       label: null,
-      vendorField: null
+      nethash: null,
+      vendorField: null,
+      wallet: null
     }
 
     for (const prop in scheme) {
@@ -32,7 +34,9 @@ export default class URIHandler {
     scheme.address = schema[1]
     scheme.amount = scheme.amount ? Number(scheme.amount) : null
     scheme.label = scheme.label ? this.__fullyDecode(scheme.label) : null
+    scheme.nethash = scheme.nethash ? this.__fullyDecode(scheme.nethash) : null
     scheme.vendorField = scheme.vendorField ? this.__fullyDecode(scheme.vendorField) : null
+    scheme.wallet = scheme.wallet ? this.__fullyDecode(scheme.wallet) : null
 
     return scheme
   }


### PR DESCRIPTION
# Summary

Fixes #1531

Resolves #1532

Where the same sender wallet exists on multiple profiles, if the wallet exists in the currently selected profile then it will select that, otherwise it will pick the first one it finds by iterating through the profiles.

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
