### PR TITLE
fix: close modal using the esc key after pressing other keys

### DIFF
--- a/src/renderer/components/Modal/ModalWindow.vue
+++ b/src/renderer/components/Modal/ModalWindow.vue
@@ -158,7 +158,7 @@ export default {
   }),
 
   mounted () {
-    document.addEventListener('keyup', this.onEscKey, { once: true })
+    document.addEventListener('keyup', this.onEscKey, false)
     this.$eventBus.on('change', this.onChange)
   },
 
@@ -198,7 +198,7 @@ export default {
     },
 
     onEscKey (event) {
-      if (event.keyCode === 27) {
+      if (event.key === 'Escape') {
         this.emitClose()
       }
     },


### PR DESCRIPTION
## Summary

Fixes #1827. 

The `once` property in `addEventListener` has been removed because if true, the listener would be automatically removed when invoked.

The `keyCode` is  deprecated: https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode

The problem with using `keyCode` is that non-English keyboards can produce different outputs and even keyboards with different layouts can produce inconsistent results.

## Checklist

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged
