### PR TITLE
fix: reset page when perpage update

### DIFF
--- a/src/renderer/components/Wallet/WalletTransactions/WalletTransactions.vue
+++ b/src/renderer/components/Wallet/WalletTransactions/WalletTransactions.vue
@@ -272,6 +272,7 @@ export default {
 
     onPerPageChange ({ currentPerPage }) {
       this.transactionTableRowCount = currentPerPage
+      this.currentPage = 1 // Reset page to 1 when change display rows
       this.__updateParams({ limit: currentPerPage, page: 1 })
       this.loadTransactions()
     },

--- a/src/renderer/components/Wallet/WalletTransactions/WalletTransactions.vue
+++ b/src/renderer/components/Wallet/WalletTransactions/WalletTransactions.vue
@@ -272,7 +272,7 @@ export default {
 
     onPerPageChange ({ currentPerPage }) {
       this.transactionTableRowCount = currentPerPage
-      this.currentPage = 1 // Reset page to 1 when change display rows
+      this.currentPage = 1
       this.__updateParams({ limit: currentPerPage, page: 1 })
       this.loadTransactions()
     },


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
Fix #1606 

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->
Reset the `currentPage` to `1` after updating the rows. 

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
