### PR TITLE
fix: prevent href breakout

### DIFF
--- a/__tests__/unit/services/plugin-manager/component/create-component.spec.js
+++ b/__tests__/unit/services/plugin-manager/component/create-component.spec.js
@@ -282,7 +282,7 @@ describe('Create Component', () => {
       })
     })
 
-    it('should not set custom properties', (done) => {
+    it('should not set custom properties', async () => {
       const spy = jest.spyOn(console, 'error').mockImplementation()
 
       const plugin = {
@@ -310,20 +310,21 @@ describe('Create Component', () => {
       const wrapper = mount(component)
       expect(wrapper.html()).toBe('<div>Test</div>')
 
-      localVue.nextTick(() => {
-        expect(spy).toHaveBeenCalledWith('innerHTML 🚫')
-        expect(spy).toHaveBeenCalledWith('outerHTML 🚫')
-        expect(spy).toHaveBeenCalledWith('appendChild 🚫')
-        expect(spy).toHaveBeenCalledWith('cloneNode 🚫')
-        expect(spy).toHaveBeenCalledWith('getRootNode 🚫')
-        expect(spy).toHaveBeenCalledWith('insertBefore 🚫')
-        expect(spy).toHaveBeenCalledWith('normalize 🚫')
-        expect(spy).toHaveBeenCalledWith('querySelector 🚫')
-        expect(spy).toHaveBeenCalledWith('querySelectorAll 🚫')
-        expect(spy).toHaveBeenCalledWith('removeChild 🚫')
-        expect(spy).toHaveBeenCalledWith('replaceChild 🚫')
-        done()
-      })
+      await wrapper.vm.$nextTick()
+
+      expect(spy).toHaveBeenCalledWith('innerHTML 🚫')
+      expect(spy).toHaveBeenCalledWith('outerHTML 🚫')
+      expect(spy).toHaveBeenCalledWith('appendChild 🚫')
+      expect(spy).toHaveBeenCalledWith('cloneNode 🚫')
+      expect(spy).toHaveBeenCalledWith('getRootNode 🚫')
+      expect(spy).toHaveBeenCalledWith('insertBefore 🚫')
+      expect(spy).toHaveBeenCalledWith('normalize 🚫')
+      expect(spy).toHaveBeenCalledWith('querySelector 🚫')
+      expect(spy).toHaveBeenCalledWith('querySelectorAll 🚫')
+      expect(spy).toHaveBeenCalledWith('removeChild 🚫')
+      expect(spy).toHaveBeenCalledWith('replaceChild 🚫')
+
+      spy.mockRestore()
     })
   })
 })

--- a/__tests__/unit/services/plugin-manager/component/create-component.spec.js
+++ b/__tests__/unit/services/plugin-manager/component/create-component.spec.js
@@ -292,6 +292,7 @@ describe('Create Component', () => {
         }),
         mounted () {
           this.$nextTick(() => {
+            this.refs.test.href = 'Jest'
             this.refs.test.innerHTML = 'Jest'
             this.refs.test.outerHTML = 'Jest'
             this.refs.test.appendChild(document.createElement('p'))
@@ -312,6 +313,7 @@ describe('Create Component', () => {
 
       await wrapper.vm.$nextTick()
 
+      expect(spy).toHaveBeenCalledWith('href 🚫')
       expect(spy).toHaveBeenCalledWith('innerHTML 🚫')
       expect(spy).toHaveBeenCalledWith('outerHTML 🚫')
       expect(spy).toHaveBeenCalledWith('appendChild 🚫')
@@ -323,6 +325,48 @@ describe('Create Component', () => {
       expect(spy).toHaveBeenCalledWith('querySelectorAll 🚫')
       expect(spy).toHaveBeenCalledWith('removeChild 🚫')
       expect(spy).toHaveBeenCalledWith('replaceChild 🚫')
+
+      spy.mockRestore()
+    })
+
+    it('should only allow href change via template variable', async () => {
+      const spy = jest.spyOn(console, 'error').mockImplementation()
+
+      const plugin = {
+        template: `<div>
+          <a ref="normalLink" href="testHref">test link</a>
+          <a ref="variableLink" :href="testHref">test link</a>
+        </div>`,
+        data: () => ({
+          testHref: 'testHref'
+        }),
+        mounted () {
+          this.$nextTick(() => {
+            this.refs.normalLink.href = 'Failed'
+
+            this.testHref = 'Success'
+          })
+        },
+        methods: {
+          updateHref () {
+            this.refs.variableLink.href = 'Failed'
+          }
+        }
+      }
+
+      const component = wrapperPlugin(plugin)
+      const wrapper = mount(component)
+
+      await wrapper.vm.$nextTick()
+
+      expect(wrapper.find({ ref: 'normalLink' }).element.href).toBe(undefined)
+      expect(wrapper.find({ ref: 'variableLink' }).element.href).toBe('http://localhost/Success')
+
+      wrapper.vm.updateHref()
+
+      expect(wrapper.find({ ref: 'variableLink' }).element.href).toBe(undefined)
+      expect(spy).toHaveBeenCalledWith('href 🚫')
+      expect(spy).toHaveBeenCalledTimes(2)
 
       spy.mockRestore()
     })

--- a/src/renderer/services/plugin-manager/component/get-context.js
+++ b/src/renderer/services/plugin-manager/component/get-context.js
@@ -34,6 +34,7 @@ export function getSafeContext (vueContext, component) {
     ]
 
     const badSetters = [
+      'href',
       'innerHTML',
       'outerHTML'
     ]


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

It was possible to bypass checks in the plugin system by overriding the href property.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
