### PR TITLE
fix: break words if the vendor field message is large

### DIFF
--- a/src/renderer/components/Transaction/TransactionConfirm/TransactionConfirmTransfer.vue
+++ b/src/renderer/components/Transaction/TransactionConfirm/TransactionConfirmTransfer.vue
@@ -40,6 +40,7 @@
       v-if="transaction.vendorField"
       class="TransactionConfirmTransfer__vendorfield"
       :label="$t('TRANSACTION.VENDOR_FIELD')"
+      item-value-class="w-full break-words"
     >
       {{ transaction.vendorField }}
     </ListDividedItem>

--- a/src/renderer/components/Transaction/TransactionShow/TransactionShow.vue
+++ b/src/renderer/components/Transaction/TransactionShow/TransactionShow.vue
@@ -220,6 +220,7 @@
         v-if="transaction.vendorField"
         :value="transaction.vendorField"
         :label="$t('TRANSACTION.VENDOR_FIELD')"
+        item-value-class="max-w-xs break-words"
       />
 
       <ListDividedItem


### PR DESCRIPTION
## Summary

When a viewing a transaction modal with a large vendor field message, the message up into individual lines to keep the modal at a reasonable size. 

**Before:**

![image](https://user-images.githubusercontent.com/1894191/76270130-e2cac000-6252-11ea-968c-0341cc8ea2ec.png)

**After:**

![Screenshot from 2020-03-09 17-43-48](https://user-images.githubusercontent.com/1894191/76255909-c49e9900-622d-11ea-8713-5188eee93d63.png)

## Checklist

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged
