### PR TITLE
fix: handle invalid address from qr code

### DIFF
--- a/src/renderer/components/Input/InputDelegate.vue
+++ b/src/renderer/components/Input/InputDelegate.vue
@@ -65,7 +65,6 @@ import ModalQrCodeScanner from '@/components/Modal/ModalQrCodeScanner'
 import { MenuDropdown } from '@/components/Menu'
 import Cycled from 'cycled'
 import InputField from './InputField'
-import truncate from '@/filters/truncate'
 import { includes, isEmpty, map, orderBy } from 'lodash'
 
 export default {
@@ -176,7 +175,7 @@ export default {
           publicKey: object.publicKey
         }
 
-        delegate.name = `${truncate(object.username, 25)} (${this.wallet_truncate(object.address)})`
+        delegate.name = `${object.username} (${this.wallet_truncate(object.address)})`
 
         return delegate
       })

--- a/src/renderer/components/Input/InputDelegate.vue
+++ b/src/renderer/components/Input/InputDelegate.vue
@@ -306,7 +306,9 @@ export default {
         this.$error(this.$t('MODAL_QR_SCANNER.DECODE_FAILED', { data: value }))
       }
 
-      this.model = this.$store.getters['delegate/byAddress'](address).username
+      const delegate = this.$store.getters['delegate/byAddress'](address)
+      this.model = delegate ? delegate.username : address
+
       this.$nextTick(() => {
         this.closeDropdown()
         toggle()


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

The `InputDelegate` component assumed that every address scanned from a qr code actually belonged to a delegate. This PR adds an additional check to make sure it does and removes the call to truncate the delegates username, since usernames are capped at a length of 20 by default.

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
