### PR TITLE
fix: ensure that password has value before validating it and better regex

### DIFF
--- a/__tests__/unit/components/Input/InputPassword.spec.js
+++ b/__tests__/unit/components/Input/InputPassword.spec.js
@@ -75,9 +75,29 @@ describe('InputPassword', () => {
     })
   })
 
+  describe('when the password does not include a lowercase character', () => {
+    it('should provide feedback about it', () => {
+      mountData.propsData.value = 'A123'
+      mountData.propsData.minLength = 2
+      const wrapper = mount(InputPassword, mountData)
+
+      expect(wrapper.vm.passwordFeedback()).toEqual('VALIDATION.PASSWORD.LOWER_CASE')
+    })
+  })
+
+  describe('when the password does not include an uppercase character', () => {
+    it('should provide feedback about it', () => {
+      mountData.propsData.value = 'a123'
+      mountData.propsData.minLength = 2
+      const wrapper = mount(InputPassword, mountData)
+
+      expect(wrapper.vm.passwordFeedback()).toEqual('VALIDATION.PASSWORD.UPPER_CASE')
+    })
+  })
+
   describe('when the password does not include a number', () => {
     it('should provide feedback about it', () => {
-      mountData.propsData.value = 'aaaabbbb'
+      mountData.propsData.value = 'aB'
       mountData.propsData.minLength = 2
       const wrapper = mount(InputPassword, mountData)
 
@@ -87,7 +107,7 @@ describe('InputPassword', () => {
 
   describe('when the password does not include a special character', () => {
     it('should provide feedback about it', () => {
-      mountData.propsData.value = 'aaaa0000'
+      mountData.propsData.value = 'aB0'
       mountData.propsData.minLength = 2
       const wrapper = mount(InputPassword, mountData)
 
@@ -97,7 +117,7 @@ describe('InputPassword', () => {
 
   describe('when the password follows all the constraints', () => {
     it('should not provide feedback', () => {
-      const value = 'aaaa000+'
+      const value = 'aB1+'
       mountData.propsData.value = value
       mountData.propsData.minLength = value.length
       const wrapper = mount(InputPassword, mountData)

--- a/src/renderer/components/Input/InputPassword.vue
+++ b/src/renderer/components/Input/InputPassword.vue
@@ -195,9 +195,21 @@ export default {
 
       if (this.minLength && this.model.length < this.minLength) {
         return this.$t('VALIDATION.PASSWORD.TOO_SHORT', [this.minLength])
-      } else if (!this.model.match(/[0-9]+/)) {
+      }
+
+      if (!this.model.match(/[a-z]/)) {
+        return this.$t('VALIDATION.PASSWORD.LOWER_CASE')
+      }
+
+      if (!this.model.match(/[A-Z]/)) {
+        return this.$t('VALIDATION.PASSWORD.UPPER_CASE')
+      }
+
+      if (!this.model.match(/[0-9]/)) {
         return this.$t('VALIDATION.PASSWORD.NUMBERS')
-      } else if (!this.model.match(/[^a-zA-Z0-9]+/)) {
+      }
+
+      if (!this.model.match(/\W|_/)) {
         return this.$t('VALIDATION.PASSWORD.SPECIAL_CHARACTERS')
       }
 
@@ -217,22 +229,29 @@ export default {
 
         return true
       },
-      isValid () {
-        if (!this.isRequired && !this.model.length) {
-          return true
-        } else if (!this.isCreate) {
-          return true
-        }
-
-        if (this.minLength && this.model.length < this.minLength) {
-          return false
-        } else if (!this.model.match(/[0-9]+/)) {
-          return false
-        } else if (!this.model.match(/[^a-zA-Z0-9]+/)) {
+      isValid (value) {
+        if (!value) {
           return false
         }
 
-        return true
+        if (!this.isRequired && !value.length) {
+          return true
+        }
+
+        if (!this.isCreate) {
+          return true
+        }
+
+        if (this.minLength && value.length < this.minLength) {
+          return false
+        }
+
+        const containsLowercase = /[a-z]/.test(value)
+        const containsUppercase = /[A-Z]/.test(value)
+        const containsNumbers = /[0-9]/.test(value)
+        const containsSpecial = /\W|_/.test(value)
+
+        return containsLowercase && containsUppercase && containsNumbers && containsSpecial
       }
     }
   }

--- a/src/renderer/i18n/locales/en-US.js
+++ b/src/renderer/i18n/locales/en-US.js
@@ -182,6 +182,8 @@ export default {
     },
     PASSWORD: {
       TOO_SHORT: 'Your password must be at least {0} characters long',
+      LOWER_CASE: 'Your password must contain at least 1 lowercase character',
+      UPPER_CASE: 'Your password must contain at least 1 uppercase character',
       NUMBERS: 'Your password must contain at least 1 number',
       SPECIAL_CHARACTERS: 'Your password must contain at least 1 special character',
       NO_MATCH: 'Your passwords do not match'


### PR DESCRIPTION
> Resolves https://github.com/ArkEcosystem/desktop-wallet/issues/1895

Ensures that a value is set when `InputPassword#isValid` is called. Also adds a bit stricter and more readable regex validation to ensure certain strength criteria are met.