### PR TITLE
fix: ledger transaction amount on confirm modal

### DIFF
--- a/src/renderer/components/Transaction/TransactionForm/TransactionFormDelegateRegistration.vue
+++ b/src/renderer/components/Transaction/TransactionForm/TransactionFormDelegateRegistration.vue
@@ -184,6 +184,7 @@ export default {
         try {
           const transactionObject = await this.$client.buildDelegateRegistration(transactionData, this.$refs.fee && this.$refs.fee.isAdvancedFee, true)
           transaction = await TransactionService.ledgerSign(this.currentWallet, transactionObject, this)
+          transaction.totalAmount = TransactionService.getTotalAmount(transaction)
           success = true
         } catch (error) {
           this.$error(`${this.$t('TRANSACTION.LEDGER_SIGN_FAILED')}: ${error.message}`)

--- a/src/renderer/components/Transaction/TransactionForm/TransactionFormSecondSignature.vue
+++ b/src/renderer/components/Transaction/TransactionForm/TransactionFormSecondSignature.vue
@@ -288,6 +288,7 @@ export default {
         try {
           const transactionObject = await this.$client.buildSecondSignatureRegistration(transactionData, this.$refs.fee && this.$refs.fee.isAdvancedFee, true)
           transaction = await TransactionService.ledgerSign(this.currentWallet, transactionObject, this)
+          transaction.totalAmount = TransactionService.getTotalAmount(transaction)
           success = true
         } catch (error) {
           this.$error(`${this.$t('TRANSACTION.LEDGER_SIGN_FAILED')}: ${error.message}`)

--- a/src/renderer/components/Transaction/TransactionForm/TransactionFormTransfer.vue
+++ b/src/renderer/components/Transaction/TransactionForm/TransactionFormTransfer.vue
@@ -441,6 +441,7 @@ export default {
         try {
           const transactionObject = await this.$client.buildTransfer(transactionData, this.$refs.fee && this.$refs.fee.isAdvancedFee, true)
           transaction = await TransactionService.ledgerSign(this.currentWallet, transactionObject, this)
+          transaction.totalAmount = TransactionService.getTotalAmount(transaction)
           success = true
         } catch (error) {
           this.$error(`${this.$t('TRANSACTION.LEDGER_SIGN_FAILED')}: ${error.message}`)

--- a/src/renderer/components/Transaction/TransactionForm/TransactionFormVote.vue
+++ b/src/renderer/components/Transaction/TransactionForm/TransactionFormVote.vue
@@ -310,6 +310,7 @@ export default {
         try {
           const transactionObject = await this.$client.buildVote(transactionData, this.$refs.fee && this.$refs.fee.isAdvancedFee, true)
           transaction = await TransactionService.ledgerSign(this.currentWallet, transactionObject, this)
+          transaction.totalAmount = TransactionService.getTotalAmount(transaction)
           success = true
         } catch (error) {
           this.$error(`${this.$t('TRANSACTION.LEDGER_SIGN_FAILED')}: ${error.message}`)


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Relates to #1562, except for transactions created for a Ledger wallet. Transactions now use a `totalAmount` property to display on the confirmation modal (and also for sorting). In the future, we will remove this property and look at doing it a better way, so we don't need to worry about assigning that property whenever a transaction is created.

I'll look at tests at the same time as updating to not require `totalAmount`.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
