### PR TITLE
fix: delete plugin when no data stored

### DIFF
--- a/__tests__/unit/components/PluginManager/PluginManagerModals/PluginRemovalModal.spec.js
+++ b/__tests__/unit/components/PluginManager/PluginManagerModals/PluginRemovalModal.spec.js
@@ -14,6 +14,19 @@ beforeEach(() => {
         permissions: []
       }
     },
+    mocks: {
+      $store: {
+        getters: {
+          'plugin/profileHasPluginOptions': (pluginId) => {
+            if (pluginId === 'hasOptions') {
+              return true
+            }
+
+            return false
+          }
+        }
+      }
+    },
     stubs: {
       ListDivided: '<div class="ListDivided" />'
     }
@@ -30,7 +43,19 @@ describe('PluginRemovalModal', () => {
     expect(wrapper.find('.ListDivided').exists()).toBeFalse()
   })
 
-  it('should render divided list if plugin has STORAGE permission', () => {
+  it('should render divided list if plugin has STORAGE permission and data stored', () => {
+    wrapper.setProps({
+      plugin: {
+        id: 'hasOptions',
+        permissions: ['STORAGE']
+      }
+    })
+
+    expect(wrapper.vm.hasStorage).toBeTrue()
+    expect(wrapper.find('.ListDivided').exists()).toBeTrue()
+  })
+
+  it('should not render divided list if plugin has STORAGE permission but no data stored', () => {
     wrapper.setProps({
       plugin: {
         id: 'test',
@@ -38,8 +63,8 @@ describe('PluginRemovalModal', () => {
       }
     })
 
-    expect(wrapper.vm.hasStorage).toBeTrue()
-    expect(wrapper.find('.ListDivided').exists()).toBeTrue()
+    expect(wrapper.vm.hasStorage).toBeFalse()
+    expect(wrapper.find('.ListDivided').exists()).toBeFalse()
   })
 
   describe('Methods', () => {

--- a/src/renderer/components/PluginManager/PluginManagerModals/PluginRemovalModal.vue
+++ b/src/renderer/components/PluginManager/PluginManagerModals/PluginRemovalModal.vue
@@ -54,7 +54,7 @@ export default {
 
   computed: {
     hasStorage () {
-      return this.plugin.permissions.includes('STORAGE')
+      return this.plugin.permissions.includes('STORAGE') && this.$store.getters['plugin/profileHasPluginOptions'](this.plugin.id)
     }
   },
 

--- a/src/renderer/store/modules/plugin.js
+++ b/src/renderer/store/modules/plugin.js
@@ -341,7 +341,7 @@ export default {
     },
 
     DELETE_PLUGIN_OPTIONS (state, { pluginId, profileId }) {
-      if (state.pluginOptions[profileId][pluginId]) {
+      if (state.pluginOptions[profileId] && state.pluginOptions[profileId][pluginId]) {
         Vue.delete(state.pluginOptions[profileId], pluginId)
       }
     },

--- a/src/renderer/store/modules/plugin.js
+++ b/src/renderer/store/modules/plugin.js
@@ -248,6 +248,14 @@ export default {
       }, [])
     },
 
+    profileHasPluginOptions: (state, _, __, rootGetters) => (pluginId, profileId) => {
+      if (!profileId) {
+        profileId = rootGetters['session/profileId']
+      }
+
+      return state.pluginOptions[profileId] && state.pluginOptions[profileId][pluginId]
+    },
+
     pluginOptions: (state) => (pluginId, profileId) => {
       if (!state.pluginOptions[profileId]) {
         return {}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

When a plugin has the STORAGE permission, it will ask whether to remove all data for the plugin when removing it from the wallet. The removal would fail if the plugin never stored data but the option to remove all was selected.

Resolves #1602

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_ - awaiting on test suite by dated
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
