### PR TITLE
refactor: wait for next tick when focussing password/passphrase input

### DIFF
--- a/src/renderer/components/Input/InputPassword.vue
+++ b/src/renderer/components/Input/InputPassword.vue
@@ -19,7 +19,7 @@
         :name="name"
         :disabled="isDisabled"
         :type="passwordIsVisible ? 'text' : 'password'"
-        class="InputPassword__input flex flex-grow bg-transparent text-theme-page-text"
+        class="InputPassword__input flex flex-grow bg-transparent text-theme-page-text mr-2"
         @blur="onBlur"
         @focus="onFocus"
       >
@@ -179,8 +179,9 @@ export default {
       this.$v.$reset()
     },
 
-    toggleVisible () {
+    async toggleVisible () {
       this.passwordIsVisible = !this.passwordIsVisible
+      await this.focus()
     },
 
     passwordFeedback () {

--- a/src/renderer/components/Passphrase/PassphraseInput.vue
+++ b/src/renderer/components/Passphrase/PassphraseInput.vue
@@ -20,7 +20,7 @@
         :name="name"
         :disabled="isDisabled"
         :type="passphraseIsVisible ? 'text' : 'password'"
-        class="PassphraseInput__input flex flex-grow bg-transparent text-theme-page-text"
+        class="PassphraseInput__input flex flex-grow bg-transparent text-theme-page-text mr-2"
         @blur="onBlur"
         @focus="onFocus"
       >
@@ -222,9 +222,9 @@ export default {
       this.$v.model.$touch()
     },
 
-    toggleVisible () {
+    async toggleVisible () {
       this.passphraseIsVisible = !this.passphraseIsVisible
-      this.$refs.input.focus()
+      await this.focus()
     }
   },
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

When toggling the visibility of the passphrase and password inputs the focus is set before the component is fully rendered, thus causing the focus to be set at the beginning of the input and not at the end.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
