### PR TITLE
feat: expose profiles themes to plugins

### DIFF
--- a/src/renderer/store/modules/profile.js
+++ b/src/renderer/store/modules/profile.js
@@ -51,9 +51,20 @@ export default new BaseModule(ProfileModel, {
     },
 
     public: (state, _, __, rootGetters) => (all = false) => {
-      const minimiseProfile = (profile) => ({
+      const isDarkTheme = theme => {
+        if (['light', 'dark'].includes(theme)) {
+          return theme === 'dark'
+        }
+        return rootGetters['plugin/themes'][theme].darkMode
+      }
+
+      const minimiseProfile = profile => ({
         avatar: profile.avatar,
         currency: profile.currency,
+        theme: {
+          name: profile.theme,
+          isDark: isDarkTheme(profile.theme)
+        },
         language: profile.language,
         name: profile.name,
         network: rootGetters['network/byId'](profile.networkId),


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

In order to display graphics in the appropriate color scheme (dark / light) plugins need information about the currently defined theme.

This PR adds the `theme` property to the public getter of the profiles store module, which is exposed to the plugin system. The property holds the name and a boolean flag to indicate whether it is a dark or light theme.

```
{ 
  name: "light",
  isDark: false
}
```

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
