### PR TITLE
chore(config): add plugin comment

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -113,6 +113,8 @@ exports.MARKET = {
   }
 }
 
+// This section resolves ARK Desktop-Wallet Plugins from the NPM registry.
+// It should remain "ARK", unless there there is an existing NPM module for a projects own Plugins.
 exports.PLUGINS = {
   adapters: ['npm'],
   pluginsUrl: 'https://raw.githubusercontent.com/ark-ecosystem-desktop-plugins/config/master/plugins.json',

--- a/config/index.js
+++ b/config/index.js
@@ -113,8 +113,8 @@ exports.MARKET = {
   }
 }
 
-// This section resolves ARK Desktop-Wallet Plugins from the NPM registry.
-// It should remain "ARK", unless there there is an existing NPM module for a projects own Plugins.
+// This section handles fetching Desktop-Wallet Plugins from the NPM registry.
+// It should remain "ARK" unless intentionally implementing a custom package.
 exports.PLUGINS = {
   adapters: ['npm'],
   pluginsUrl: 'https://raw.githubusercontent.com/ark-ecosystem-desktop-plugins/config/master/plugins.json',


### PR DESCRIPTION
## Summary

Minor change adding a comment about changing the plugin config.

It's already fairly obvious the plugin section shouldn't be changed when you look at what it does,
but this comment could still be pretty useful for others.

```javascript

// This section handles fetching Desktop-Wallet Plugins from the NPM registry.
// It should remain "ARK" unless intentionally implementing a custom package.

```

## Checklist

- [x] Ready to be merged
