### PR TITLE
refactor: fix styling of release notes

### DIFF
--- a/src/renderer/components/App/AppUpdater.vue
+++ b/src/renderer/components/App/AppUpdater.vue
@@ -263,18 +263,25 @@ export default {
   max-height: 400px;
   @apply overflow-y-auto;
 }
+.AppUpdater__release-notes h2,
 .AppUpdater__release-notes h3 {
-  @apply my-4 text-lg
+  @apply my-4 text-lg;
+}
+.AppUpdater__release-notes tt {
+  @apply text-sm font-mono;
 }
 .AppUpdater__release-notes li {
-  @apply text-sm text-base leading-tight
+  @apply text-sm text-base leading-tight;
+}
+.AppUpdater__release-notes ul + p {
+  @apply mt-4;
 }
 
 .AppUpdater__footer {
-  @apply flex flex-row justify-center
+  @apply flex flex-row justify-center;
 }
 .AppUpdater__content + footer {
-  @apply mt-5
+  @apply mt-5;
 }
 
 .AppUpdater--maximized {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

The headers used in the github release notes have been changed with the latest release, thus breaking the styling inside the Deskop Wallet. This PR fixes that and adds a few more styles.

![image](https://user-images.githubusercontent.com/6547002/76322035-22d98380-62e3-11ea-988c-97d19f1b2494.png)

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
