### PR TITLE
fix: timeout NPM requests and continue execution

### DIFF
--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -289,7 +289,12 @@ export default {
   methods: {
     async loadEssential () {
       // We need to await plugins in order for all plugins to load properly
-      await this.$plugins.init(this)
+      try {
+        await this.$plugins.init(this)
+      } catch {
+        this.$error('Failed to load plugins. NPM might be down.')
+      }
+
       await this.$store.dispatch('network/load')
       const currentProfileId = this.$store.getters['session/profileId']
       await this.$store.dispatch('session/reset')
@@ -332,7 +337,11 @@ export default {
 
       ipcRenderer.send('splashscreen:app-ready')
 
-      await Promise.all([this.$plugins.fetchPluginsFromAdapter(), this.$plugins.fetchPluginsList()])
+      try {
+        await Promise.all([this.$plugins.fetchPluginsFromAdapter(), this.$plugins.fetchPluginsList()])
+      } catch {
+        this.$error('Failed to load plugins. NPM might be down.')
+      }
     },
 
     __watchProfile () {

--- a/src/renderer/services/plugin-manager.js
+++ b/src/renderer/services/plugin-manager.js
@@ -4,7 +4,6 @@ import { I18N, PLUGINS } from '@config'
 import { dayjs } from '@/services/datetime'
 import * as fs from 'fs'
 import * as fsExtra from 'fs-extra'
-import got from 'got'
 import { partition } from 'lodash'
 import { upperFirst } from '@/utils'
 import * as path from 'path'
@@ -17,6 +16,7 @@ import { PluginSandbox } from './plugin-manager/plugin-sandbox'
 import { PluginSetup } from './plugin-manager/plugin-setup'
 import { validatePluginPath } from './plugin-manager/utils/validate-plugin-path'
 import validatePackageName from 'validate-npm-package-name'
+import { reqwest } from '@/utils/http'
 
 let rootPath = path.resolve(__dirname, '../../../')
 if (process.env.NODE_ENV === 'production') {
@@ -207,7 +207,13 @@ export class PluginManager {
   }
 
   async fetchLogo (url) {
-    const { body } = await got(url, { encoding: null })
+    const {
+      body
+    } = await reqwest(url, {
+      encoding: null,
+      timeout: 100,
+      retry: 0
+    })
     return body.toString('base64')
   }
 
@@ -219,7 +225,7 @@ export class PluginManager {
     const requests = []
     for (const imageUrl of images) {
       requests.push(
-        got(imageUrl, { encoding: null }).then(response => response.body.toString('base64'))
+        reqwest(imageUrl, { encoding: null }).then(response => response.body.toString('base64'))
       )
     }
 
@@ -241,13 +247,13 @@ export class PluginManager {
 
       try {
         plugin.logo = await this.fetchLogo(plugin.logo)
-      } catch (error) {
+      } catch {
         plugin.logo = null
       }
 
       try {
         plugin.images = await this.fetchImages(plugin.images)
-      } catch (error) {
+      } catch {
         plugin.images = []
       }
 
@@ -290,7 +296,7 @@ export class PluginManager {
     const { owner, repository, branch } = this.parsePluginUrl(url)
 
     const baseUrl = `https://raw.githubusercontent.com/${owner}/${repository}/${branch}`
-    const { body } = await got(`${baseUrl}/package.json`, { json: true })
+    const { body } = await reqwest(`${baseUrl}/package.json`, { json: true })
 
     let plugin
 
@@ -367,7 +373,11 @@ export class PluginManager {
 
   async fetchPluginsList () {
     try {
-      const { body } = await got(`${PLUGINS.pluginsUrl}?ts=${(new Date()).getTime()}`, { json: true })
+      const {
+        body
+      } = await reqwest(`${PLUGINS.pluginsUrl}?ts=${(new Date()).getTime()}`, {
+        json: true
+      })
       this.app.$store.dispatch('plugin/setWhitelisted', { scope: 'global', plugins: body.plugins })
       this.app.$store.dispatch('plugin/setBlacklisted', { scope: 'global', plugins: body.blacklist })
     } catch (error) {

--- a/src/renderer/services/plugin-manager/adapters/npm-adapter.js
+++ b/src/renderer/services/plugin-manager/adapters/npm-adapter.js
@@ -1,7 +1,7 @@
 import { PLUGINS } from '@config'
 import { chunk } from 'lodash'
-import got from 'got'
 import packageJson from 'package-json'
+import { reqwest } from '@/utils/http'
 
 const CHUNKSIZE = 50
 
@@ -47,7 +47,9 @@ class NpmAdapter {
   async fetchPlugins (options = {}) {
     const keywords = PLUGINS.keywords.join(' ')
 
-    const { body } = await got('/-/v1/search', {
+    const {
+      body
+    } = await reqwest('/-/v1/search', {
       query: {
         text: `keywords:${keywords}`,
         from: options.from || 0,
@@ -55,7 +57,8 @@ class NpmAdapter {
         t: Date.now()
       },
       baseUrl: this.baseUrl,
-      json: true
+      json: true,
+      timeout: 3000
     })
 
     return {

--- a/src/renderer/services/wallet.js
+++ b/src/renderer/services/wallet.js
@@ -2,8 +2,8 @@ import * as bip39 from 'bip39'
 import { Crypto, Identities } from '@arkecosystem/crypto'
 import { version as mainnetVersion } from '@config/networks/mainnet'
 import store from '@/store'
-import got from 'got'
 import { CryptoUtils } from './crypto/utils'
+import { reqwest } from '@/utils/http'
 
 export default class WalletService {
   /*
@@ -106,7 +106,7 @@ export default class WalletService {
     }
 
     const neoUrl = 'https://neoscan.io/api/main_net/v1/get_last_transactions_by_address/'
-    const response = await got(neoUrl + address, {
+    const response = await reqwest(neoUrl + address, {
       json: true
     })
 

--- a/src/renderer/store/modules/network.js
+++ b/src/renderer/store/modules/network.js
@@ -6,8 +6,8 @@ import { isEmpty } from '@/utils'
 import eventBus from '@/plugins/event-bus'
 import NetworkModel from '@/models/network'
 import Client from '@/services/client'
-import got from 'got'
 import Vue from 'vue'
+import { reqwest } from '@/utils/http'
 
 export default new BaseModule(NetworkModel, {
 
@@ -100,7 +100,7 @@ export default new BaseModule(NetworkModel, {
 
         if (network.knownWalletsUrl) {
           try {
-            const knownWallets = await got(network.knownWalletsUrl, {
+            const knownWallets = await reqwest(network.knownWalletsUrl, {
               json: true
             })
             network.knownWallets = knownWallets.body

--- a/src/renderer/utils/http.js
+++ b/src/renderer/utils/http.js
@@ -1,0 +1,9 @@
+import got from 'got'
+
+export const reqwest = (url, options = {}) => got(url, {
+  ...{
+    timeout: 1000,
+    retry: 0
+  },
+  ...options
+})


### PR DESCRIPTION
`got` by default has no timeout which means requests are ongoing until the server terminates them. Also, any exceptions thrown during the plugin manager bootstrap weren't handled so the wallet would get stuck.