### PR TITLE
ci: disable notarisation on forks

### DIFF
--- a/.github/workflows/draft-artifacts.yml
+++ b/.github/workflows/draft-artifacts.yml
@@ -1,54 +1,11 @@
-name: Test & Build
+name: Draft Artifacts
 
 on:
   push:
     branches:
-      - "master"
       - "develop"
-  pull_request:
-    types: [ready_for_review, synchronize, opened]
 
 jobs:
-  lint-unit:
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: [12.x]
-
-    steps:
-      - uses: actions/checkout@v1
-
-      - name: Cache node modules
-        uses: actions/cache@v1
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-node-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: ${{ runner.os }}-node-
-
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
-        with:
-          node-version: ${{ matrix.node-version }}
-
-      - name: Update System
-        run: sudo apt-get update
-
-      - name: Ledger
-        run: sudo apt-get install libudev-dev libusb-1.0-0-dev
-
-      - name: Install
-        run: yarn global add node-gyp && yarn install --frozen-lockfile && npm rebuild
-
-      - name: Lint
-        run: yarn lint
-
-      - name: Test
-        run: node --max-old-space-size=4096 ./node_modules/.bin/jest --config __tests__/unit.jest.conf.js __tests__/unit/ --logHeapUsage --coverage
-
-      - name: Codecov
-        run: ./node_modules/.bin/codecov --token=${{ secrets.CODECOV_TOKEN }}
-
   build-linux:
     runs-on: ubuntu-latest
 
@@ -129,8 +86,18 @@ jobs:
       - name: Install
         run: yarn global add node-gyp && yarn install --frozen-lockfile
 
+      - name: Prepare for app notarization
+        run: |
+          mkdir -p ~/private_keys/
+          echo '${{ secrets.APPLE_API_KEY }}' > ~/private_keys/AuthKey_${{ secrets.APPLE_API_KEY_ID }}.p8
+
       - name: Build
         run: yarn build:mac
+        env:
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_KEY_ISSUER_ID: ${{ secrets.APPLE_API_KEY_ISSUER_ID }}
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
 
       # - name: Upload .zip
       #   uses: actions/upload-artifact@master
@@ -166,6 +133,9 @@ jobs:
       - name: Build
         run: yarn build:win
         shell: cmd
+        env:
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
 
       - name: Upload .exe
         uses: actions/upload-artifact@v1

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,4 +1,4 @@
-name: Draft Release
+name: Publish Release
 
 on:
   push:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -141,6 +141,11 @@ jobs:
           APPLE_API_KEY_ISSUER_ID: ${{ secrets.APPLE_API_KEY_ISSUER_ID }}
           CSC_LINK: ${{ secrets.CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+        if: github.base_ref == undefined
+
+      - name: Build
+        run: yarn build:mac
+        if: github.base_ref != undefined
 
       # - name: Upload .zip
       #   uses: actions/upload-artifact@master
@@ -179,6 +184,12 @@ jobs:
         env:
           CSC_LINK: ${{ secrets.CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+        if: github.base_ref == undefined
+
+      - name: Build
+        run: yarn build:win
+        shell: cmd
+        if: github.base_ref != undefined
 
       - name: Upload .exe
         uses: actions/upload-artifact@v1

--- a/scripts/notarize.js
+++ b/scripts/notarize.js
@@ -3,8 +3,15 @@ const { notarize } = require('electron-notarize')
 
 exports.default = async function notarizing (context) {
   const { electronPlatformName, appOutDir } = context
+
+  // We are not on macOS so we skip notarisation.
   if (electronPlatformName !== 'darwin') {
     return
+  }
+
+  // We are on a fork without the required credentials.
+  if (process.env.GITHUB_BASE_REF !== undefined) {
+    return;
   }
 
   const appName = context.packager.appInfo.productFilename


### PR DESCRIPTION
The `GITHUB_BASE_REF` environment variable only exists when a PR comes from a fork `Only set for forked repositories. The branch of the base repository.` so we can use it to prevent notarisation from forks but still use it for our own needs.

Code signing still needs an adjustment.