### PR TITLE
perf: remove summary when marking announcement as read

### DIFF
--- a/src/renderer/components/Announcements/AnnouncementsPost.vue
+++ b/src/renderer/components/Announcements/AnnouncementsPost.vue
@@ -88,7 +88,6 @@ export default {
       required: true
     },
     summary: {
-      type: String,
       required: true,
       validator: value => typeof value === 'string' || value === null
     },

--- a/src/renderer/components/Announcements/AnnouncementsPost.vue
+++ b/src/renderer/components/Announcements/AnnouncementsPost.vue
@@ -89,7 +89,8 @@ export default {
     },
     summary: {
       type: String,
-      required: true
+      required: true,
+      validator: value => typeof value === 'string' || value === null
     },
     url: {
       type: String,

--- a/src/renderer/models/announcement.js
+++ b/src/renderer/models/announcement.js
@@ -10,10 +10,11 @@ export default new BaseModel({
     },
     title: {},
     summary: {
-      format: (data) => trunc(data['content:encoded'], 300).text
+      type: ['string', 'null'],
+      format: data => trunc(data['content:encoded'], 300).text
     },
     url: {
-      format: (data) => data.link
+      format: data => data.link
     },
     isRead: {
       format: () => false

--- a/src/renderer/store/migrations/2.8.2 - remove summary from read announcements.js
+++ b/src/renderer/store/migrations/2.8.2 - remove summary from read announcements.js
@@ -1,0 +1,6 @@
+export default store => {
+  const readAnnouncements = store.getters['announcements/read']
+  store.dispatch('announcements/markAsReadBulk', readAnnouncements)
+
+  store.dispatch('app/setLatestAppliedMigration', '2.8.2')
+}

--- a/src/renderer/store/modules/announcements.js
+++ b/src/renderer/store/modules/announcements.js
@@ -31,6 +31,7 @@ export default {
       const readAnnouncementIndex = state.announcements.findIndex(announcement => announcement.guid === readAnnouncement.guid)
       Vue.set(state.announcements, readAnnouncementIndex, {
         ...readAnnouncement,
+        summary: null,
         isRead: true
       })
     },
@@ -45,6 +46,7 @@ export default {
 
         announcementsToUpdate.push({
           ...announcement,
+          summary: isRead ? null : announcement.summary,
           isRead
         })
       }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Since an announcement can't be marked as `unread` and the summary isn't shown once it has been marked as `read`, there is no reason to keep the summary around.

Includes a migration to remove the summary from already read announcements.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
