### PR TITLE
feat: add links to multipayment list on transaction show

### DIFF
--- a/src/renderer/components/Transaction/TransactionMultiPaymentList.vue
+++ b/src/renderer/components/Transaction/TransactionMultiPaymentList.vue
@@ -23,18 +23,26 @@
       />
 
       <div class="flex-1 px-4">
-        <div class="TransactionMultiPaymentList__recipient py-1">
-          <span class="font-bold">
+        <div class="TransactionMultiPaymentList__recipient flex py-1">
+          <span class="font-bold mr-1">
             {{ $t('TRANSACTION.RECIPIENT') }}:
           </span>
 
-          <span>
+          <WalletAddress
+            v-if="showLinks"
+            :address="item.address || item.recipientId"
+            @click="emitClick"
+          >
+            {{ formatWalletAddress(item.address || item.recipientId) }}
+          </WalletAddress>
+
+          <span v-else>
             {{ formatWalletAddress(item.address || item.recipientId) }}
           </span>
         </div>
 
-        <div class="TransactionMultiPaymentList__amount py-1">
-          <span class="font-bold">
+        <div class="TransactionMultiPaymentList__amount flex py-1">
+          <span class="font-bold mr-1">
             {{ $t('TRANSACTION.AMOUNT') }}:
           </span>
 
@@ -50,6 +58,7 @@
 <script>
 import truncate from '@/filters/truncate'
 import { InputEditableList } from '@/components/Input'
+import WalletAddress from '@/components/Wallet/WalletAddress'
 import WalletIdenticon from '@/components/Wallet/WalletIdenticon'
 
 export default {
@@ -57,6 +66,7 @@ export default {
 
   components: {
     InputEditableList,
+    WalletAddress,
     WalletIdenticon
   },
 
@@ -81,6 +91,12 @@ export default {
     },
 
     showCount: {
+      type: Boolean,
+      required: false,
+      default: false
+    },
+
+    showLinks: {
       type: Boolean,
       required: false,
       default: false
@@ -123,6 +139,10 @@ export default {
 
     emitRemove (index) {
       this.$emit('remove', index)
+    },
+
+    emitClick () {
+      this.$emit('click')
     }
   }
 }

--- a/src/renderer/components/Transaction/TransactionShow/TransactionShow.vue
+++ b/src/renderer/components/Transaction/TransactionShow/TransactionShow.vue
@@ -231,7 +231,9 @@
         <TransactionMultiPaymentList
           :title="null"
           :items="transaction.asset.payments"
+          :show-links="true"
           readonly
+          @click="emitClose"
         />
       </ListDividedItem>
     </ListDivided>

--- a/src/renderer/components/Wallet/WalletAddress.vue
+++ b/src/renderer/components/Wallet/WalletAddress.vue
@@ -85,7 +85,9 @@
         @mouseover="onMouseOver"
         @mouseout="onMouseOut"
       >
-        {{ wallet_formatAddress(address, addressLength) }}
+        <slot>
+          {{ wallet_formatAddress(address, addressLength) }}
+        </slot>
       </a>
     </span>
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

This PR adds a new prop to the `TransactionMultiPaymentList` so that the recipients of multipayment transactions can be linked to from the transaction show modal.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
