### PR TITLE
feat: allow plugins to clear all options at once

### DIFF
--- a/__tests__/unit/services/plugin-manager/sandbox/storage-sandbox.spec.js
+++ b/__tests__/unit/services/plugin-manager/sandbox/storage-sandbox.spec.js
@@ -22,11 +22,15 @@ beforeAll(() => {
         }),
         'session/profileId': '1'
       },
-      dispatch: jest.fn((_, data) => {
-        if (!db[data.profileId]) {
-          db[data.profileId] = {}
+      dispatch: jest.fn((action, data) => {
+        if (action === 'plugin/setPluginOption') {
+          if (!db[data.profileId]) {
+            db[data.profileId] = {}
+          }
+          db[data.profileId][data.key] = data.value
+        } else if (action === 'plugin/deletePluginOptionsForProfile') {
+          delete db[data.profileId]
         }
-        db[data.profileId][data.key] = data.value
       })
     }
   }
@@ -55,54 +59,80 @@ describe('Storage Sandbox', () => {
     expect(walletApi.storage.getOptions).toBeTruthy()
     expect(walletApi.storage.get).toBeTruthy()
     expect(walletApi.storage.set).toBeTruthy()
+    expect(walletApi.storage.clear).toBeTruthy()
   })
 
-  it('should set a value to key', () => {
-    walletApi.storage.set(localOptions.key, localOptions.value)
-    expect(app.$store.dispatch).toHaveBeenCalledWith('plugin/setPluginOption', localOptions)
+  describe('set', () => {
+    it('should set a value to key', () => {
+      walletApi.storage.set(localOptions.key, localOptions.value)
+      expect(app.$store.dispatch).toHaveBeenCalledWith('plugin/setPluginOption', localOptions)
+    })
+
+    it('should set a value to global key', () => {
+      walletApi.storage.set(globalOptions.key, globalOptions.value, true)
+      expect(app.$store.dispatch).toHaveBeenCalledWith('plugin/setPluginOption', globalOptions)
+    })
   })
 
-  it('should set a value to global key', () => {
-    walletApi.storage.set(globalOptions.key, globalOptions.value, true)
-    expect(app.$store.dispatch).toHaveBeenCalledWith('plugin/setPluginOption', globalOptions)
+  describe('get', () => {
+    it('should get the value of key', () => {
+      const result = walletApi.storage.get(localOptions.key)
+      expect(app.$store.getters['plugin/pluginOptions']).toHaveBeenCalledWith(plugin.config.id, '1')
+      expect(result).toBe(localOptions.value)
+    })
+
+    it('should get the value of global key from the same profile', () => {
+      const result = walletApi.storage.get(globalOptions.key, true)
+      expect(result).toBe(globalOptions.value)
+    })
+
+    it('should get the value of global key from a different profile', () => {
+      app.$store.getters['session/profileId'] = '2'
+      const result = walletApi.storage.get(globalOptions.key, true)
+      expect(result).toBe(globalOptions.value)
+    })
+
+    it('should NOT get the value of a local key from a different profile', () => {
+      app.$store.getters['session/profileId'] = '2'
+      const result = walletApi.storage.get(localOptions.key)
+      expect(result).toBe(undefined)
+    })
   })
 
-  it('should get the value of key', () => {
-    const result = walletApi.storage.get(localOptions.key)
-    expect(app.$store.getters['plugin/pluginOptions']).toHaveBeenCalledWith(plugin.config.id, '1')
-    expect(result).toBe(localOptions.value)
+  describe('getOptions', () => {
+    it('should get all local values', () => {
+      app.$store.getters['session/profileId'] = '1'
+      let result = walletApi.storage.getOptions()
+      expect(Object.keys(result)).toHaveLength(1)
+      expect(result).toHaveProperty(localOptions.key, localOptions.value)
+      app.$store.getters['session/profileId'] = '2'
+      result = walletApi.storage.getOptions()
+      expect(Object.keys(result)).toHaveLength(0)
+    })
+
+    it('should get all global values', () => {
+      const result = walletApi.storage.getOptions(true)
+      expect(Object.keys(result)).toHaveLength(1)
+      expect(result).toHaveProperty(globalOptions.key, globalOptions.value)
+    })
   })
 
-  it('should get the value of global key from the same profile', () => {
-    const result = walletApi.storage.get(globalOptions.key, true)
-    expect(result).toBe(globalOptions.value)
-  })
+  describe('clear', () => {
+    beforeAll(() => {
+      walletApi.storage.set(localOptions.key, localOptions.value)
+      walletApi.storage.set(globalOptions.key, globalOptions.value, true)
+    })
 
-  it('should get the value of global key from a different profile', () => {
-    app.$store.getters['session/profileId'] = '2'
-    const result = walletApi.storage.get(globalOptions.key, true)
-    expect(result).toBe(globalOptions.value)
-  })
+    it('should clear all local values', () => {
+      expect(walletApi.storage.get(localOptions.key)).toBe(localOptions.value)
+      walletApi.storage.clear()
+      expect(walletApi.storage.get(localOptions.key)).toBe(undefined)
+    })
 
-  it('should NOT get the value of a local key from a different profile', () => {
-    app.$store.getters['session/profileId'] = '2'
-    const result = walletApi.storage.get(localOptions.key)
-    expect(result).toBe(undefined)
-  })
-
-  it('should get all local values', () => {
-    app.$store.getters['session/profileId'] = '1'
-    let result = walletApi.storage.getOptions()
-    expect(Object.keys(result)).toHaveLength(1)
-    expect(result).toHaveProperty(localOptions.key, localOptions.value)
-    app.$store.getters['session/profileId'] = '2'
-    result = walletApi.storage.getOptions()
-    expect(Object.keys(result)).toHaveLength(0)
-  })
-
-  it('should get all global values', () => {
-    const result = walletApi.storage.getOptions(true)
-    expect(Object.keys(result)).toHaveLength(1)
-    expect(result).toHaveProperty(globalOptions.key, globalOptions.value)
+    it('should clear all global values', () => {
+      expect(walletApi.storage.get(globalOptions.key, true)).toBe(globalOptions.value)
+      walletApi.storage.clear(true)
+      expect(walletApi.storage.get(globalOptions.key, true)).toBe(undefined)
+    })
   })
 })

--- a/src/renderer/services/plugin-manager/sandbox/storage-sandbox.js
+++ b/src/renderer/services/plugin-manager/sandbox/storage-sandbox.js
@@ -22,6 +22,13 @@ export function create (walletApi, app, plugin) {
         })
       },
 
+      clear: (global = false) => {
+        app.$store.dispatch('plugin/deletePluginOptionsForProfile', {
+          profileId: global ? 'global' : app.$store.getters['session/profileId'],
+          pluginId: plugin.config.id
+        })
+      },
+
       getOptions
     }
   }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Extends the storage sandbox by a `clear(global = false)` method which allows plugins to clear their stored data at once.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
