### PR TITLE
refactor: activate the plugin menu item when navigating to plugin route

### DIFF
--- a/__tests__/unit/components/App/AppSidemenu/AppSidemenu.spec.js
+++ b/__tests__/unit/components/App/AppSidemenu/AppSidemenu.spec.js
@@ -113,11 +113,19 @@ describe('AppSidemenu', () => {
     expect(wrapper.vm.isImportantNotificationVisible).toBe(false)
   })
 
-  it('should toggle & close plugin menu state', () => {
-    expect(wrapper.vm.isPluginMenuVisible).toBe(false)
-    wrapper.vm.toggleShowPluginMenu()
-    expect(wrapper.vm.isPluginMenuVisible).toBe(true)
-    wrapper.vm.closeShowPlugins()
-    expect(wrapper.vm.isPluginMenuVisible).toBe(false)
+  describe('Plugin Menu', () => {
+    it('should toggle & close plugin menu state', () => {
+      expect(wrapper.vm.isPluginMenuVisible).toBe(false)
+      wrapper.vm.toggleShowPluginMenu()
+      expect(wrapper.vm.isPluginMenuVisible).toBe(true)
+      wrapper.vm.closeShowPlugins()
+      expect(wrapper.vm.isPluginMenuVisible).toBe(false)
+    })
+
+    it('should activate the plugin menu item when \'setActive\' is true', () => {
+      expect(wrapper.vm.activeItem).toBe('mock_route')
+      wrapper.vm.closeShowPlugins(true)
+      expect(wrapper.vm.activeItem).toBe('plugin-pages')
+    })
   })
 })

--- a/src/renderer/components/App/AppSidemenu/AppSidemenu.vue
+++ b/src/renderer/components/App/AppSidemenu/AppSidemenu.vue
@@ -224,7 +224,11 @@ export default {
       this.isPluginMenuVisible = !this.isPluginMenuVisible
     },
 
-    closeShowPlugins () {
+    closeShowPlugins (setActive) {
+      if (setActive) {
+        this.setActive('plugin-pages')
+      }
+
       this.isPluginMenuVisible = false
     }
   }

--- a/src/renderer/components/App/AppSidemenu/AppSidemenuPlugins.vue
+++ b/src/renderer/components/App/AppSidemenu/AppSidemenuPlugins.vue
@@ -69,7 +69,7 @@ export default {
 
   methods: {
     navigateToRoute (routeName) {
-      this.$emit('close')
+      this.$emit('close', true)
       this.$router.push({ name: routeName })
     },
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

With these changes the plugin page menu item gets activated upon navigating to a plugin page.

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
