### PR TITLE
fix: re-render chart if currency changed while being inactive

### DIFF
--- a/src/renderer/components/MarketChart/MarketChart.vue
+++ b/src/renderer/components/MarketChart/MarketChart.vue
@@ -64,7 +64,8 @@ export default {
     isReady: false,
     chartData: {},
     options: {},
-    gradient: null
+    gradient: null,
+    lastCurrency: null
   }),
 
   computed: {
@@ -137,9 +138,13 @@ export default {
     }
   },
 
+  mounted () {
+    this.setLastCurrency()
+  },
+
   activated () {
     // Only if it's not already rendered
-    if (this.isExpanded && !this.isReady) {
+    if ((this.isExpanded && !this.isReady) || this.lastCurrency !== this.currency) {
       this.renderChart()
     }
   },
@@ -149,7 +154,15 @@ export default {
       this.isReady = true
     },
 
+    setLastCurrency () {
+      this.lastCurrency = this.currency
+    },
+
     async renderChart () {
+      if (!this._inactive) {
+        this.setLastCurrency()
+      }
+
       await this.renderGradient()
 
       const response = await cryptoCompare.historicByType(this.period, this.ticker, this.currency)

--- a/src/renderer/components/MarketChart/MarketChart.vue
+++ b/src/renderer/components/MarketChart/MarketChart.vue
@@ -268,7 +268,8 @@ export default {
           tooltips: {
             displayColors: false,
             intersect: false,
-            mode: 'x',
+            mode: 'index',
+            axis: 'x',
             callbacks: {
               label: (item, data) => {
                 return this.currency_format(item.yLabel / scaleCorrection, { currency: this.currency })
@@ -304,7 +305,7 @@ export default {
           labels: response.labels,
           datasets: [{
             // Do not show the points, but enable a big target for the tooltip
-            pointHitRadius: 12,
+            pointHitRadius: 6,
             pointRadius: 0,
             borderWidth: 3,
             type: 'line',


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Fixes #1567. 

Also changes the `mode` of the tooltips so that only one event is fired if hovering over a point in between indeces. This gets rid of the double-label-tooltips. Also reduces the point hit radius by half, since the `intersect` option is set to `false` anyway.

![image](https://user-images.githubusercontent.com/6547002/70848974-25117a80-1e79-11ea-970c-ab0ccf32f066.png)

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
