### PR TITLE
fix: transaction amount on confirmation modal

### DIFF
--- a/src/renderer/services/client.js
+++ b/src/renderer/services/client.js
@@ -8,7 +8,7 @@ import semver from 'semver'
 import { TRANSACTION_TYPES } from '@config'
 import store from '@/store'
 import eventBus from '@/plugins/event-bus'
-import BigNumber from '@/plugins/bignumber'
+import TransactionService from '@/services/transaction'
 
 export default class ClientService {
   /*
@@ -289,7 +289,7 @@ export default class ClientService {
     const result = transactions.map(transaction => {
       transaction.isSender = transaction.sender === address
       transaction.isRecipient = transaction.recipient === address
-      transaction.totalAmount = new BigNumber(transaction.amount).plus(transaction.fee).toString()
+      transaction.totalAmount = TransactionService.getTotalAmount(transaction)
 
       return transaction
     })

--- a/src/renderer/services/client.js
+++ b/src/renderer/services/client.js
@@ -645,7 +645,13 @@ export default class ClientService {
       //
     }
 
-    return returnObject ? transaction : transaction.getStruct()
+    const transactionResponse = returnObject ? transaction : transaction.getStruct()
+
+    if (!returnObject) {
+      transactionResponse.totalAmount = TransactionService.getTotalAmount(transactionResponse)
+    }
+
+    return transactionResponse
   }
 
   /**

--- a/src/renderer/services/transaction.js
+++ b/src/renderer/services/transaction.js
@@ -1,5 +1,6 @@
 import { TRANSACTION_TYPES } from '@config'
 import { Transactions } from '@arkecosystem/crypto'
+import BigNumber from '@/plugins/bignumber'
 
 export default class TransactionService {
   /*
@@ -21,6 +22,15 @@ export default class TransactionService {
       excludeSignature: true,
       excludeSecondSignature: true
     }).toString('hex')
+  }
+
+  /**
+   * Get total amount for transaction.
+   * @param  {Object} transaction
+   * @return {String}
+   */
+  static getTotalAmount (transaction) {
+    return new BigNumber(transaction.amount).plus(transaction.fee).toString()
   }
 
   /*

--- a/src/renderer/store/modules/transaction.js
+++ b/src/renderer/store/modules/transaction.js
@@ -1,9 +1,9 @@
 import dayjs from 'dayjs'
 import { findIndex, unionBy } from 'lodash'
 import config from '@config'
-import BigNumber from '@/plugins/bignumber'
 import eventBus from '@/plugins/event-bus'
 import TransactionModel from '@/models/transaction'
+import TransactionService from '@/services/transaction'
 import Vue from 'vue'
 
 const includes = (objects, find) => objects.map(a => a.id).includes(find.id)
@@ -35,7 +35,7 @@ export default {
       }).map(transaction => {
         transaction.isSender = transaction.sender === address
         transaction.isRecipient = transaction.recipient === address
-        transaction.totalAmount = new BigNumber(transaction.amount).plus(transaction.fee).toString()
+        transaction.totalAmount = TransactionService.getTotalAmount(transaction)
 
         return transaction
       })
@@ -59,7 +59,7 @@ export default {
       const transactions = state.transactions[profileId].map(transaction => {
         transaction.isSender = addresses.includes(transaction.sender)
         transaction.isRecipient = addresses.includes(transaction.recipient)
-        transaction.totalAmount = new BigNumber(transaction.amount).plus(transaction.fee).toString()
+        transaction.totalAmount = TransactionService.getTotalAmount(transaction)
 
         return transaction
       })


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Consolidated called to assign totalAmount to a transaction. This is as a result of fixing a bug where new transactions didn't have that property. A similar method already exists in [feat/2.6-tx-types](https://github.com/ArkEcosystem/desktop-wallet/tree/feat/2.6-tx-types), along with tests so I've excluded the tests from this PR.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
