### PR TITLE
fix: also delete global options when removing a plugin

### DIFF
--- a/src/renderer/components/PluginManager/PluginManagerModals/PluginRemovalModal.vue
+++ b/src/renderer/components/PluginManager/PluginManagerModals/PluginRemovalModal.vue
@@ -54,7 +54,11 @@ export default {
 
   computed: {
     hasStorage () {
-      return this.plugin.permissions.includes('STORAGE') && this.$store.getters['plugin/profileHasPluginOptions'](this.plugin.id)
+      return this.plugin.permissions.includes('STORAGE') &&
+        (
+          this.$store.getters['plugin/profileHasPluginOptions'](this.plugin.id) ||
+          this.$store.getters['plugin/profileHasPluginOptions'](this.plugin.id, 'global')
+        )
     }
   },
 

--- a/src/renderer/store/modules/plugin.js
+++ b/src/renderer/store/modules/plugin.js
@@ -345,7 +345,7 @@ export default {
       if (state.pluginOptions[profileId] && state.pluginOptions[profileId][pluginId]) {
         Vue.delete(state.pluginOptions[profileId], pluginId)
 
-        if (!Object.keys(state.pluginOptions[profileId].length) {
+        if (!Object.keys(state.pluginOptions[profileId].length)) {
           Vue.delete(state.pluginOptions, profileId)
         }
       }

--- a/src/renderer/store/modules/plugin.js
+++ b/src/renderer/store/modules/plugin.js
@@ -474,6 +474,10 @@ export default {
         }
       }
 
+      if (removeOptions && getters.profileHasPluginOptions(pluginId, 'global')) {
+        dispatch('deletePluginOptionsForProfile', { pluginId, profileId: 'global' })
+      }
+
       try {
         await this._vm.$plugins.deletePlugin(pluginId)
       } catch (error) {

--- a/src/renderer/store/modules/plugin.js
+++ b/src/renderer/store/modules/plugin.js
@@ -344,6 +344,10 @@ export default {
     DELETE_PLUGIN_OPTIONS (state, { pluginId, profileId }) {
       if (state.pluginOptions[profileId] && state.pluginOptions[profileId][pluginId]) {
         Vue.delete(state.pluginOptions[profileId], pluginId)
+
+        if (!Object.keys(state.pluginOptions[profileId].length) {
+          Vue.delete(state.pluginOptions, profileId)
+        }
       }
     },
 

--- a/src/renderer/store/modules/plugin.js
+++ b/src/renderer/store/modules/plugin.js
@@ -345,7 +345,7 @@ export default {
       if (state.pluginOptions[profileId] && state.pluginOptions[profileId][pluginId]) {
         Vue.delete(state.pluginOptions[profileId], pluginId)
 
-        if (!Object.keys(state.pluginOptions[profileId].length)) {
+        if (!Object.keys(state.pluginOptions[profileId]).length) {
           Vue.delete(state.pluginOptions, profileId)
         }
       }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

When removing a plugin only the options stored for a proper plugin id are deleted, the global options are not regarded. With these PR the "remove options" toggle shows up also for globally stored plugin options, and deletes those accordingly.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
