### PR TITLE
fix: add scrollbar to installed plugin list

### DIFF
--- a/src/renderer/components/App/AppSidemenu/AppSidemenuPlugins.vue
+++ b/src/renderer/components/App/AppSidemenu/AppSidemenuPlugins.vue
@@ -3,9 +3,7 @@
     v-click-outside="emitClose"
     :class="{
       'AppSidemenuPlugins--horizontal': isHorizontal,
-      'AppSidemenuPlugins__scrollable--horizontal': isHorizontal && pluginMenuItems.length >= 5,
       'AppSidemenuPlugins': !isHorizontal,
-      'AppSidemenuPlugins__scrollable': !isHorizontal && pluginMenuItems.length >= 5,
       'AppSidemenuPlugins--single': pluginMenuItems.length === 1
     }"
     class="absolute z-20 theme-dark"
@@ -79,10 +77,7 @@ export default {
   transform: translateY(-10%);
 }
 .AppSidemenuPlugins .MenuOptions {
-  @apply .flex-col .max-h-xs;
-}
-.AppSidemenuPlugins__scrollable .MenuOptions {
-  @apply .flex-col .max-h-xs .overflow-y-scroll;
+  @apply .flex-col .max-h-xs .overflow-y-auto;
 }
 
 .AppSidemenuPlugins--single {
@@ -95,9 +90,6 @@ export default {
   top: 5.75rem;
 }
 .AppSidemenuPlugins--horizontal .MenuOptions {
-  @apply .flex-col .max-h-xs;
-}
-.AppSidemenuPlugins__scrollable--horizontal .MenuOptions {
-  @apply .flex-col .max-h-xs .overflow-y-scroll;
+  @apply .flex-col .max-h-xs .overflow-y-auto;
 }
 </style>

--- a/src/renderer/components/App/AppSidemenu/AppSidemenuPlugins.vue
+++ b/src/renderer/components/App/AppSidemenu/AppSidemenuPlugins.vue
@@ -3,7 +3,9 @@
     v-click-outside="emitClose"
     :class="{
       'AppSidemenuPlugins--horizontal': isHorizontal,
+      'AppSidemenuPlugins__scrollable--horizontal': isHorizontal && pluginMenuItems.length >= 5,
       'AppSidemenuPlugins': !isHorizontal,
+      'AppSidemenuPlugins__scrollable': !isHorizontal && pluginMenuItems.length >= 5,
       'AppSidemenuPlugins--single': pluginMenuItems.length === 1
     }"
     class="absolute z-20 theme-dark"
@@ -77,7 +79,10 @@ export default {
   transform: translateY(-10%);
 }
 .AppSidemenuPlugins .MenuOptions {
-  @apply .flex-col .max-h-xs .overflow-y-auto;
+  @apply .flex-col .max-h-xs;
+}
+.AppSidemenuPlugins__scrollable .MenuOptions {
+  @apply .flex-col .max-h-xs .overflow-y-scroll;
 }
 
 .AppSidemenuPlugins--single {
@@ -90,6 +95,9 @@ export default {
   top: 5.75rem;
 }
 .AppSidemenuPlugins--horizontal .MenuOptions {
-  @apply .flex-col .max-h-xs .overflow-y-auto;
+  @apply .flex-col .max-h-xs;
+}
+.AppSidemenuPlugins__scrollable--horizontal .MenuOptions {
+  @apply .flex-col .max-h-xs .overflow-y-scroll;
 }
 </style>

--- a/src/renderer/components/App/AppSidemenu/AppSidemenuPlugins.vue
+++ b/src/renderer/components/App/AppSidemenu/AppSidemenuPlugins.vue
@@ -14,23 +14,17 @@
       :single-column="false"
       class="whitespace-no-wrap"
     >
-      <div
-        v-for="(columnItems, columnId) in pluginMenuItems"
-        :key="columnId"
-      >
-        <MenuOptionsItem
-          v-for="(menuItem, menuId) in columnItems"
-          :key="menuId"
-          :title="menuItem.title"
-          @click="navigateToRoute(menuItem.routeName)"
-        />
-      </div>
+      <MenuOptionsItem
+        v-for="(menuItem, menuId) in pluginMenuItems"
+        :key="menuId"
+        :title="menuItem.title"
+        @click="navigateToRoute(menuItem.routeName)"
+      />
     </MenuOptions>
   </div>
 </template>
 
 <script>
-import { chunk } from 'lodash'
 import { MenuOptions, MenuOptionsItem } from '@/components/Menu'
 
 export default {
@@ -52,18 +46,12 @@ export default {
       type: Boolean,
       required: false,
       default: false
-    },
-
-    itemsPerColumn: {
-      type: Number,
-      required: false,
-      default: 5
     }
   },
 
   computed: {
     pluginMenuItems () {
-      return chunk(this.$store.getters['plugin/menuItems'], this.itemsPerColumn)
+      return this.$store.getters['plugin/menuItems']
     }
   },
 
@@ -88,6 +76,9 @@ export default {
   top: 19rem;
   transform: translateY(-10%);
 }
+.AppSidemenuPlugins .MenuOptions {
+  @apply .flex-col .max-h-xs .overflow-y-auto;
+}
 
 .AppSidemenuPlugins--single {
   top: 22.2rem;
@@ -97,5 +88,8 @@ export default {
   width: 300px;
   right: 8.5rem;
   top: 5.75rem;
+}
+.AppSidemenuPlugins--horizontal .MenuOptions {
+  @apply .flex-col .max-h-xs .overflow-y-auto;
 }
 </style>


### PR DESCRIPTION
## Summary

If 5+ plugins are installed then add a scrollbar to the plugin list.

**before:**

![image (1)](https://user-images.githubusercontent.com/1894191/76462679-d95f6600-63c0-11ea-9e01-763582021bf6.png)

**after:**

![Peek 2020-03-11 17-38](https://user-images.githubusercontent.com/1894191/76462635-c51b6900-63c0-11ea-9b02-52dab0766d13.gif)


## Checklist

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged
