### PR TITLE
chore: fix alternative currency alignment

### DIFF
--- a/src/renderer/components/Input/InputCurrency.vue
+++ b/src/renderer/components/Input/InputCurrency.vue
@@ -29,7 +29,7 @@
       <div
         v-if="isMarketEnabled && alternativeCurrency"
         :title="alternativeCurrency"
-        class="InputCurrency__alternative-amount flex flex-no-shrink text-grey-dark ml-4"
+        class="InputCurrency__alternative-amount flex flex-no-shrink items-center text-grey-dark ml-4"
       >
         {{ alternativeAmount }}
       </div>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Fixes the vertical alignment of the alternative amount in the currency input.
![image](https://user-images.githubusercontent.com/6547002/76307909-ff560f00-62c9-11ea-8977-e508114d21d4.png)

![image](https://user-images.githubusercontent.com/6547002/76307923-0846e080-62ca-11ea-8b2f-a967b607506f.png)

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
