### PR TITLE
fix: update dark theme for disabled button in menu

### DIFF
--- a/src/renderer/components/Wallet/WalletHeading/WalletHeadingSecondaryActions.vue
+++ b/src/renderer/components/Wallet/WalletHeading/WalletHeadingSecondaryActions.vue
@@ -214,6 +214,7 @@ export default {
 .ButtonDropdown__ButtonModal__disabled {
   background-color: var(--theme-option-heading-button-disabled);
   color: var(--theme-option-heading-button-text-disabled);
+  @apply .cursor-not-allowed;
 }
 .ButtonDropdown__ButtonModal__disabled:hover {
   background-color: var(--theme-option-heading-button-disabled-hover);

--- a/src/renderer/styles/_theme.css
+++ b/src/renderer/styles/_theme.css
@@ -191,6 +191,10 @@
   --theme-option-heading-button: #3d456d;
   --theme-option-heading-button-hover: #cc5e60;
   --theme-option-heading-button-text: #8894cf;
+  --theme-option-heading-button-disabled: #3d404f;
+  --theme-option-heading-button-text-disabled: #6d798a;
+  --theme-option-heading-button-disabled-hover: #555869;
+  --theme-option-heading-button-text-disabled-hover: #828d9e;
   --theme-input-toggle-choice: #333644;
   --theme-input-toggle-choice-text: #4c5166;
   --theme-input-field-border: #585c6f;


### PR DESCRIPTION
## Summary

Using the dark theme the "Resign Bussines" button has transparent background.

![Screenshot from 2020-03-05 14-42-00](https://user-images.githubusercontent.com/1894191/76013106-2ab9b200-5ef6-11ea-99c5-db5e4a0161ac.png)

I added the following variables for the dark theme:

```
--theme-option-heading-button-disabled: #3d404f;
--theme-option-heading-button-text-disabled: #6d798a;
--theme-option-heading-button-disabled-hover: #555869;
--theme-option-heading-button-text-disabled-hover: #828d9e;
```

So the result is:

![Screenshot from 2020-03-05 15-17-23](https://user-images.githubusercontent.com/1894191/76013138-3c02be80-5ef6-11ea-9140-56a93b3a5b6d.png)

## Checklist

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged
