### PR TITLE
fix: set the menu tab item to stretch

### DIFF
--- a/src/renderer/components/Menu/MenuTab/MenuTab.vue
+++ b/src/renderer/components/Menu/MenuTab/MenuTab.vue
@@ -96,12 +96,16 @@ export default {
   @apply .flex .flex-col .h-full;
 }
 
+.MenuTab__nav__item {
+  @apply .self-stretch;
+}
+
 .MenuTab__nav__item--active {
   @apply .bg-theme-switch-button .text-theme-button-text;
 }
 
 .MenuTab__nav__item--clickable {
-  @apply bg-theme-voting-banner-background text-theme-page-text opacity-75;
+  @apply .bg-theme-voting-banner-background .text-theme-page-text .opacity-75;
 }
 
 .MenuTab__nav__item--disabled {


### PR DESCRIPTION
## Summary

When the width is less than `<450` the **"Wallet design"** has a line break forcing the menu to increase in size, so the `align-self: stretch` forces the menu item to take up the entire space.

**Before:**

![Screenshot2 from 2020-02-26 10-02-12](https://user-images.githubusercontent.com/1894191/75351972-bc3a7b80-5887-11ea-9c5a-1881d0f52f33.png)

**After:**

![Screenshot from 2020-02-26 10-26-58](https://user-images.githubusercontent.com/1894191/75352014-cceaf180-5887-11ea-8b7d-85f3695ad41d.png)

## Checklist

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged
