### PR TITLE
feat: add names to plugin themes

### DIFF
--- a/src/renderer/components/App/AppSidemenu/AppSidemenuSettings.vue
+++ b/src/renderer/components/App/AppSidemenu/AppSidemenuSettings.vue
@@ -52,7 +52,7 @@
             <MenuDropdown
               v-if="pluginThemes"
               ref="theme-menu"
-              container-classes="theme-light"
+              container-classes="theme-light whitespace-no-wrap"
               :items="themes"
               :value="sessionTheme"
               @select="setTheme"
@@ -311,7 +311,17 @@ export default {
         : this.$store.getters['plugin/themes']
     },
     themes () {
-      return ['light', 'dark', ...Object.keys(this.pluginThemes)]
+      const pluginThemes = {}
+
+      for (const [themeId, config] of Object.entries(this.pluginThemes)) {
+        pluginThemes[themeId] = config.name
+      }
+
+      return {
+        light: this.$t('COMMON.THEMES.LIGHT'),
+        dark: this.$t('COMMON.THEMES.DARK'),
+        ...pluginThemes
+      }
     }
   },
 

--- a/src/renderer/i18n/locales/en-US.js
+++ b/src/renderer/i18n/locales/en-US.js
@@ -46,6 +46,10 @@ export default {
     SKIP: 'Skip',
     START: 'Start',
     THEME: 'Theme',
+    THEMES: {
+      LIGHT: 'Default: Light',
+      DARK: 'Default: Dark'
+    },
     TIME_FORMAT: 'Time format',
     URL: 'URL',
     VERIFIED_ADDRESS: 'This is a verified address',

--- a/src/renderer/pages/Profile/ProfileEdition.vue
+++ b/src/renderer/pages/Profile/ProfileEdition.vue
@@ -263,6 +263,7 @@
                   :class="{
                     'ProfileEdition__field--modified': modified.theme && modified.theme !== profile.theme
                   }"
+                  container-classes="whitespace-no-wrap"
                   :items="themes"
                   :value="theme"
                   @select="selectTheme"
@@ -583,7 +584,17 @@ export default {
         : this.$store.getters['plugin/themes']
     },
     themes () {
-      return ['light', 'dark', ...Object.keys(this.pluginThemes)]
+      const pluginThemes = {}
+
+      for (const [themeId, config] of Object.entries(this.pluginThemes)) {
+        pluginThemes[themeId] = config.name
+      }
+
+      return {
+        light: this.$t('COMMON.THEMES.LIGHT'),
+        dark: this.$t('COMMON.THEMES.DARK'),
+        ...pluginThemes
+      }
     }
   },
 

--- a/src/renderer/services/plugin-manager/setup/themes-setup.js
+++ b/src/renderer/services/plugin-manager/setup/themes-setup.js
@@ -12,16 +12,20 @@ export function create (plugin, pluginObject, sandbox, profileId) {
     const pluginThemes = normalizeJson(pluginObject.getThemes())
     if (pluginThemes && typeof pluginThemes === 'object') {
       // Validate the configuration of each theme and ensure that their CSS exist
-      const themes = Object.keys(pluginThemes).reduce((valid, themeName) => {
-        const config = pluginThemes[themeName]
+      const themes = Object.keys(pluginThemes).reduce((valid, themeId) => {
+        const config = pluginThemes[themeId]
 
         if (typeof config.darkMode === 'boolean' && typeof config.cssPath === 'string') {
           const cssPath = path.join(plugin.fullPath, 'src', config.cssPath)
           if (!fs.existsSync(cssPath)) {
-            throw new Error(`No file found on \`${config.cssPath}\` for theme "${themeName}"`)
+            throw new Error(`No file found on \`${config.cssPath}\` for theme "${themeId}"`)
           }
 
-          valid[themeName] = { ...config, cssPath }
+          valid[themeId] = {
+            ...config,
+            name: config.name || themeId,
+            cssPath
+          }
         }
         return valid
       }, {})


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

With this PR plugin themes can have an additional `name` property in their config, which will show up in the respective dropdowns in the app sidemenu and profile edition page.

This also adds localisation to the default light / dark themes and prefixes them with `Default: `.

![image](https://user-images.githubusercontent.com/6547002/76705781-d5925300-66e2-11ea-9844-fc7098334933.png)

I will add sorting to the plugin themes once #1823 is merged to not duplicate the necessary changes.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
