### PR TITLE
fix: does not show success message when canceling a save file dialog

### DIFF
--- a/src/renderer/components/Transaction/TransactionConfirm/TransactionConfirm.vue
+++ b/src/renderer/components/Transaction/TransactionConfirm/TransactionConfirm.vue
@@ -170,9 +170,14 @@ export default {
 
       try {
         const path = await this.electron_writeFile(raw, defaultPath)
-        this.$success(this.$t('TRANSACTION.SUCCESS.SAVE_OFFLINE', { path }))
-      } catch (e) {
-        this.$error(this.$t('TRANSACTION.ERROR.SAVE_OFFLINE', { error: e.message }))
+
+        if (path) {
+          this.$success(this.$t('TRANSACTION.SUCCESS.SAVE_OFFLINE', { path }))
+        } else {
+          return
+        }
+      } catch (error) {
+        this.$error(this.$t('TRANSACTION.ERROR.SAVE_OFFLINE', { error: error.message }))
       }
     }
   }
@@ -181,7 +186,7 @@ export default {
 
 <style lang="postcss" scoped>
 .TransactionConfirm__send-button:hover > span {
-  @apply .bg-blue
+  @apply .bg-blue;
 }
 .TransactionConfirm__send-button,
 .TransactionConfirm__send-button > span {


### PR DESCRIPTION
## Summary

Canceling the save file dialog should not show a success message.

**Steps to Reproduce**

1. Go to wallets
2. Select a wallet
3. Click on "Send" button
4. Fill out the transaction form
5. Click on "Next" button
6. Click on "Save" button
7. Close / cancel the dialog box
8. See success message

![Screenshot from 2020-05-21 10-37-11](https://user-images.githubusercontent.com/1894191/82567710-221b6400-9b54-11ea-9fb2-e2037ec0cddc.png)

## Checklist

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged
