### PR TITLE
fix: retrieve fullscreen state after splashscreen

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -72,7 +72,6 @@ function createWindow () {
     fullScreen: false
   })
 
-  const wasFullScreen = windowState.isFullScreen
   windows.main = new BrowserWindow({
     width: windowState.width,
     height: windowState.height,
@@ -92,7 +91,7 @@ function createWindow () {
       windows.loading.close()
     }
     windows.main.show()
-    windows.main.setFullScreen(wasFullScreen)
+    windows.main.setFullScreen(windowState ? windowState.isFullScreen : false)
   })
 
   ipcMain.on('disable-iframe-protection', function (_event, urls) {

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -91,7 +91,7 @@ function createWindow () {
       windows.loading.close()
     }
     windows.main.show()
-    windows.main.setFullScreen(windowState ? windowState.isFullScreen : false)
+    windows.main.setFullScreen(windowState ? Boolean(windowState.isFullScreen) : false)
   })
 
   ipcMain.on('disable-iframe-protection', function (_event, urls) {


### PR DESCRIPTION
Resolve https://github.com/ArkEcosystem/desktop-wallet/issues/1702