### PR TITLE
refactor: remove wallet api and peer version

### DIFF
--- a/__tests__/unit/store/modules/delegate.spec.js
+++ b/__tests__/unit/store/modules/delegate.spec.js
@@ -1,7 +1,7 @@
 import nock from 'nock'
 import Vue from 'vue'
 import Vuex from 'vuex'
-import apiClient from '@/plugins/api-client'
+import apiClient, { client as ClientService } from '@/plugins/api-client'
 import store from '@/store'
 import delegates, { delegate1, delegate2 } from '../../__fixtures__/store/delegate'
 import { network1 } from '../../__fixtures__/store/network'
@@ -19,10 +19,7 @@ beforeAll(() => {
 
 beforeEach(() => {
   nock.cleanAll()
-  nock('http://127.0.0.1')
-    .persist()
-    .post('/api/v2/wallets/search')
-    .reply(200, { data: [] })
+  ClientService.host = 'http://127.0.0.1'
 })
 
 describe('delegate store module', () => {
@@ -54,33 +51,12 @@ describe('delegate store module', () => {
     expect(store.getters['delegate/byPublicKey']()).toBe(false)
   })
 
-  it('should fetch delegates from v1 api should store the same as v2 api', async () => {
-    const v2DelegateData = delegates.map(delegate => {
-      return {
-        username: delegate.username,
-        address: delegate.address,
-        publicKey: delegate.publicKey,
-        votes: delegate.votes,
-        rank: delegate.rank,
-        blocks: {
-          produced: delegate.blocks.produced
-        },
-        production: {
-          approval: delegate.production.approval
-        },
-        forged: {
-          fees: delegate.forged.fees,
-          rewards: delegate.forged.rewards,
-          total: delegate.forged.total
-        }
-      }
-    })
-
+  it('should fetch delegates from api', async () => {
     nock('http://127.0.0.1')
       .get('/api/v2/delegates')
       .query({ page: 1, limit: 100, orderBy: 'rank:asc' })
       .reply(200, {
-        data: v2DelegateData,
+        data: delegates,
         meta: {
           totalCount: 2
         }

--- a/__tests__/unit/store/modules/peer.spec.js
+++ b/__tests__/unit/store/modules/peer.spec.js
@@ -48,10 +48,6 @@ beforeAll(() => {
 
 beforeEach(() => {
   nock.cleanAll()
-  nock('http://127.0.0.1')
-    .persist()
-    .post('/api/v2/wallets/search')
-    .reply(200, { data: [] })
 })
 
 describe('peer store module', () => {
@@ -286,14 +282,6 @@ describe('peer store module', () => {
         }
       })
 
-    nock(`http://${goodPeer1.ip}:4040`)
-      .get('/config')
-      .reply(200, {
-        data: {
-          version: '2.0.0'
-        }
-      })
-
     const response = await store.dispatch('peer/validatePeer', { ...goodPeer1, timeout: 100 })
 
     expect(response).toBeObject()
@@ -316,14 +304,6 @@ describe('peer store module', () => {
       .reply(200, {
         data: {
           height: 10002
-        }
-      })
-
-    nock(`https://${goodPeer1.ip}:4040`)
-      .get('/config')
-      .reply(200, {
-        data: {
-          version: '2.0.0'
         }
       })
 
@@ -360,14 +340,6 @@ describe('peer store module', () => {
       })
       .get('/api/v2/node/syncing')
       .reply(400)
-
-    nock(`http://${goodPeer1.ip}:4040`)
-      .get('/config')
-      .reply(200, {
-        data: {
-          version: '2.0.0'
-        }
-      })
 
     const response = await store.dispatch('peer/validatePeer', { ...goodPeer1, timeout: 100 })
     expect(response).toEqual(expect.stringMatching(/^Status check failed$/))

--- a/__tests__/unit/store/modules/transaction.spec.js
+++ b/__tests__/unit/store/modules/transaction.spec.js
@@ -42,10 +42,6 @@ describe('TransactionModule', () => {
     wallets.forEach(wallet => store.commit('wallet/STORE', wallet))
     ClientService.host = 'http://127.0.0.1:4003'
     nock.cleanAll()
-    nock('http://127.0.0.1')
-      .persist()
-      .post('/api/v2/wallets/search')
-      .reply(200, { data: [] })
   })
 
   describe('getters byAddress', () => {

--- a/src/renderer/i18n/locales/en-US.js
+++ b/src/renderer/i18n/locales/en-US.js
@@ -118,7 +118,6 @@ export default {
 
   PEER: {
     BEST: 'Connect to best',
-    CONFIG_CHECK_FAILED: 'Config check failed',
     CONNECTED: 'Connected to peer',
     CONNECT_CUSTOM: 'Connect custom peer',
     CONNECT_FAILED: 'Failed to connect to peer',

--- a/src/renderer/models/peer.js
+++ b/src/renderer/models/peer.js
@@ -45,5 +45,5 @@ export default new BaseModel({
       format: (value) => value.isHttps || false
     }
   },
-  required: ['ip', 'port', 'version', 'height', 'latency']
+  required: ['ip', 'port', 'height', 'latency']
 })

--- a/src/renderer/services/client.js
+++ b/src/renderer/services/client.js
@@ -1,10 +1,9 @@
 import { Connection } from '@arkecosystem/client'
-import { Identities, Transactions } from '@arkecosystem/crypto'
+import { Transactions } from '@arkecosystem/crypto'
 import { castArray, chunk, orderBy } from 'lodash'
 import got from 'got'
 import moment from 'moment'
 import logger from 'electron-log'
-import semver from 'semver'
 import { TRANSACTION_TYPES } from '@config'
 import store from '@/store'
 import eventBus from '@/plugins/event-bus'
@@ -110,9 +109,6 @@ export default class ClientService {
 
   constructor (watchProfile = true) {
     this.__host = null
-    // The API version is imprecise, since new capabilities are being added continuously.
-    // So, this property uses the peer version to know which features are available
-    this.__capabilities = '2.0.0'
     this.client = new Connection('http://localhost')
 
     if (watchProfile) {
@@ -132,18 +128,6 @@ export default class ClientService {
 
   get version () {
     return this.__version
-  }
-
-  get capabilities () {
-    return this.__capabilities
-  }
-
-  set capabilities (version) {
-    this.__capabilities = semver.coerce(version)
-  }
-
-  isCapable (version) {
-    return semver.gte(this.capabilities, version)
   }
 
   /**
@@ -310,55 +294,53 @@ export default class ClientService {
     options = options || {}
 
     const walletData = {}
-    if (this.isCapable('2.1.0')) {
-      let transactions = []
-      let hadFailure = false
+    let transactions = []
+    let hadFailure = false
 
-      for (const addressChunk of chunk(addresses, 20)) {
-        try {
-          const { body } = await this.client.api('transactions').search({
-            addresses: addressChunk
-          })
-          transactions.push(...body.data)
-        } catch (error) {
-          logger.error(error)
-          hadFailure = true
-        }
-      }
-
-      if (!hadFailure) {
-        transactions = orderBy(transactions, 'timestamp', 'desc').map(transaction => {
-          transaction.timestamp = transaction.timestamp.unix * 1000 // to milliseconds
-          transaction.isSender = addresses.includes(transaction.sender)
-          transaction.isRecipient = addresses.includes(transaction.recipient)
-
-          return transaction
+    for (const addressChunk of chunk(addresses, 20)) {
+      try {
+        const { body } = await this.client.api('transactions').search({
+          addresses: addressChunk
         })
-
-        for (const transaction of transactions) {
-          if (addresses.includes(transaction.sender)) {
-            if (!walletData[transaction.sender]) {
-              walletData[transaction.sender] = {}
-            }
-            walletData[transaction.sender][transaction.id] = transaction
-          }
-
-          if (transaction.recipient && addresses.includes(transaction.recipient)) {
-            if (!walletData[transaction.recipient]) {
-              walletData[transaction.recipient] = {}
-            }
-            walletData[transaction.recipient][transaction.id] = transaction
-          }
-        }
-
-        for (const address of Object.keys(walletData)) {
-          if (walletData[address]) {
-            walletData[address] = Object.values(walletData[address])
-          }
-        }
-
-        return walletData
+        transactions.push(...body.data)
+      } catch (error) {
+        logger.error(error)
+        hadFailure = true
       }
+    }
+
+    if (!hadFailure) {
+      transactions = orderBy(transactions, 'timestamp', 'desc').map(transaction => {
+        transaction.timestamp = transaction.timestamp.unix * 1000 // to milliseconds
+        transaction.isSender = addresses.includes(transaction.sender)
+        transaction.isRecipient = addresses.includes(transaction.recipient)
+
+        return transaction
+      })
+
+      for (const transaction of transactions) {
+        if (addresses.includes(transaction.sender)) {
+          if (!walletData[transaction.sender]) {
+            walletData[transaction.sender] = {}
+          }
+          walletData[transaction.sender][transaction.id] = transaction
+        }
+
+        if (transaction.recipient && addresses.includes(transaction.recipient)) {
+          if (!walletData[transaction.recipient]) {
+            walletData[transaction.recipient] = {}
+          }
+          walletData[transaction.recipient][transaction.id] = transaction
+        }
+      }
+
+      for (const address of Object.keys(walletData)) {
+        if (walletData[address]) {
+          walletData[address] = Object.values(walletData[address])
+        }
+      }
+
+      return walletData
     }
 
     for (const address of addresses) {
@@ -394,25 +376,11 @@ export default class ClientService {
   async fetchWallets (addresses) {
     const walletData = []
 
-    if (this.isCapable('2.1.0')) {
-      for (const addressChunk of chunk(addresses, 20)) {
-        const { body } = await this.client.api('wallets').search({
-          addresses: addressChunk
-        })
-        walletData.push(...body.data)
-      }
-    } else {
-      for (const address of addresses) {
-        try {
-          walletData.push(await this.fetchWallet(address))
-        } catch (error) {
-          logger.error(error)
-          const message = error.response ? error.response.body.message : error.message
-          if (message !== 'Wallet not found') {
-            throw error
-          }
-        }
-      }
+    for (const addressChunk of chunk(addresses, 20)) {
+      const { body } = await this.client.api('wallets').search({
+        addresses: addressChunk
+      })
+      walletData.push(...body.data)
     }
 
     return walletData
@@ -704,32 +672,10 @@ export default class ClientService {
           return
         }
 
-        const network = store.getters['network/byId'](profile.networkId)
         const currentPeer = store.getters['peer/current']()
-
         if (currentPeer && currentPeer.ip) {
           const scheme = currentPeer.isHttps ? 'https://' : 'http://'
           this.host = `${scheme}${currentPeer.ip}:${currentPeer.port}`
-          this.capabilities = currentPeer.version
-
-        // TODO if we could use the server from network, then, it is a peer and this shouldn't be necessary
-        } else {
-          let { server, apiVersion } = network
-          this.host = server
-
-          // Infer which are the real capabilities of the peer
-          try {
-            const testAddress = Identities.Address.fromPassphrase('test', network.version)
-            const { address } = this.client.api('wallets').search({
-              addresses: [testAddress]
-            })
-
-            apiVersion = (address === testAddress) ? '2.1.0' : '2.0.0'
-          } catch (_) {
-            // The peer does not have capability to search for multiple wallets or transactions at once
-          }
-
-          this.capabilities = apiVersion
         }
 
         if (!oldProfile || profile.id !== oldProfile.id) {

--- a/src/renderer/services/client.js
+++ b/src/renderer/services/client.js
@@ -1,7 +1,6 @@
 import { Connection } from '@arkecosystem/client'
 import { Transactions } from '@arkecosystem/crypto'
 import { castArray, chunk, orderBy } from 'lodash'
-import got from 'got'
 import moment from 'moment'
 import logger from 'electron-log'
 import { TRANSACTION_TYPES } from '@config'
@@ -50,41 +49,6 @@ export default class ClientService {
     }
 
     return data
-  }
-
-  /**
-   * TODO: Remove unnecessary endpoints once core 2.4 is released (maybe wait until 2.5 so other chains have updated)
-   * Only for V2
-   * Get the configuration of a peer
-   * @param {String} host - URL of the host (using `core-p2p` port)
-   * @param {Number} [timeout=3000]
-   * @return {(Object|null)}
-   */
-  static async fetchPeerConfig (host, timeout = 3000) {
-    const walletApiHost = host.replace(/:\d+/, ':4040')
-    const endpoints = [
-      `${walletApiHost}/config`,
-      `${host}/config`,
-      walletApiHost
-    ]
-
-    for (const endpoint of endpoints) {
-      try {
-        const { body } = await got(endpoint, {
-          json: true,
-          timeout
-        })
-
-        if (body) {
-          return body.data
-        }
-      } catch (error) {
-        // TODO only if a new feature to enable logging is added
-        // console.log(`Error on \`${host}\``)
-      }
-    }
-
-    return null
   }
 
   static async fetchFeeStatistics (server, timeout) {

--- a/src/renderer/store/modules/ledger.js
+++ b/src/renderer/store/modules/ledger.js
@@ -259,11 +259,7 @@ export default {
 
       // Note: We only batch if search endpoint available, otherwise we would
       //       be doing unnecessary API calls for potentially cold wallets.
-      let batchIncrement = 1
-      if (this._vm.$client.isCapable('2.1.0')) {
-        batchIncrement = startIndex === 0 ? 10 : 2
-      }
-
+      const batchIncrement = startIndex === 0 ? 10 : 2
       try {
         for (let ledgerIndex = startIndex; ; ledgerIndex += batchIncrement) {
           if (getters.shouldStopLoading(processId)) {

--- a/src/renderer/store/modules/peer.js
+++ b/src/renderer/store/modules/peer.js
@@ -273,7 +273,6 @@ export default {
 
       if (peer) {
         this._vm.$client.host = getBaseUrl(peer)
-        this._vm.$client.capabilities = peer.version
 
         // TODO only when necessary (when / before sending) (if no dynamic)
         await dispatch('transaction/updateStaticFees', null, { root: true })

--- a/src/renderer/store/modules/peer.js
+++ b/src/renderer/store/modules/peer.js
@@ -324,8 +324,7 @@ export default {
         .findPeersWithPlugin('core-api', {
           additional: [
             'height',
-            'latency',
-            'version'
+            'latency'
           ]
         })
 
@@ -334,8 +333,7 @@ export default {
           .findPeersWithPlugin('core-wallet-api', {
             additional: [
               'height',
-              'latency',
-              'version'
+              'latency'
             ]
           })
       }
@@ -515,16 +513,6 @@ export default {
         return i18n.t('PEER.WRONG_NETWORK')
       }
 
-      let peerConfig
-      try {
-        peerConfig = await ClientService.fetchPeerConfig(baseUrl)
-      } catch (error) {
-        //
-      }
-      if (!peerConfig) {
-        return i18n.t('PEER.CONFIG_CHECK_FAILED')
-      }
-
       const client = new ClientService(false)
       client.host = baseUrl
       client.client.withOptions({ timeout: 3000 })
@@ -546,8 +534,7 @@ export default {
         height: peerStatus.height,
         status: 'OK',
         latency: 0,
-        isHttps: schemeUrl && schemeUrl[1] === 'https://',
-        version: peerConfig.version
+        isHttps: schemeUrl && schemeUrl[1] === 'https://'
       }
     }
   }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

There is currently no need for the wallet to check on a peer's version since the only compatibility checks were for core 2.1.0. Also removed the use of core-wallet-api (port 4040), because the only thing it was used for was to get the core version for the above compatibility checks.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
