### PR TITLE
refactor: omit themes from list of all plugins

### DIFF
--- a/__tests__/unit/components/PluginManager/PluginManagerSideMenu.spec.js
+++ b/__tests__/unit/components/PluginManager/PluginManagerSideMenu.spec.js
@@ -25,9 +25,15 @@ describe('PluginManagerSideMenu', () => {
   })
 
   describe('Computed properties', () => {
-    describe('categories', () => {
-      it('should return all categories', () => {
-        expect(wrapper.vm.categories).toEqual(['all', 'gaming', 'theme', 'utility', 'other'])
+    describe('pluginCategories', () => {
+      it('should return plugin categories', () => {
+        expect(wrapper.vm.pluginCategories).toEqual(['all', 'gaming', 'utility', 'other'])
+      })
+    })
+
+    describe('otherCategories', () => {
+      it('should return other categories', () => {
+        expect(wrapper.vm.otherCategories).toEqual(['theme'])
       })
     })
   })

--- a/src/renderer/components/PluginManager/PluginManagerSideMenu.vue
+++ b/src/renderer/components/PluginManager/PluginManagerSideMenu.vue
@@ -17,7 +17,7 @@
         @click="emitCategory(category)"
       >
         <span>
-          {{ $t(`PAGES.PLUGIN_MANAGER.MENU_ITEMS.${category.toUpperCase()}`) }}
+          {{ $t(`PAGES.PLUGIN_MANAGER.CATEGORIES.${category.toUpperCase()}`) }}
         </span>
       </li>
     </ul>
@@ -31,7 +31,7 @@
         @click="emitCategory(category)"
       >
         <span>
-          {{ $t(`PAGES.PLUGIN_MANAGER.MENU_ITEMS.${category.toUpperCase()}`) }}
+          {{ $t(`PAGES.PLUGIN_MANAGER.CATEGORIES.${category.toUpperCase()}`) }}
         </span>
       </li>
     </ul>

--- a/src/renderer/components/PluginManager/PluginManagerSideMenu.vue
+++ b/src/renderer/components/PluginManager/PluginManagerSideMenu.vue
@@ -5,9 +5,26 @@
       @click="emitToggle"
     />
 
+    <div class="font-bold mb-4 select-none">
+      {{ $t('PAGES.PLUGIN_MANAGER.HEADER') }}
+    </div>
     <ul class="PluginManagerSideMenu__categories">
       <li
-        v-for="category in categories"
+        v-for="category in pluginCategories"
+        :key="category"
+        class="transition"
+        :class="{ 'active': category === activeCategory }"
+        @click="emitCategory(category)"
+      >
+        <span>
+          {{ $t(`PAGES.PLUGIN_MANAGER.CATEGORIES.${category.toUpperCase()}`) }}
+        </span>
+      </li>
+    </ul>
+
+    <ul class="PluginManagerSideMenu__other-categories">
+      <li
+        v-for="category in otherCategories"
         :key="category"
         class="transition"
         :class="{ 'active': category === activeCategory }"
@@ -42,8 +59,12 @@ export default {
   },
 
   computed: {
-    categories () {
-      return concat(['all'], PLUGINS.categories)
+    pluginCategories () {
+      return concat(['all'], PLUGINS.categories.filter(category => category !== 'theme'))
+    },
+
+    otherCategories () {
+      return ['theme']
     }
   },
 
@@ -63,16 +84,29 @@ export default {
 
 <style lang="postcss" scoped>
 .PluginManagerSideMenu {
-  @apply flex flex-col min-w-48 px-10 my-10 border-r border-theme-line-separator;
+  @apply .flex .flex-col .min-w-48 .px-10 .my-10 .border-r .border-theme-line-separator .overflow-y-auto;
 }
-.PluginManagerSideMenu__categories {
-  @apply list-reset w-full text-theme-page-text-light;
+
+.PluginManagerSideMenu__categories,
+.PluginManagerSideMenu__other-categories {
+  @apply .list-reset .w-full .text-theme-page-text-light;
+}
+.PluginManagerSideMenu__other-categories {
+  @apply .border-t .border-theme-line-separator;
+}
+
+.PluginManagerSideMenu__categories li,
+.PluginManagerSideMenu__other-categories li {
+  @apply .block .font-semibold .py-4 .px-10 .-mx-10 .border-l-3 .border-transparent .cursor-pointer;
 }
 .PluginManagerSideMenu__categories li {
-  @apply block font-semibold py-4 px-10 -mx-10 border-l-3 border-transparent cursor-pointer
+  @apply .px-16;
 }
+
 .PluginManagerSideMenu__categories li:hover,
-.PluginManagerSideMenu__categories li.active {
-  @apply bg-theme-secondary-feature text-theme-page-text border-blue
+.PluginManagerSideMenu__categories li.active,
+.PluginManagerSideMenu__other-categories li:hover,
+.PluginManagerSideMenu__other-categories li.active {
+  @apply .bg-theme-secondary-feature .text-theme-page-text .border-blue;
 }
 </style>

--- a/src/renderer/components/PluginManager/PluginManagerSideMenu.vue
+++ b/src/renderer/components/PluginManager/PluginManagerSideMenu.vue
@@ -17,7 +17,7 @@
         @click="emitCategory(category)"
       >
         <span>
-          {{ $t(`PAGES.PLUGIN_MANAGER.CATEGORIES.${category.toUpperCase()}`) }}
+          {{ $t(`PAGES.PLUGIN_MANAGER.MENU_ITEMS.${category.toUpperCase()}`) }}
         </span>
       </li>
     </ul>
@@ -31,7 +31,7 @@
         @click="emitCategory(category)"
       >
         <span>
-          {{ $t(`PAGES.PLUGIN_MANAGER.CATEGORIES.${category.toUpperCase()}`) }}
+          {{ $t(`PAGES.PLUGIN_MANAGER.MENU_ITEMS.${category.toUpperCase()}`) }}
         </span>
       </li>
     </ul>

--- a/src/renderer/i18n/locales/en-US.js
+++ b/src/renderer/i18n/locales/en-US.js
@@ -654,18 +654,11 @@ export default {
         TITLE: 'Welcome to the Plugin Manager',
         SUBTITLE: 'The easy way to find, manage and install plugins'
       },
-      MENU_ITEMS: {
-        ALL: 'All',
-        GAMING: 'Gaming',
-        UTILITY: 'Utility',
-        THEME: 'Themes',
-        OTHER: 'Other'
-      },
       CATEGORIES: {
         ALL: 'All',
         GAMING: 'Gaming',
         UTILITY: 'Utility',
-        THEME: 'Theme',
+        THEME: 'Themes',
         OTHER: 'Other'
       },
       FILTERS: {

--- a/src/renderer/i18n/locales/en-US.js
+++ b/src/renderer/i18n/locales/en-US.js
@@ -654,6 +654,13 @@ export default {
         TITLE: 'Welcome to the Plugin Manager',
         SUBTITLE: 'The easy way to find, manage and install plugins'
       },
+      MENU_ITEMS: {
+        ALL: 'All',
+        GAMING: 'Gaming',
+        UTILITY: 'Utility',
+        THEME: 'Themes',
+        OTHER: 'Other'
+      },
       CATEGORIES: {
         ALL: 'All',
         GAMING: 'Gaming',

--- a/src/renderer/services/plugin-manager.js
+++ b/src/renderer/services/plugin-manager.js
@@ -206,7 +206,9 @@ export class PluginManager {
 
       try {
         plugin.logo = await this.fetchLogo(plugin.logo)
-      } catch (error) { }
+      } catch (error) {
+        plugin.logo = null
+      }
 
       const validName = validatePackageName(plugin.id).validForNewPackages
       if (!validName) {

--- a/src/renderer/store/modules/plugin.js
+++ b/src/renderer/store/modules/plugin.js
@@ -44,7 +44,9 @@ export default {
 
         let match = true
 
-        if (category && category !== 'all') {
+        if (category === 'all') {
+          match = match && !plugin.config.categories.includes('theme')
+        } else if (category && category !== 'all') {
           match = match && plugin.config.categories.includes(category)
         }
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->

Hides Themes when listing all plugins. Instead, themes will only be visible from their own category

![image](https://user-images.githubusercontent.com/8069294/74745600-0b672780-525c-11ea-80e0-85afc64b70f5.png)

Excluded tests while they are being written in #1583 

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
