### PR TITLE
feat: add scope to plugin routes and menu items

### DIFF
--- a/__tests__/unit/services/plugin-manager/setup/menu-items-setup.spec.js
+++ b/__tests__/unit/services/plugin-manager/setup/menu-items-setup.spec.js
@@ -9,7 +9,7 @@ const plugin = new Plugin({
 
 plugin.routes = [
   {
-    name: 'test'
+    name: '1:test'
   }
 ]
 

--- a/__tests__/unit/services/plugin-manager/setup/routes-setup.spec.js
+++ b/__tests__/unit/services/plugin-manager/setup/routes-setup.spec.js
@@ -64,7 +64,7 @@ describe('Routes Items Setup', () => {
     const customSetup = createRoutesSetup(plugin, pluginObject, sandbox)
     customSetup()
 
-    expect(plugin.routes.length).toBe(0)
-    expect(sandbox.app.$router.addRoutes).toHaveBeenCalledTimes(0)
+    expect(plugin.routes.length).toBe(1)
+    expect(sandbox.app.$router.addRoutes).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/renderer/services/plugin-manager/sandbox/route-sandbox.js
+++ b/src/renderer/services/plugin-manager/sandbox/route-sandbox.js
@@ -4,10 +4,20 @@ export function create (walletApi, plugin, app) {
   return () => {
     walletApi.route = {
       get: () => {
-        return { ...app.$route, matched: [] }
+        return {
+          ...app.$route,
+          name: app.$route.name.split(':')[1],
+          fullName: app.$route.name,
+          matched: []
+        }
       },
       goTo: routeName => {
-        const route = getAllRoutes(app, plugin).find(route => routeName === route.name)
+        const route = getAllRoutes(app, plugin).find(route => {
+          return (
+            route.name === routeName ||
+            route.name === [plugin.config.id, routeName].join(':')
+          )
+        })
         if (route) {
           app.$router.push(route)
         }

--- a/src/renderer/services/plugin-manager/setup/menu-items-setup.js
+++ b/src/renderer/services/plugin-manager/setup/menu-items-setup.js
@@ -7,7 +7,11 @@ export function create (plugin, pluginObject, sandbox, profileId) {
       return
     }
 
-    const pluginMenuItems = normalizeJson(pluginObject.getMenuItems())
+    const pluginMenuItems = normalizeJson(pluginObject.getMenuItems().map(menuItem => ({
+      ...menuItem,
+      routeName: [plugin.config.id, menuItem.routeName].join(':')
+    })))
+
     if (pluginMenuItems && Array.isArray(pluginMenuItems) && pluginMenuItems.length) {
       const allRoutes = getAllRoutes(sandbox.app, plugin)
       const menuItems = pluginMenuItems.reduce((valid, menuItem) => {

--- a/src/renderer/services/plugin-manager/setup/routes-setup.js
+++ b/src/renderer/services/plugin-manager/setup/routes-setup.js
@@ -7,7 +7,11 @@ export function create (plugin, pluginObject, sandbox) {
       return
     }
 
-    const pluginRoutes = normalizeJson(pluginObject.getRoutes())
+    const pluginRoutes = normalizeJson(pluginObject.getRoutes().map(route => ({
+      ...route,
+      name: [plugin.config.id, route.name].join(':')
+    })))
+
     if (pluginRoutes && Array.isArray(pluginRoutes) && pluginRoutes.length) {
       const allRoutes = getAllRoutes(sandbox.app)
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Multiple plugins that define the same routes can currently result in unexpected routing. For example the following configuration will potentially route to the original ARK Explorer plugin (if installed and enabled):

```
    this.routes = [
      {
        path: '/my-ark-explorer,
        name: 'ark-explorer',
        component: 'MyExplorer
      }
    ]

    this.menuItems = [
      {
        routeName: 'ark-explorer',
        title: 'My ARK Explorer'
      }
    ]
```

This PR scopes the plugin routes under the plugin's id. Navigation through the `ROUTES` permission can still be done without using the scope.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
