### PR TITLE
refactor: allow all global plugin options to be retrieved at once

### DIFF
--- a/__tests__/unit/services/plugin-manager/sandbox/storage-sandbox.spec.js
+++ b/__tests__/unit/services/plugin-manager/sandbox/storage-sandbox.spec.js
@@ -101,8 +101,7 @@ describe('Storage Sandbox', () => {
   })
 
   it('should get all global values', () => {
-    app.$store.getters['session/profileId'] = 'global'
-    const result = walletApi.storage.getOptions()
+    const result = walletApi.storage.getOptions(true)
     expect(Object.keys(result)).toHaveLength(1)
     expect(result).toHaveProperty(globalOptions.key, globalOptions.value)
   })

--- a/src/renderer/services/plugin-manager/sandbox/storage-sandbox.js
+++ b/src/renderer/services/plugin-manager/sandbox/storage-sandbox.js
@@ -1,12 +1,15 @@
 export function create (walletApi, app, plugin) {
   return () => {
+    const getOptions = (global = false) => {
+      return app.$store.getters['plugin/pluginOptions'](
+        plugin.config.id,
+        global ? 'global' : app.$store.getters['session/profileId']
+      )
+    }
+
     walletApi.storage = {
       get: (key, global = false) => {
-        const options = app.$store.getters['plugin/pluginOptions'](
-          plugin.config.id,
-          global ? 'global' : app.$store.getters['session/profileId']
-        )
-
+        const options = getOptions(global)
         return options && options[key]
       },
 
@@ -19,12 +22,7 @@ export function create (walletApi, app, plugin) {
         })
       },
 
-      getOptions: () => {
-        return app.$store.getters['plugin/pluginOptions'](
-          plugin.config.id,
-          app.$store.getters['session/profileId']
-        )
-      }
+      getOptions
     }
   }
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Refactors the storage sandboxes `getOptions` method so that all global options can be retrieved.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
