### PR TITLE
feat: multipayment display modals details

### DIFF
--- a/__tests__/unit/components/Transaction/TransactionConfirm/TransactionConfirmMultiPayment.spec.js
+++ b/__tests__/unit/components/Transaction/TransactionConfirm/TransactionConfirmMultiPayment.spec.js
@@ -1,5 +1,6 @@
 import { createLocalVue, mount } from '@vue/test-utils'
 import installI18n from '../../../__utils__/i18n'
+import CurrencyMixin from '@/mixins/currency'
 import TransactionConfirmMultiPayment from '@/components/Transaction/TransactionConfirm/TransactionConfirmMultiPayment'
 
 const localVue = createLocalVue()
@@ -34,6 +35,7 @@ const createWrapper = (component, transaction) => {
       transaction
     },
     mocks: {
+      currency_toBuilder: jest.fn(CurrencyMixin.methods.currency_toBuilder),
       formatter_networkCurrency: jest.fn((amount) => amount),
       wallet_formatAddress: jest.fn((address) => `formatted-${address}`),
       wallet_name: jest.fn(wallet => wallet)

--- a/src/renderer/components/Transaction/TransactionConfirm/TransactionConfirmMultiPayment.vue
+++ b/src/renderer/components/Transaction/TransactionConfirm/TransactionConfirmMultiPayment.vue
@@ -18,7 +18,7 @@
 
     <ListDividedItem
       class="TransactionConfirmMultiPayment__recipients"
-      :label="$t('TRANSACTION.RECIPIENTS')"
+      :label="`${$t('TRANSACTION.RECIPIENTS')} - ${payments.length}`"
       item-value-class="items-center"
     >
       <TransactionMultiPaymentList

--- a/src/renderer/components/Transaction/TransactionConfirm/TransactionConfirmMultiPayment.vue
+++ b/src/renderer/components/Transaction/TransactionConfirm/TransactionConfirmMultiPayment.vue
@@ -34,6 +34,22 @@
         readonly
       />
     </ListDividedItem>
+
+    <ListDividedItem
+      v-if="transaction.vendorField"
+      class="TransactionConfirmMultiPayment__vendorfield"
+      :label="$t('TRANSACTION.VENDOR_FIELD')"
+      item-value-class="w-full break-words"
+    >
+      {{ transaction.vendorField }}
+    </ListDividedItem>
+
+    <ListDividedItem
+      class="TransactionConfirmMultiPayment__fee"
+      :label="$t('TRANSACTION.FEE')"
+    >
+      {{ formatter_networkCurrency(transaction.fee) }}
+    </ListDividedItem>
   </ListDivided>
 </template>
 

--- a/src/renderer/components/Transaction/TransactionConfirm/TransactionConfirmMultiPayment.vue
+++ b/src/renderer/components/Transaction/TransactionConfirm/TransactionConfirmMultiPayment.vue
@@ -17,6 +17,13 @@
     </ListDividedItem>
 
     <ListDividedItem
+      class="TransactionConfirmMultiPayment__amount"
+      :label="$t('TRANSACTION.MULTI_PAYMENT.TOTAL_AMOUNT')"
+    >
+      {{ formatter_networkCurrency(totalAmount) }}
+    </ListDividedItem>
+
+    <ListDividedItem
       class="TransactionConfirmMultiPayment__recipients"
       :label="`${$t('TRANSACTION.RECIPIENTS')} - ${payments.length}`"
       item-value-class="items-center"
@@ -51,6 +58,16 @@ export default {
   computed: {
     senderLabel () {
       return this.wallet_formatAddress(this.currentWallet.address)
+    },
+
+    totalAmount () {
+      const amount = this.currency_toBuilder(0)
+
+      for (const payment of this.payments) {
+        amount.add(payment.amount)
+      }
+
+      return amount.value
     },
 
     payments () {

--- a/src/renderer/components/Transaction/TransactionConfirm/TransactionConfirmMultiPayment.vue
+++ b/src/renderer/components/Transaction/TransactionConfirm/TransactionConfirmMultiPayment.vue
@@ -96,6 +96,11 @@ export default {
 <style scoped>
 .TransactionConfirmMultiPayment__recipients {
   @apply .overflow-y-auto;
-  max-height: 200px;
+}
+</style>
+
+<style>
+.TransactionConfirmMultiPayment__recipients .InputEditableList__list {
+  max-height: 13rem;
 }
 </style>

--- a/src/renderer/components/Transaction/TransactionModal.vue
+++ b/src/renderer/components/Transaction/TransactionModal.vue
@@ -385,5 +385,6 @@ export default {
 .TransactionModalMultiPayment,
 .TransactionModalMultiSignature {
   min-width: 35rem;
+  max-height: 80vh;
 }
 </style>

--- a/src/renderer/components/Transaction/TransactionShow/TransactionShow.vue
+++ b/src/renderer/components/Transaction/TransactionShow/TransactionShow.vue
@@ -220,7 +220,8 @@
         v-if="transaction.vendorField"
         :value="transaction.vendorField"
         :label="$t('TRANSACTION.VENDOR_FIELD')"
-        item-value-class="max-w-xs break-words"
+        item-label-class="mb-auto"
+        item-value-class="max-w-xs break-words text-right"
       />
 
       <ListDividedItem

--- a/src/renderer/components/Transaction/TransactionShow/TransactionShow.vue
+++ b/src/renderer/components/Transaction/TransactionShow/TransactionShow.vue
@@ -221,7 +221,7 @@
         :value="transaction.vendorField"
         :label="$t('TRANSACTION.VENDOR_FIELD')"
         item-label-class="mb-auto"
-        item-value-class="max-w-xs break-words text-right"
+        item-value-class="max-w-xs break-words text-justify"
       />
 
       <ListDividedItem

--- a/src/renderer/i18n/locales/en-US.js
+++ b/src/renderer/i18n/locales/en-US.js
@@ -1059,9 +1059,10 @@ export default {
     },
     MULTI_PAYMENT: {
       BUTTON_ADD: 'Add',
-      WARNING_DUPLICATE: 'The address is already a recipient',
+      NO_RECIPIENTS: 'There are no recipients',
       RECIPIENTS: 'Recipients',
-      NO_RECIPIENTS: 'There are no recipients'
+      TOTAL_AMOUNT: 'Total amount',
+      WARNING_DUPLICATE: 'The address is already a recipient'
     },
     MULTI_SIGNATURE: {
       ADDRESS: 'Multisignature Address',


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

**TransactionShow**

 - aligns the smartbridge to the right and the label to top

**TransactionConfirmMultiPayment**

 - adds the recipient count
 - adds the total amount
 - adds the vendorfield and fee

**TransactionModal**

- limits the max height to `80vh`

![image](https://user-images.githubusercontent.com/6547002/76301936-7043f980-62bf-11ea-80be-7a84c94cea73.png)
![image](https://user-images.githubusercontent.com/6547002/76301894-59050c00-62bf-11ea-9555-71790acb9e32.png)
![image](https://user-images.githubusercontent.com/6547002/76301902-5dc9c000-62bf-11ea-85d7-409a127e0aee.png)

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
