### PR TITLE
fix: left aligned sortable table headers

### DIFF
--- a/src/renderer/styles/_table.css
+++ b/src/renderer/styles/_table.css
@@ -70,6 +70,10 @@
   @apply .justify-center
 }
 
+.vgt-table th.vgt-right-align.text-left {
+  @apply .justify-start
+}
+
 .vgt-table th.sorting-asc:after {
   @apply .inline-block .ml-1;
   background: url('../assets/images/arrows/sort-asc.svg') no-repeat;


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

#1494 broke table formatting for left-aligned headers that used the `text-left` class if the column contained numerical data and that column was being used to sort the data in the table. This is because that PR forces sorted headers to be flexboxes with `justify-content: flex-end` (since `vgt-right-align` is automatically applied if the column contains numerical data).

This fixes it by overriding this with `justify-content: flex-start` if the header also has the `text-left` class. This approach was chosen as it mirrors the existing `.vgt-table th.vgt-right-align.text-center` CSS rule for centre-aligned headers.

Although the wallet itself doesn't seem to use left-aligned sortable headers for numerical data, some plugins, including my own, will need this as plugins can't define their own CSS classes and `vue-good-table` does not permit us to specify our own styles, only classes.

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
