### PR TITLE
feat: expose current peer to plugins and allow options in requests

### DIFF
--- a/__tests__/unit/services/plugin-manager/sandbox/peer-current-sandbox.spec.js
+++ b/__tests__/unit/services/plugin-manager/sandbox/peer-current-sandbox.spec.js
@@ -1,15 +1,32 @@
 import { create as createPeerCurrentSandbox } from '@/services/plugin-manager/sandbox/peer-current-sandbox'
 
-const walletApi = {}
-const app = {}
-const peerCurrentSandbox = createPeerCurrentSandbox(walletApi, app)
-peerCurrentSandbox()
+const mockGetter = jest.fn(() => ({
+  ip: '1.1.1.1'
+}))
+
+let walletApi
+let app
+let peerCurrentSandbox
 
 describe('Peer Current Sandbox', () => {
+  beforeEach(() => {
+    walletApi = {}
+    app = {
+      $store: {
+        getters: {
+          'peer/current': mockGetter
+        }
+      }
+    }
+    peerCurrentSandbox = createPeerCurrentSandbox(walletApi, app)
+    peerCurrentSandbox()
+  })
+
   it('should expose functions', () => {
     expect(walletApi.peers).toBeTruthy()
     expect(walletApi.peers.current).toBeTruthy()
     expect(walletApi.peers.current.get).toBeTruthy()
     expect(walletApi.peers.current.post).toBeTruthy()
+    expect(walletApi.peers.getCurrent).toBeTruthy()
   })
 })

--- a/src/renderer/services/plugin-manager/sandbox/peer-current-sandbox.js
+++ b/src/renderer/services/plugin-manager/sandbox/peer-current-sandbox.js
@@ -2,13 +2,21 @@ export function create (walletApi, app) {
   return () => {
     walletApi.peers = {
       current: {
-        get: async (url, timeout = 3000) => {
-          return (await app.$client.client.get(url, { timeout })).body
+        get: async (url, options = {}) => {
+          options.timeout || (options.timeout = 3000)
+
+          return (await app.$client.client.get(url, options)).body
         },
 
-        post: async (url, timeout = 3000) => {
-          return (await app.$client.client.post(url, { timeout })).body
+        post: async (url, options = {}) => {
+          options.timeout || (options.timeout = 3000)
+
+          return (await app.$client.client.post(url, options)).body
         }
+      },
+
+      getCurrent: () => {
+        return app.$store.getters['peer/current']()
       }
     }
   }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

This PR exposes the current peer through the wallet api to plugins and can be retrieved with `walletApi.peers.getCurrent()`. It also refactors the `get` / `post` methods to accept an options object, which for example allows to pass in query parameters instead of having to build the url.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
