### PR TITLE
fix: remove sort option for IPFS from table

### DIFF
--- a/src/renderer/components/Transaction/TransactionTable/TransactionTable.vue
+++ b/src/renderer/components/Transaction/TransactionTable/TransactionTable.vue
@@ -222,7 +222,8 @@ export default {
           label: this.$t('TRANSACTION.HASH'),
           field: 'asset.ipfs',
           tdClass: 'text-right md:w-3/5',
-          thClass: 'text-right md:w-3/5'
+          thClass: 'text-right md:w-3/5',
+          sortable: false
         })
       } else {
         columns.push(...[


### PR DESCRIPTION
Removes the sorting capabilities of the `hash` column over IPFS. This prevents erros from unsortable parameters. 

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
