### PR TITLE
fix:peerValidation

### DIFF
--- a/__tests__/unit/store/modules/peer.spec.js
+++ b/__tests__/unit/store/modules/peer.spec.js
@@ -282,7 +282,9 @@ describe('peer store module', () => {
         }
       })
 
-    const response = await store.dispatch('peer/validatePeer', { ...goodPeer1, timeout: 100 })
+    const url = new URL(`${goodPeer1.host}:${goodPeer1.port}`)
+
+    const response = await store.dispatch('peer/validatePeer', { url, timeout: 100 })
 
     expect(response).toBeObject()
     expect(response).toContainEntries([
@@ -307,9 +309,10 @@ describe('peer store module', () => {
         }
       })
 
+    const url = new URL(`https://${goodPeer1.ip}:${goodPeer1.port}`)
+
     const response = await store.dispatch('peer/validatePeer', {
-      ...goodPeer1,
-      host: `https://${goodPeer1.ip}`,
+      url,
       timeout: 100
     })
 
@@ -325,7 +328,9 @@ describe('peer store module', () => {
       .get('/api/v2/node/configuration')
       .reply(400)
 
-    const response = await store.dispatch('peer/validatePeer', { ...goodPeer1, timeout: 100 })
+    const url = new URL(`${goodPeer1.host}:${goodPeer1.port}`)
+
+    const response = await store.dispatch('peer/validatePeer', { url, timeout: 100 })
     expect(response).toEqual(expect.stringMatching(/^Could not connect$/))
   })
 
@@ -341,7 +346,9 @@ describe('peer store module', () => {
       .get('/api/v2/node/syncing')
       .reply(400)
 
-    const response = await store.dispatch('peer/validatePeer', { ...goodPeer1, timeout: 100 })
+    const url = new URL(`${goodPeer1.host}:${goodPeer1.port}`)
+
+    const response = await store.dispatch('peer/validatePeer', { url, timeout: 100 })
     expect(response).toEqual(expect.stringMatching(/^Status check failed$/))
   })
 
@@ -356,7 +363,9 @@ describe('peer store module', () => {
         }
       })
 
-    const response = await store.dispatch('peer/validatePeer', { ...goodPeer1, timeout: 100 })
+    const url = new URL(`${goodPeer1.host}:${goodPeer1.port}`)
+
+    const response = await store.dispatch('peer/validatePeer', { url, timeout: 100 })
     expect(response).toEqual(expect.stringMatching(/^Wrong network$/))
   })
 })

--- a/src/renderer/components/Network/NetworkCustomPeerModal.vue
+++ b/src/renderer/components/Network/NetworkCustomPeerModal.vue
@@ -122,8 +122,9 @@ export default {
   methods: {
     async validate () {
       this.showLoadingModal = true
+      const url = new URL(`${this.form.host}:${this.form.port}`)
       const response = await this.$store.dispatch('peer/validatePeer', {
-        host: this.form.host,
+        url,
         port: this.form.port
       })
       if (response === false) {

--- a/src/renderer/components/Network/NetworkModal.vue
+++ b/src/renderer/components/Network/NetworkModal.vue
@@ -445,18 +445,14 @@ export default {
       this.showLoadingModal = true
 
       try {
-        let { hostname: host, port, protocol } = new URL(this.form.server)
-
-        if (!port) {
-          port = protocol === 'https:' ? 443 : 80
-        }
-
+        const url = new URL(this.form.server)
         const response = await this.$store.dispatch('peer/validatePeer', {
-          host,
-          port,
+          url,
           ignoreNetwork: true
         })
+
         let success = false
+
         if (response === false) {
           this.$error(this.$t('MODAL_NETWORK.SEED_VALIDATE_FAILED'))
         } else if (typeof response === 'string') {
@@ -468,7 +464,7 @@ export default {
 
         return success
       } catch (error) {
-        //
+        console.error(error)
       }
 
       return false

--- a/src/renderer/components/Wallet/WalletTransactions/WalletTransactions.vue
+++ b/src/renderer/components/Wallet/WalletTransactions/WalletTransactions.vue
@@ -272,6 +272,7 @@ export default {
 
     onPerPageChange ({ currentPerPage }) {
       this.transactionTableRowCount = currentPerPage
+      this.currentPage = 1 // Reset page to 1 when change display rows
       this.__updateParams({ limit: currentPerPage, page: 1 })
       this.loadTransactions()
     },


### PR DESCRIPTION
## Summary

- Fix #1618 and other possible peer validations that uses different protocols and ports. 
- Changes the default behavior of `$store.dispatch('peer/validatePeer')` to accept a `URL()` class instance as input for the peer. This way, the wallet can parse it universally. 

## Checklist

- [x] Documentation
- [x] Tests
- [ ] Ready to be merged

