### PR TITLE
chore: remove the cursor and opacity for avatar and background selection

### DIFF
--- a/src/renderer/pages/Profile/ProfileEdition.vue
+++ b/src/renderer/pages/Profile/ProfileEdition.vue
@@ -897,8 +897,18 @@ export default {
 .ProfileEdition__name .ListDividedItem__value .InputText .InputField__wrapper {
   height: 0;
 }
+
 .ProfileEdition__avatar .InputGrid__container {
   grid-template-columns: repeat(4, 4rem) !important;
   grid-gap: 1rem !important;
+}
+.ProfileEdition__avatar .SelectionAvatar .InputGrid__container button:first-child,
+.ProfileEdition__avatar .SelectionAvatar .InputGrid__container button:first-child .InputGridItem {
+  @apply .cursor-default .opacity-100;
+}
+
+.ProfileEdition__background .SelectionBackgroundGrid .InputGrid__container button:first-child,
+.ProfileEdition__background .SelectionBackgroundGrid .InputGrid__container button:first-child .InputGridItem {
+  @apply .cursor-default .opacity-100;
 }
 </style>

--- a/src/renderer/pages/Profile/ProfileNew.vue
+++ b/src/renderer/pages/Profile/ProfileNew.vue
@@ -79,7 +79,7 @@
                 />
               </div>
 
-              <div class="flex items-center justify-between mt-5 pt-5 mb-2 border-t border-theme-line-separator border-dashed">
+              <div class="ProfileNew__avatar flex items-center justify-between mt-5 pt-5 mb-2 border-t border-theme-line-separator border-dashed">
                 <div class="mr-2">
                   <h5 class="mb-2">
                     {{ $t('COMMON.AVATAR') }}
@@ -169,7 +169,7 @@
                 />
               </div>
 
-              <div class="flex items-center justify-between">
+              <div class="ProfileNew__background flex items-center justify-between">
                 <div>
                   <h5 class="mb-2">
                     {{ $t('COMMON.BACKGROUND') }}
@@ -447,3 +447,15 @@ export default {
   }
 }
 </script>
+
+<style lang="postcss">
+.ProfileNew__avatar .SelectionAvatar .InputGrid__container button:first-child,
+.ProfileNew__avatar .SelectionAvatar .InputGrid__container button:first-child .InputGridItem {
+  @apply .cursor-default .opacity-100;
+}
+
+.ProfileNew__background .SelectionBackgroundGrid .InputGrid__container button:first-child,
+.ProfileNew__background .SelectionBackgroundGrid .InputGrid__container button:first-child .InputGridItem {
+  @apply .cursor-default .opacity-100;
+}
+</style>


### PR DESCRIPTION
## Summary

When creating and editing a new profile, avatar and background images should not have click action. So there is no need for a cursor pointer and opacity styles.

**Current Behavior**

![Peek 2020-04-07 15-26](https://user-images.githubusercontent.com/1894191/78710864-717f3b00-78ec-11ea-861f-803a771c458d.gif)

![Peek 2020-04-07 15-27](https://user-images.githubusercontent.com/1894191/78710871-75ab5880-78ec-11ea-9258-09b0a8f2200b.gif)

## Checklist

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged
