### PR TITLE
refactor: adjust bridgechain transaction form validation

### DIFF
--- a/__tests__/unit/components/Transaction/TransactionConfirm/TransactionConfirmBridgechain/TransactionConfirmBridgechainRegistration.spec.js
+++ b/__tests__/unit/components/Transaction/TransactionConfirm/TransactionConfirmBridgechain/TransactionConfirmBridgechainRegistration.spec.js
@@ -99,7 +99,7 @@ describe('TransactionConfirmBridgechainRegistration', () => {
         expect(wrapper.vm.apiPort).toBe(4003)
       })
 
-      it('should return placeholder if no core-api port', () => {
+      it('should return null if no core-api port', () => {
         createWrapper(null, {
           asset: {
             bridgechainRegistration: {
@@ -115,7 +115,7 @@ describe('TransactionConfirmBridgechainRegistration', () => {
           }
         })
 
-        expect(wrapper.vm.apiPort).toBe('-')
+        expect(wrapper.vm.apiPort).toBe(null)
       })
     })
   })

--- a/__tests__/unit/components/Transaction/TransactionConfirm/TransactionConfirmBridgechain/TransactionConfirmBridgechainUpdate.spec.js
+++ b/__tests__/unit/components/Transaction/TransactionConfirm/TransactionConfirmBridgechain/TransactionConfirmBridgechainUpdate.spec.js
@@ -84,7 +84,7 @@ describe('TransactionConfirmBridgechainUpdate', () => {
         expect(wrapper.vm.apiPort).toBe(4003)
       })
 
-      it('should return placeholder if no core-api port', () => {
+      it('should return null if no core-api port', () => {
         createWrapper(null, {
           asset: {
             bridgechainUpdate: {
@@ -100,7 +100,7 @@ describe('TransactionConfirmBridgechainUpdate', () => {
           }
         })
 
-        expect(wrapper.vm.apiPort).toBe('-')
+        expect(wrapper.vm.apiPort).toBe(null)
       })
     })
   })

--- a/__tests__/unit/components/Transaction/TransactionForm/TransactionFormBridgechain/mixin.spec.js
+++ b/__tests__/unit/components/Transaction/TransactionForm/TransactionFormBridgechain/mixin.spec.js
@@ -588,13 +588,21 @@ describe.each([
       })
     })
 
-    describe('hasMoreThanMaximumSeedNodes', () => {
+    describe('hasSeedNodesError', () => {
+      it('should be true if there is an invalid seed node', () => {
+        wrapper.vm.invalidSeeds = [
+          { ip: '0.5.5.5', isInvalid: true }
+        ]
+
+        expect(wrapper.vm.hasSeedNodesError).toBe(true)
+      })
+
       it('should be false if there are less than maximum seed nodes', () => {
         wrapper.vm.$v.form.seedNodes.$model = [
           { ip: '0.5.5.5', isInvalid: false }
         ]
 
-        expect(wrapper.vm.hasMoreThanMaximumSeedNodes).toBe(false)
+        expect(wrapper.vm.hasSeedNodesError).toBe(false)
       })
 
       it('should be true if there are more than maximum seed nodes', () => {
@@ -612,7 +620,7 @@ describe.each([
           { ip: '10.5.5.5', isInvalid: false }
         ]
 
-        expect(wrapper.vm.hasMoreThanMaximumSeedNodes).toBe(true)
+        expect(wrapper.vm.hasSeedNodesError).toBe(true)
       })
     })
 
@@ -703,7 +711,12 @@ describe.each([
         wrapper.vm.$v.form.asset.bridgechainRepository.$reset()
 
         expect(wrapper.vm.$v.form.asset.bridgechainRepository.$dirty).toBe(false)
-        expect(wrapper.vm.$v.form.asset.bridgechainRepository.$invalid).toBe(true)
+        if (componentName === 'TransactionFormBridgechainRegistration') {
+          expect(wrapper.vm.$v.form.asset.bridgechainRepository.$invalid).toBe(true)
+        } else {
+          expect(wrapper.vm.$v.form.asset.bridgechainRepository.$invalid).toBe(false)
+        }
+
         expect(wrapper.vm.bridgechainRepositoryError).toBe(null)
       })
 

--- a/__tests__/unit/components/Transaction/TransactionForm/TransactionFormBridgechain/mixin.spec.js
+++ b/__tests__/unit/components/Transaction/TransactionForm/TransactionFormBridgechain/mixin.spec.js
@@ -865,7 +865,7 @@ describe.each([
         wrapper.vm.$v.form.asset.bridgechainRepository.$model = 'https://github.com/arkecosystem/core.git'
         wrapper.vm.$v.form.asset.bridgechainAssetRepository.$model = 'https://github.com/arkecosystem/core-assets.git'
 
-        const expectedAsset = {
+        let expectedAsset = {
           name: 'bridgechain',
           seedNodes: [
             '1.1.1.1',
@@ -880,8 +880,9 @@ describe.each([
         }
 
         if (componentName === 'TransactionFormBridgechainUpdate') {
-          wrapper.vm.form.asset.bridgechainId = '2a44f340d76ffc3df204c5f38cd355b7496c9065a1ade2ef92071436bd72e867'
-          expectedAsset.bridgechainId = '2a44f340d76ffc3df204c5f38cd355b7496c9065a1ade2ef92071436bd72e867'
+          expectedAsset = {
+            bridgechainId: '2a44f340d76ffc3df204c5f38cd355b7496c9065a1ade2ef92071436bd72e867'
+          }
         }
 
         expect(wrapper.vm.getTransactionData()).toEqual({
@@ -917,7 +918,7 @@ describe.each([
         wrapper.vm.$v.form.asset.bridgechainRepository.$model = 'https://github.com/arkecosystem/core.git'
         wrapper.vm.$v.form.asset.bridgechainAssetRepository.$model = 'https://github.com/arkecosystem/core-assets.git'
 
-        const expectedAsset = {
+        let expectedAsset = {
           name: 'bridgechain',
           seedNodes: [
             '1.1.1.1',
@@ -932,8 +933,9 @@ describe.each([
         }
 
         if (componentName === 'TransactionFormBridgechainUpdate') {
-          wrapper.vm.form.asset.bridgechainId = '2a44f340d76ffc3df204c5f38cd355b7496c9065a1ade2ef92071436bd72e867'
-          expectedAsset.bridgechainId = '2a44f340d76ffc3df204c5f38cd355b7496c9065a1ade2ef92071436bd72e867'
+          expectedAsset = {
+            bridgechainId: '2a44f340d76ffc3df204c5f38cd355b7496c9065a1ade2ef92071436bd72e867'
+          }
         }
 
         expect(wrapper.vm.getTransactionData()).toEqual({

--- a/__tests__/unit/components/Transaction/TransactionForm/TransactionFormBridgechain/mixin.spec.js
+++ b/__tests__/unit/components/Transaction/TransactionForm/TransactionFormBridgechain/mixin.spec.js
@@ -588,6 +588,34 @@ describe.each([
       })
     })
 
+    describe('hasMoreThanMaximumSeedNodes', () => {
+      it('should be false if there are less than maximum seed nodes', () => {
+        wrapper.vm.$v.form.seedNodes.$model = [
+          { ip: '0.5.5.5', isInvalid: false }
+        ]
+
+        expect(wrapper.vm.hasMoreThanMaximumSeedNodes).toBe(false)
+      })
+
+      it('should be true if there are more than maximum seed nodes', () => {
+        wrapper.vm.$v.form.seedNodes.$model = [
+          { ip: '0.5.5.5', isInvalid: false },
+          { ip: '1.5.5.5', isInvalid: false },
+          { ip: '2.5.5.5', isInvalid: false },
+          { ip: '3.5.5.5', isInvalid: false },
+          { ip: '4.5.5.5', isInvalid: false },
+          { ip: '5.5.5.5', isInvalid: false },
+          { ip: '6.5.5.5', isInvalid: false },
+          { ip: '7.5.5.5', isInvalid: false },
+          { ip: '8.5.5.5', isInvalid: false },
+          { ip: '9.5.5.5', isInvalid: false },
+          { ip: '10.5.5.5', isInvalid: false }
+        ]
+
+        expect(wrapper.vm.hasMoreThanMaximumSeedNodes).toBe(true)
+      })
+    })
+
     describe('seedNodeError', () => {
       it('should return null if valid', () => {
         wrapper.vm.$v.seedNode.$model = '5.5.5.5'
@@ -623,74 +651,6 @@ describe.each([
         expect(wrapper.vm.$v.seedNode.$dirty).toBe(true)
         expect(wrapper.vm.$v.seedNode.$invalid).toBe(true)
         expect(wrapper.vm.seedNodeError).toBe('TRANSACTION.BRIDGECHAIN.ERROR_DUPLICATE')
-      })
-
-      it('should return error if too many', () => {
-        wrapper.vm.$v.form.seedNodes.$model = [
-          { ip: '1.5.5.5', isInvalid: false },
-          { ip: '2.5.5.5', isInvalid: false },
-          { ip: '3.5.5.5', isInvalid: false },
-          { ip: '4.5.5.5', isInvalid: false },
-          { ip: '5.5.5.5', isInvalid: false },
-          { ip: '6.5.5.5', isInvalid: false },
-          { ip: '7.5.5.5', isInvalid: false },
-          { ip: '8.5.5.5', isInvalid: false },
-          { ip: '9.5.5.5', isInvalid: false },
-          { ip: '10.5.5.5', isInvalid: false }
-        ]
-        wrapper.vm.$v.seedNode.$model = '6.6.6.6'
-
-        expect(wrapper.vm.$v.seedNode.$dirty).toBe(true)
-        expect(wrapper.vm.$v.seedNode.$invalid).toBe(true)
-        expect(wrapper.vm.seedNodeError).toBe('VALIDATION.TOO_MANY')
-      })
-    })
-
-    describe('seedNodesError', () => {
-      it('should return null if valid', () => {
-        wrapper.vm.$v.form.seedNodes.$model = [
-          { ip: '5.5.5.5', isInvalid: false }
-        ]
-
-        expect(wrapper.vm.$v.form.seedNodes.$dirty).toBe(true)
-        expect(wrapper.vm.$v.form.seedNodes.$invalid).toBe(false)
-        expect(wrapper.vm.seedNodesError).toBe(null)
-      })
-
-      it('should return null if not dirty', () => {
-        wrapper.vm.$v.form.seedNodes.$model = []
-        wrapper.vm.$v.form.seedNodes.$reset()
-
-        expect(wrapper.vm.$v.form.seedNodes.$dirty).toBe(false)
-        expect(wrapper.vm.$v.form.seedNodes.$invalid).toBe(true)
-        expect(wrapper.vm.seedNodesError).toBe(null)
-      })
-
-      it('should return error if empty', () => {
-        wrapper.vm.$v.form.seedNodes.$model = []
-
-        expect(wrapper.vm.$v.form.seedNodes.$dirty).toBe(true)
-        expect(wrapper.vm.$v.form.seedNodes.$invalid).toBe(true)
-        expect(wrapper.vm.seedNodesError).toBe('VALIDATION.REQUIRED')
-      })
-
-      it('should return error if too many', () => {
-        wrapper.vm.$v.form.seedNodes.$model = [
-          { ip: '1.5.5.5', isInvalid: false },
-          { ip: '2.5.5.5', isInvalid: false },
-          { ip: '3.5.5.5', isInvalid: false },
-          { ip: '4.5.5.5', isInvalid: false },
-          { ip: '5.5.5.5', isInvalid: false },
-          { ip: '6.5.5.5', isInvalid: false },
-          { ip: '7.5.5.5', isInvalid: false },
-          { ip: '8.5.5.5', isInvalid: false },
-          { ip: '9.5.5.5', isInvalid: false },
-          { ip: '10.5.5.5', isInvalid: false }
-        ]
-
-        expect(wrapper.vm.$v.form.seedNodes.$dirty).toBe(true)
-        expect(wrapper.vm.$v.form.seedNodes.$invalid).toBe(true)
-        expect(wrapper.vm.seedNodesError).toBe('VALIDATION.TOO_MANY')
       })
     })
 

--- a/src/renderer/components/Input/InputEditableList.vue
+++ b/src/renderer/components/Input/InputEditableList.vue
@@ -33,7 +33,7 @@
 
     <div
       v-if="requiredAndEmpty"
-      class="InputEditableList__no-items text-center"
+      class="InputEditableList__no-items"
     >
       {{ noItemsMessage }}
     </div>

--- a/src/renderer/components/Transaction/TransactionConfirm/TransactionConfirmBridgechain/TransactionConfirmBridgechainRegistration.vue
+++ b/src/renderer/components/Transaction/TransactionConfirm/TransactionConfirmBridgechain/TransactionConfirmBridgechainRegistration.vue
@@ -64,6 +64,14 @@
     >
       {{ transaction.asset.bridgechainRegistration.bridgechainRepository }}
     </ListDividedItem>
+
+    <ListDividedItem
+      v-if="transaction.asset.bridgechainRegistration.bridgechainAssetRepository"
+      class="TransactionConfirmBridgechainRegistration__bridgechain-asset-repo"
+      :label="$t('WALLET_BUSINESS.BRIDGECHAIN.BRIDGECHAIN_ASSET_REPOSITORY')"
+    >
+      {{ transaction.asset.bridgechainRegistration.bridgechainAssetRepository }}
+    </ListDividedItem>
   </ListDivided>
 </template>
 

--- a/src/renderer/components/Transaction/TransactionConfirm/TransactionConfirmBridgechain/TransactionConfirmBridgechainRegistration.vue
+++ b/src/renderer/components/Transaction/TransactionConfirm/TransactionConfirmBridgechain/TransactionConfirmBridgechainRegistration.vue
@@ -99,8 +99,14 @@ export default {
     },
 
     apiPort () {
-      if (!this.transaction.asset.bridgechainRegistration.ports['@arkecosystem/core-api']) {
-        return '-'
+      if (
+        !this.transaction.asset.bridgechainRegistration.ports ||
+        (
+          this.transaction.asset.bridgechainRegistration.ports &&
+          !this.transaction.asset.bridgechainRegistration.ports['@arkecosystem/core-api']
+        )
+      ) {
+        return null
       }
 
       return this.transaction.asset.bridgechainRegistration.ports['@arkecosystem/core-api']

--- a/src/renderer/components/Transaction/TransactionConfirm/TransactionConfirmBridgechain/TransactionConfirmBridgechainUpdate.vue
+++ b/src/renderer/components/Transaction/TransactionConfirm/TransactionConfirmBridgechain/TransactionConfirmBridgechainUpdate.vue
@@ -17,6 +17,7 @@
     </ListDividedItem>
 
     <ListDividedItem
+      v-if="transaction.asset.bridgechainUpdate.seedNodes"
       class="TransactionConfirmBridgechainUpdate__seed-nodes"
       :label="$t('WALLET_BUSINESS.BRIDGECHAIN.SEED_NODES')"
     >
@@ -29,6 +30,7 @@
     </ListDividedItem>
 
     <ListDividedItem
+      v-if="apiPort"
       class="TransactionConfirmBridgechainUpdate__api-port"
       :label="$t('WALLET_BUSINESS.BRIDGECHAIN.API_PORT')"
     >
@@ -61,8 +63,14 @@ export default {
     },
 
     apiPort () {
-      if (!this.transaction.asset.bridgechainUpdate.ports['@arkecosystem/core-api']) {
-        return '-'
+      if (
+        !this.transaction.asset.bridgechainUpdate.ports ||
+        (
+          this.transaction.asset.bridgechainUpdate.ports &&
+          !this.transaction.asset.bridgechainUpdate.ports['@arkecosystem/core-api']
+        )
+      ) {
+        return null
       }
 
       return this.transaction.asset.bridgechainUpdate.ports['@arkecosystem/core-api']

--- a/src/renderer/components/Transaction/TransactionConfirm/TransactionConfirmBridgechain/TransactionConfirmBridgechainUpdate.vue
+++ b/src/renderer/components/Transaction/TransactionConfirm/TransactionConfirmBridgechain/TransactionConfirmBridgechainUpdate.vue
@@ -17,6 +17,22 @@
     </ListDividedItem>
 
     <ListDividedItem
+      v-if="transaction.asset.bridgechainUpdate.bridgechainRepository"
+      class="TransactionConfirmBridgechainUpdate__bridgechain-repo"
+      :label="$t('WALLET_BUSINESS.BRIDGECHAIN.BRIDGECHAIN_REPOSITORY')"
+    >
+      {{ transaction.asset.bridgechainUpdate.bridgechainRepository }}
+    </ListDividedItem>
+
+    <ListDividedItem
+      v-if="transaction.asset.bridgechainUpdate.bridgechainAssetRepository"
+      class="TransactionConfirmBridgechainUpdate__bridgechain-asset-repo"
+      :label="$t('WALLET_BUSINESS.BRIDGECHAIN.BRIDGECHAIN_ASSET_REPOSITORY')"
+    >
+      {{ transaction.asset.bridgechainUpdate.bridgechainAssetRepository }}
+    </ListDividedItem>
+
+    <ListDividedItem
       v-if="transaction.asset.bridgechainUpdate.seedNodes"
       class="TransactionConfirmBridgechainUpdate__seed-nodes"
       :label="$t('WALLET_BUSINESS.BRIDGECHAIN.SEED_NODES')"

--- a/src/renderer/components/Transaction/TransactionForm/TransactionFormBridgechain/mixin.vue
+++ b/src/renderer/components/Transaction/TransactionForm/TransactionFormBridgechain/mixin.vue
@@ -507,7 +507,13 @@ export default {
             return this.bridgechain ? true : required(value)
           },
           tooShort (value) {
-            return this.bridgechain ? true : minLength(minRepositoryLength)(value)
+            if (this.bridgechain) {
+              if (value) {
+                return minLength(minRepositoryLength)(value)
+              }
+              return true
+            }
+            return minLength(minRepositoryLength)(value)
           },
           url (value) {
             return url(value)

--- a/src/renderer/components/Transaction/TransactionForm/TransactionFormBridgechain/mixin.vue
+++ b/src/renderer/components/Transaction/TransactionForm/TransactionFormBridgechain/mixin.vue
@@ -249,7 +249,36 @@ export default {
         return !this.$v.form.seedNodes.$invalid
       }
 
+      if (this.step === 2 && this.isUpdate) {
+        return !this.$v.form.$invalid && !(
+          this.hasSameRepository &&
+          this.hasSameAssetRepository &&
+          this.hasSameSeedNodes &&
+          this.hasSamePorts
+        )
+      }
+
       return !this.$v.form.$invalid
+    },
+
+    hasSameRepository () {
+      return this.form.asset.bridgechainRepository === this.bridgechain.bridgechainRepository
+    },
+
+    hasSameAssetRepository () {
+      return this.form.asset.bridgechainAssetRepository === this.bridgechain.bridgechainAssetRepository
+    },
+
+    hasSameSeedNodes () {
+      return (
+        this.form.seedNodes.length === this.bridgechain.seedNodes.length &&
+        this.form.seedNodes.every(seedNode => this.bridgechain.seedNodes.includes(seedNode.ip))
+      )
+    },
+
+    // will have to be adjusted when multiple ports are supported in the wallet
+    hasSamePorts () {
+      return parseInt(this.form.apiPort) === this.bridgechain.ports['@arkecosystem/core-api']
     },
 
     nameError () {
@@ -351,27 +380,23 @@ export default {
         delete bridgechainAsset.name
         delete bridgechainAsset.genesisHash
 
-        if (bridgechainAsset.bridgechainRepository === this.bridgechain.bridgechainRepository) {
+        if (this.hasSameRepository) {
           delete bridgechainAsset.bridgechainRepository
         }
 
-        if (bridgechainAsset.bridgechainAssetRepository === this.bridgechain.bridgechainAssetRepository) {
+        if (this.hasSameAssetRepository) {
           delete bridgechainAsset.bridgechainAssetRepository
         }
 
-        if (
-          bridgechainAsset.seedNodes.length === this.bridgechain.seedNodes.length &&
-          bridgechainAsset.seedNodes.every(seedNode => this.bridgechain.seedNodes.includes(seedNode))
-        ) {
+        if (this.hasSameSeedNodes) {
           delete bridgechainAsset.seedNodes
         }
 
-        // will have to be adjusted when multiple ports are supported in the wallet
-        if (bridgechainAsset.ports['@arkecosystem/core-api'] === this.bridgechain.ports['@arkecosystem/core-api']) {
+        if (this.hasSamePorts) {
           delete bridgechainAsset.ports
         }
       } else {
-        if (bridgechainAsset.bridgechainAssetRepository && !bridgechainAsset.bridgechainAssetRepository.length) {
+        if (!bridgechainAsset.bridgechainAssetRepository || !bridgechainAsset.bridgechainAssetRepository.length) {
           delete bridgechainAsset.bridgechainAssetRepository
         }
       }

--- a/src/renderer/components/Transaction/TransactionForm/TransactionFormBridgechain/mixin.vue
+++ b/src/renderer/components/Transaction/TransactionForm/TransactionFormBridgechain/mixin.vue
@@ -339,14 +339,46 @@ export default {
 
   methods: {
     getTransactionData () {
+      const bridgechainAsset = Object.assign({}, this.form.asset)
+
+      // will have to be adjusted when multiple ports are supported in the wallet
+      bridgechainAsset.ports['@arkecosystem/core-api'] = parseInt(this.form.apiPort)
+      bridgechainAsset.seedNodes = this.form.seedNodes.map(seedNode => seedNode.ip)
+
       if (this.isUpdate) {
-        this.form.asset.bridgechainId = this.form.asset.genesisHash
+        bridgechainAsset.bridgechainId = bridgechainAsset.genesisHash
+
+        delete bridgechainAsset.name
+        delete bridgechainAsset.genesisHash
+
+        if (bridgechainAsset.bridgechainRepository === this.bridgechain.bridgechainRepository) {
+          delete bridgechainAsset.bridgechainRepository
+        }
+
+        if (bridgechainAsset.bridgechainAssetRepository === this.bridgechain.bridgechainAssetRepository) {
+          delete bridgechainAsset.bridgechainAssetRepository
+        }
+
+        if (
+          bridgechainAsset.seedNodes.length === this.bridgechain.seedNodes.length &&
+          bridgechainAsset.seedNodes.every(seedNode => this.bridgechain.seedNodes.includes(seedNode))
+        ) {
+          delete bridgechainAsset.seedNodes
+        }
+
+        // will have to be adjusted when multiple ports are supported in the wallet
+        if (bridgechainAsset.ports['@arkecosystem/core-api'] === this.bridgechain.ports['@arkecosystem/core-api']) {
+          delete bridgechainAsset.ports
+        }
+      } else {
+        if (bridgechainAsset.bridgechainAssetRepository && !bridgechainAsset.bridgechainAssetRepository.length) {
+          delete bridgechainAsset.bridgechainAssetRepository
+        }
       }
-      this.form.asset.seedNodes = this.form.seedNodes.map(seedNode => seedNode.ip)
 
       const transactionData = {
         address: this.currentWallet.address,
-        asset: this.form.asset,
+        asset: bridgechainAsset,
         passphrase: this.form.passphrase,
         fee: this.getFee(),
         wif: this.form.wif,
@@ -357,8 +389,6 @@ export default {
       if (this.currentWallet.secondPublicKey) {
         transactionData.secondPassphrase = this.form.secondPassphrase
       }
-
-      transactionData.asset.ports['@arkecosystem/core-api'] = parseInt(this.form.apiPort)
 
       return transactionData
     },

--- a/src/renderer/components/Transaction/TransactionForm/TransactionFormBridgechain/mixin.vue
+++ b/src/renderer/components/Transaction/TransactionForm/TransactionFormBridgechain/mixin.vue
@@ -43,7 +43,7 @@
           :items="$v.form.seedNodes.$model"
           :max-items="maxSeedNodes"
           :show-count="true"
-          :is-invalid="hasMoreThanMaximumSeedNodes"
+          :is-invalid="hasSeedNodesError"
           :required="true"
           class="TransactionFormBridgechain__seed-nodes mt-4"
           @remove="emitRemoveSeedNode"
@@ -270,8 +270,8 @@ export default {
       return !this.$v.seedNode.$model.length || !!this.seedNodeError
     },
 
-    hasMoreThanMaximumSeedNodes () {
-      return this.form.seedNodes.length > this.maxSeedNodes
+    hasSeedNodesError () {
+      return this.invalidSeeds.length > 0 || this.form.seedNodes.length > this.maxSeedNodes
     },
 
     seedNodeError () {

--- a/src/renderer/components/Transaction/TransactionPeerList.vue
+++ b/src/renderer/components/Transaction/TransactionPeerList.vue
@@ -2,11 +2,13 @@
   <InputEditableList
     v-model="items"
     :title="title"
+    :max-items="maxItems"
+    :show-count="showCount"
     :readonly="readonly"
     :required="required"
     :helper-text="helperText"
     :is-invalid="isInvalid"
-    :no-items-message="$t('TRANSACTION.BRIDGECHAIN.NO_PEERS')"
+    :no-items-message="$t('TRANSACTION.BRIDGECHAIN.NO_SEED_NODES')"
     @remove="emitRemove"
   >
     <div
@@ -39,6 +41,18 @@ export default {
     items: {
       type: Array,
       required: true
+    },
+
+    maxItems: {
+      type: Number,
+      required: false,
+      default: null
+    },
+
+    showCount: {
+      type: Boolean,
+      required: false,
+      default: false
     },
 
     readonly: {

--- a/src/renderer/i18n/locales/en-US.js
+++ b/src/renderer/i18n/locales/en-US.js
@@ -1088,7 +1088,7 @@ export default {
       BRIDGECHAIN_ASSET_REPOSITORY: 'Bridgechain Asset Repository',
       API_PORT: 'API Port',
       ERROR_DUPLICATE: 'The seed node has already been added',
-      NO_PEERS: 'There are no peers',
+      NO_SEED_NODES: 'There are no seed nodes',
       INVALID_SEEDS: 'You have an invalid seed node - please check it is up and running correctly | You have invalid seed nodes - please check they are up and running correctly'
     },
     WARNING: {

--- a/src/renderer/services/client.js
+++ b/src/renderer/services/client.js
@@ -1121,8 +1121,20 @@ export default class ClientService {
       throw new Error(`Bridgechain Registration fee should be smaller than ${staticFee}`)
     }
 
+    const bridgechainRegistrationAsset = {
+      name: asset.name,
+      seedNodes: asset.seedNodes,
+      ports: asset.ports,
+      genesisHash: asset.genesisHash,
+      bridgechainRepository: asset.bridgechainRepository
+    }
+
+    if (asset.bridgechainAssetRepository && asset.bridgechainAssetRepository.length) {
+      bridgechainRegistrationAsset.bridgechainAssetRepository = asset.bridgechainAssetRepository
+    }
+
     const transaction = new MagistrateCrypto.Builders.BridgechainRegistrationBuilder()
-      .bridgechainRegistrationAsset(asset)
+      .bridgechainRegistrationAsset(bridgechainRegistrationAsset)
       .fee(fee)
 
     passphrase = this.normalizePassphrase(passphrase)

--- a/src/renderer/services/client.js
+++ b/src/renderer/services/client.js
@@ -1121,20 +1121,8 @@ export default class ClientService {
       throw new Error(`Bridgechain Registration fee should be smaller than ${staticFee}`)
     }
 
-    const bridgechainRegistrationAsset = {
-      name: asset.name,
-      seedNodes: asset.seedNodes,
-      ports: asset.ports,
-      genesisHash: asset.genesisHash,
-      bridgechainRepository: asset.bridgechainRepository
-    }
-
-    if (asset.bridgechainAssetRepository && asset.bridgechainAssetRepository.length) {
-      bridgechainRegistrationAsset.bridgechainAssetRepository = asset.bridgechainAssetRepository
-    }
-
     const transaction = new MagistrateCrypto.Builders.BridgechainRegistrationBuilder()
-      .bridgechainRegistrationAsset(bridgechainRegistrationAsset)
+      .bridgechainRegistrationAsset(asset)
       .fee(fee)
 
     passphrase = this.normalizePassphrase(passphrase)


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Changes:

- Show "no peer nodes" error message when list is empty
- Align empty error message to the left
- Add max height to seed node list
- Add count / max count to list and allow to 'overflow'  with items
- Add `required` error message to `name`, `genesisHash` and `bridgechainRepository` upon registration
- excludes unchanged fields from bridgechain update assets
- only shows changed fields in magistrate confirmation modals
- invalidates magistrate forms if no fields have changed

Fixes:

- Fixes the `tooShort` validation on bridgechain updates
- excludes the asset repository from a bridgechain registration asset if empty
- removes the non-existent `VALIDATION.TOO_MANY` error on the seed node input

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
