### PR TITLE
refactor: try to fetch local plugin images first

### DIFF
--- a/src/renderer/services/plugin-manager.js
+++ b/src/renderer/services/plugin-manager.js
@@ -378,7 +378,13 @@ export class PluginManager {
       } catch (error) {
         pluginConfig.logo = null
       }
+    }
 
+    try {
+      pluginConfig.images = pluginConfig.images.map(image => {
+        return fs.readFileSync(`${pluginPath}/images/${image.split('/').pop()}`).toString('base64')
+      })
+    } catch (error) {
       try {
         pluginConfig.images = await this.fetchImages(pluginConfig.images)
       } catch (error) {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Fixes: fetching of the preview images was nested in the catch black, therefore was never called when the service successfully read the logo file of a locally installed plugin.

Refactors: instead of fetching the preview images from the defined URLs directly, try to get the images from a default path first (`images/`).

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
