### PR TITLE
refactor: more generic userLanguage handling

### DIFF
--- a/src/renderer/mixins/formatter.js
+++ b/src/renderer/mixins/formatter.js
@@ -35,10 +35,15 @@ export default {
      */
     formatter_date (value, format = null) {
       let userLanguage =
-        (window.navigator.userLanguage || window.navigator.language).toLowerCase()
+        (window.navigator.userLanguage || window.navigator.language).toLowerCase() || 'en'
 
-      if (userLanguage === 'en-us') {
-        userLanguage = 'en'
+      const [language, region] = userLanguage.split('-')
+
+      if (
+        (language === 'en' && region === 'us') ||
+        language === region
+      ) {
+        userLanguage = language
       }
 
       try {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

#1753 only correctly reassigns the userLanguage to `en` if it is `en-US`. Other locales, like `de-DE`, `it-IT`, `fr-FR` and so on will also fallback to `en`.

With this more generic approach all locales with the format `xx-XX` are handled correctly.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
