### PR TITLE
fix: delete plugin path of installed plugin when updating and various tweaks

### DIFF
--- a/__tests__/unit/services/plugin-manager.spec.js
+++ b/__tests__/unit/services/plugin-manager.spec.js
@@ -165,45 +165,45 @@ describe('Plugin Manager', () => {
     it('should disable', async () => {
       await pluginManager.init(app)
       pluginManager.plugins = {
-        [pkg.name]: {
+        [`${pkg.name}-disabled`]: {
           config: {
-            id: pkg.name,
+            id: `${pkg.name}-disabled`,
             permissions: []
           }
         }
       }
       pluginManager.pluginSetups = {
-        [pkg.name]: {
+        [`${pkg.name}-disabled`]: {
           destroy: jest.fn()
         }
       }
 
-      await pluginManager.disablePlugin(pkg.name, 'p-1')
-      expect(mockDispatch).toHaveBeenCalledWith('plugin/deleteLoaded', { pluginId: pkg.name, profileId: 'p-1' })
-      expect(pluginManager.pluginSetups[pkg.name].destroy).toHaveBeenCalledTimes(1)
+      await pluginManager.disablePlugin(`${pkg.name}-disabled`, 'p-1')
+      expect(mockDispatch).toHaveBeenCalledWith('plugin/deleteLoaded', { pluginId: `${pkg.name}-disabled`, profileId: 'p-1' })
+      expect(pluginManager.pluginSetups[`${pkg.name}-disabled`].destroy).toHaveBeenCalledTimes(1)
     })
 
     it('should unload theme', async () => {
       await pluginManager.init(app)
       pluginManager.plugins = {
-        [pkg.name]: {
+        [`${pkg.name}-disabled`]: {
           config: {
-            id: pkg.name,
+            id: `${pkg.name}-disabled`,
             permissions: ['THEMES']
           }
         }
       }
       pluginManager.pluginSetups = {
-        [pkg.name]: {
+        [`${pkg.name}-disabled`]: {
           destroy: jest.fn()
         }
       }
 
-      await pluginManager.disablePlugin(pkg.name, 'p-1')
-      expect(mockDispatch).toHaveBeenCalledWith('plugin/deleteLoaded', { pluginId: pkg.name, profileId: 'p-1' })
+      await pluginManager.disablePlugin(`${pkg.name}-disabled`, 'p-1')
+      expect(mockDispatch).toHaveBeenCalledWith('plugin/deleteLoaded', { pluginId: `${pkg.name}-disabled`, profileId: 'p-1' })
       expect(mockDispatch).toHaveBeenCalledWith('session/setTheme', expect.any(String))
       expect(mockDispatch).toHaveBeenCalledWith('profile/update', expect.any(Object))
-      expect(pluginManager.pluginSetups[pkg.name].destroy).toHaveBeenCalledTimes(1)
+      expect(pluginManager.pluginSetups[`${pkg.name}-disabled`].destroy).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/src/main/plugin-manager.js
+++ b/src/main/plugin-manager.js
@@ -1,3 +1,4 @@
+import path from 'path'
 import { PLUGINS } from '../../config'
 import { download } from 'electron-dl'
 import decompress from 'decompress'
@@ -11,7 +12,7 @@ export const setupPluginManager = ({ sendToWindow, mainWindow, ipcMain }) => {
   let savePath
 
   const pluginsPath = `${process.env.NODE_ENV !== 'development' ? PLUGINS.path : PLUGINS.devPath}`
-  const cachePath = `${pluginsPath}/.cache`
+  const cachePath = path.join(pluginsPath, '.cache')
 
   ensureDirSync(cachePath)
 
@@ -39,17 +40,16 @@ export const setupPluginManager = ({ sendToWindow, mainWindow, ipcMain }) => {
     }
   })
 
-  ipcMain.on(prefix + 'install', async (_, { pluginId, isUpdate }) => {
-    const pluginPath = [pluginsPath, pluginId].join('/')
-
+  ipcMain.on(prefix + 'install', async (_, { pluginId, pluginPath }) => {
     try {
-      if (isUpdate) {
+      if (pluginPath) {
         await trash(pluginPath)
       }
 
+      pluginPath = path.join(pluginsPath, pluginId)
       await decompress(savePath, pluginPath, {
         map: file => {
-          file.path = file.path.split('/').slice(1).join('/')
+          file.path = path.join(...file.path.split(path.sep).slice(1))
           return file
         }
       })

--- a/src/main/plugin-manager.js
+++ b/src/main/plugin-manager.js
@@ -1,4 +1,3 @@
-import path from 'path'
 import { PLUGINS } from '../../config'
 import { download } from 'electron-dl'
 import decompress from 'decompress'
@@ -12,7 +11,7 @@ export const setupPluginManager = ({ sendToWindow, mainWindow, ipcMain }) => {
   let savePath
 
   const pluginsPath = `${process.env.NODE_ENV !== 'development' ? PLUGINS.path : PLUGINS.devPath}`
-  const cachePath = path.join(pluginsPath, '.cache')
+  const cachePath = `${pluginsPath}/.cache`
 
   ensureDirSync(cachePath)
 
@@ -46,10 +45,10 @@ export const setupPluginManager = ({ sendToWindow, mainWindow, ipcMain }) => {
         await trash(pluginPath)
       }
 
-      pluginPath = path.join(pluginsPath, pluginId)
+      pluginPath = [pluginsPath, pluginId].join('/')
       await decompress(savePath, pluginPath, {
         map: file => {
-          file.path = path.join(...file.path.split(path.sep).slice(1))
+          file.path = file.path.split('/').slice(1).join('/')
           return file
         }
       })

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -320,7 +320,7 @@ export default {
         this.$warn('Ledger Disconnected!')
       })
 
-      await this.$plugins.fetchPluginsFromAdapter()
+      await Promise.all([this.$plugins.fetchPluginsFromAdapter(), this.$plugins.fetchBlacklist()])
     },
 
     onPortalChange (isActive) {

--- a/src/renderer/pages/PluginManager.vue
+++ b/src/renderer/pages/PluginManager.vue
@@ -561,9 +561,11 @@ export default {
     onInstall () {
       this.setModal('loading')
 
+      const installedPlugin = this.$store.getters['plugin/installedById'](this.selectedPlugin.id)
+
       ipcRenderer.send('plugin-manager:install', {
         pluginId: this.selectedPlugin.id,
-        isUpdate: this.isUpdate
+        pluginPath: installedPlugin ? installedPlugin.fullPath : null
       })
     },
 

--- a/src/renderer/services/plugin-manager.js
+++ b/src/renderer/services/plugin-manager.js
@@ -95,7 +95,7 @@ export class PluginManager {
     }
 
     if (!this.app.$store.getters['plugin/isEnabled'](plugin.config.id, profileId)) {
-      throw new errors.PluginNotEnabledError(plugin.config.id)
+      throw new errors.PluginStatusError('enabled', plugin.config.id)
     }
 
     if (!this.app.$store.getters['plugin/isInstalledSupported'](plugin.config.id)) {
@@ -171,6 +171,10 @@ export class PluginManager {
     const plugin = this.plugins[pluginId]
     if (!plugin) {
       throw new errors.PluginNotFoundError(pluginId)
+    }
+
+    if (this.app.$store.getters['plugin/isEnabled'](plugin.config.id, profileId)) {
+      throw new errors.PluginStatusError('disabled', plugin.config.id)
     }
 
     if (plugin.config.permissions.includes('THEMES')) {

--- a/src/renderer/services/plugin-manager.js
+++ b/src/renderer/services/plugin-manager.js
@@ -183,7 +183,9 @@ export class PluginManager {
 
     await this.app.$store.dispatch('plugin/deleteLoaded', { pluginId, profileId })
 
-    await this.pluginSetups[pluginId].destroy()
+    if (this.pluginSetups[pluginId]) {
+      await this.pluginSetups[pluginId].destroy()
+    }
   }
 
   async fetchLogo (url) {

--- a/src/renderer/services/plugin-manager/errors.js
+++ b/src/renderer/services/plugin-manager/errors.js
@@ -30,9 +30,9 @@ export class PluginDownloadFailedError extends PluginManagerError {
   }
 }
 
-export class PluginNotEnabledError extends PluginManagerError {
-  constructor (plugin) {
-    super(`Plugin '${plugin}' is not enabled`)
+export class PluginStatusError extends PluginManagerError {
+  constructor (status, plugin) {
+    super(`Plugin '${plugin}' is not ${status}`)
   }
 }
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

Checks that the plugin is not enabled in the store before disabling it from the service. Adds check from #1581, deletes the path of the installed plugin when updating (fix for updating to new folder structure).

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
