### PR TITLE
feat: allow to hide cancel button of confirmation modal

### DIFF
--- a/__tests__/unit/components/Modal/ModalConfirmation.spec.js
+++ b/__tests__/unit/components/Modal/ModalConfirmation.spec.js
@@ -14,6 +14,24 @@ describe('ModalConfirmation', () => {
     expect(wrapper.isVueInstance()).toBeTrue()
   })
 
+  it('should render buttons', () => {
+    expect(wrapper.findAll('button')).toHaveLength(2)
+    expect(wrapper.find('.ModalConfirmation__cancel-button').isVisible())
+    expect(wrapper.find('.ModalConfirmation__continue-button').isVisible())
+  })
+
+  it('should be possible to hide the cancel button', () => {
+    wrapper = shallowMount(ModalConfirmation, {
+      i18n,
+      propsData: {
+        showCancelButton: false
+      }
+    })
+    expect(wrapper.findAll('button')).toHaveLength(1)
+    expect(wrapper.find('.ModalConfirmation__cancel-button').exists()).toBe(false)
+    expect(wrapper.find('.ModalConfirmation__continue-button').isVisible())
+  })
+
   it('should default portal target to "modal"', () => {
     expect(wrapper.props('portalTarget')).toBe('modal')
   })

--- a/src/renderer/components/Modal/ModalConfirmation.vue
+++ b/src/renderer/components/Modal/ModalConfirmation.vue
@@ -28,14 +28,15 @@
 
       <div class="mt-4 flex flex-row">
         <button
-          class="blue-button"
+          v-if="showCancelButton"
+          class="ModalConfirmation__cancel-button blue-button"
           @click="emitCancel"
         >
           {{ cancelButton }}
         </button>
 
         <button
-          class="action-button px-8"
+          class="ModalConfirmation__continue-button action-button py-4 px-8"
           @click="emitContinue"
         >
           {{ continueButton }}
@@ -62,6 +63,11 @@ export default {
       default () {
         return this.$t('MODAL_CONFIRMATION.CANCEL')
       }
+    },
+    showCancelButton: {
+      type: Boolean,
+      required: false,
+      default: true
     },
     containerClasses: {
       type: String,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Under certain circumstances it makes sense to have a confirmation modal with only one option. This PR adds a new prop to the `ModalConfirmation` component which allows to hide the cancel button.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
