### PR TITLE
fix: plugin footer override on destroy

### DIFF
--- a/__tests__/unit/components/Plugin/PluginWrapper.spec.js
+++ b/__tests__/unit/components/Plugin/PluginWrapper.spec.js
@@ -50,7 +50,7 @@ describe('PluginWrapper', () => {
       vue.nextTick(() => {
         expect(spy).toHaveBeenCalledWith({
           to: 'plugin-footer',
-          from: 'plugin-wrapper',
+          from: 'plugin-wrapper'
         })
         done()
       })

--- a/__tests__/unit/components/Plugin/PluginWrapper.spec.js
+++ b/__tests__/unit/components/Plugin/PluginWrapper.spec.js
@@ -1,0 +1,89 @@
+import { createLocalVue, mount } from '@vue/test-utils'
+import PluginWrapper from '@/components/Plugin/PluginWrapper'
+import { Wormhole } from 'portal-vue'
+
+const vue = createLocalVue()
+
+jest.mock('portal-vue', () => ({
+  Wormhole: {
+    open: jest.fn(),
+    close: jest.fn()
+  }
+}))
+
+describe('PluginWrapper', () => {
+  const mountComponent = config => {
+    return mount(PluginWrapper, config)
+  }
+
+  describe('when there is a footer slot', () => {
+    it('should open a Wormhole when mounted', done => {
+      const spy = jest.spyOn(Wormhole, 'open')
+
+      const wrapper = mountComponent({
+        slots: {
+          footer: '<div></div>'
+        }
+      })
+
+      vue.nextTick(() => {
+        expect(spy).toHaveBeenCalledWith({
+          to: 'plugin-footer',
+          from: 'plugin-wrapper',
+          passengers: wrapper.vm.footerSlot
+        })
+        done()
+      })
+
+      spy.mockRestore()
+    })
+
+    it('should close a Wormhole when destroyed', done => {
+      const spy = jest.spyOn(Wormhole, 'close')
+
+      const wrapper = mountComponent({
+        slots: {
+          footer: '<div></div>'
+        }
+      }).destroy()
+
+      vue.nextTick(() => {
+        expect(spy).toHaveBeenCalledWith({
+          to: 'plugin-footer',
+          from: 'plugin-wrapper',
+        })
+        done()
+      })
+
+      spy.mockRestore()
+    })
+  })
+
+  describe('when there is no footer slot', () => {
+    it('should not open a Wormhole when mounted', done => {
+      const spy = jest.spyOn(Wormhole, 'open')
+
+      const wrapper = mountComponent()
+
+      vue.nextTick(() => {
+        expect(spy).not.toHaveBeenCalled()
+        done()
+      })
+
+      spy.mockRestore()
+    })
+
+    it('should not close a Wormhole when destroyed', done => {
+      const spy = jest.spyOn(Wormhole, 'close')
+
+      const wrapper = mountComponent().destroy()
+
+      vue.nextTick(() => {
+        expect(spy).not.toHaveBeenCalled()
+        done()
+      })
+
+      spy.mockRestore()
+    })
+  })
+})

--- a/__tests__/unit/components/Plugin/PluginWrapper.spec.js
+++ b/__tests__/unit/components/Plugin/PluginWrapper.spec.js
@@ -41,7 +41,7 @@ describe('PluginWrapper', () => {
     it('should close a Wormhole when destroyed', done => {
       const spy = jest.spyOn(Wormhole, 'close')
 
-      const wrapper = mountComponent({
+      mountComponent({
         slots: {
           footer: '<div></div>'
         }
@@ -63,7 +63,7 @@ describe('PluginWrapper', () => {
     it('should not open a Wormhole when mounted', done => {
       const spy = jest.spyOn(Wormhole, 'open')
 
-      const wrapper = mountComponent()
+      mountComponent()
 
       vue.nextTick(() => {
         expect(spy).not.toHaveBeenCalled()
@@ -76,7 +76,7 @@ describe('PluginWrapper', () => {
     it('should not close a Wormhole when destroyed', done => {
       const spy = jest.spyOn(Wormhole, 'close')
 
-      const wrapper = mountComponent().destroy()
+      mountComponent().destroy()
 
       vue.nextTick(() => {
         expect(spy).not.toHaveBeenCalled()

--- a/src/renderer/components/Plugin/PluginWrapper.vue
+++ b/src/renderer/components/Plugin/PluginWrapper.vue
@@ -21,7 +21,7 @@ export default {
     }
   },
 
-  destroyed () {
+  beforeDestroy () {
     if (this.footerSlot) {
       this.$nextTick(() => {
         Wormhole.close({

--- a/src/renderer/components/Plugin/PluginWrapper.vue
+++ b/src/renderer/components/Plugin/PluginWrapper.vue
@@ -3,26 +3,33 @@ import { Wormhole } from 'portal-vue'
 export default {
   name: 'PluginWrapper',
 
+  computed: {
+    footerSlot () {
+      return this.$slots.footer
+    }
+  },
+
   mounted () {
-    const footerSlot = this.$slots.footer
-    if (footerSlot) {
+    if (this.footerSlot) {
       this.$nextTick(() => {
         Wormhole.open({
           to: 'plugin-footer',
           from: 'plugin-wrapper',
-          passengers: footerSlot
+          passengers: this.footerSlot
         })
       })
     }
   },
 
   destroyed () {
-    this.$nextTick(() => {
-      Wormhole.close({
-        to: 'plugin-footer',
-        from: 'plugin-wrapper'
+    if (this.footerSlot) {
+      this.$nextTick(() => {
+        Wormhole.close({
+          to: 'plugin-footer',
+          from: 'plugin-wrapper'
+        })
       })
-    })
+    }
   },
 
   render (h) {

--- a/src/renderer/components/Plugin/PluginWrapper.vue
+++ b/src/renderer/components/Plugin/PluginWrapper.vue
@@ -16,6 +16,15 @@ export default {
     }
   },
 
+  destroyed () {
+    this.$nextTick(() => {
+      Wormhole.close({
+        to: 'plugin-footer',
+        from: 'plugin-wrapper'
+      })
+    })
+  },
+
   render (h) {
     const children = this.$slots.default
     return children


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

When a plugin changes the app footer in one of it's components a wormhole is opened with the respective content. This wormhole however isn't closed when the plugin wrapper is destroyed, causing the change of the footer to be persistent.

This PR closes the wormhole when the plugin wrapper is destroyed.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
