### PR TITLE
feat(ledger): add schnorr support

### DIFF
--- a/__tests__/unit/__mocks__/@arkecosystem/ledger-transport.js
+++ b/__tests__/unit/__mocks__/@arkecosystem/ledger-transport.js
@@ -2,7 +2,9 @@ export class ARKTransport {
   constructor () {
     this.getPublicKey = jest.fn(() => '0278a28d0eac9916ef46613d9dbac706acc218e64864d4b4c1fcb0c759b6205b2b')
     this.signMessage = jest.fn(() => 'SIGNATURE')
+    this.signMessageWithSchnorr = jest.fn(() => 'SIGNATURE')
     this.signTransaction = jest.fn(() => 'SIGNATURE')
+    this.signTransactionWithSchnorr = jest.fn(() => 'SIGNATURE')
     this.getVersion = jest.fn(() => '1.0.0')
   }
 }

--- a/__tests__/unit/services/ledger-service.spec.js
+++ b/__tests__/unit/services/ledger-service.spec.js
@@ -63,6 +63,15 @@ describe('LedgerService', () => {
     })
   })
 
+  describe('signTransactionWithSchnorr', () => {
+    it('should run', async () => {
+      const response = await ledgerService.signTransactionWithSchnorr('44\'/1\'/0\'/0/0', '1234')
+
+      expect(response).toBeTruthy()
+      expect(ledgerService.ledger.signTransactionWithSchnorr).toHaveBeenCalledTimes(1)
+    })
+  })
+
   describe('signMessage', () => {
     it('should run', async () => {
       ledgerService.ledger.signMessage.mockClear()
@@ -71,6 +80,17 @@ describe('LedgerService', () => {
 
       expect(response).toBeTruthy()
       expect(ledgerService.ledger.signMessage).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('signMessageWithSchnorr', () => {
+    it('should run', async () => {
+      ledgerService.ledger.signMessageWithSchnorr.mockClear()
+
+      const response = await ledgerService.signMessageWithSchnorr('44\'/1\'/0\'/0/0', Buffer.from('1234'))
+
+      expect(response).toBeTruthy()
+      expect(ledgerService.ledger.signMessageWithSchnorr).toHaveBeenCalledTimes(1)
     })
   })
 

--- a/__tests__/unit/services/transaction.spec.js
+++ b/__tests__/unit/services/transaction.spec.js
@@ -842,7 +842,7 @@ describe('Services > Transaction', () => {
     })
   })
 
-  describe('ledgerSign', () => {
+  describe('ledgerSignWithSchnorr', () => {
     const vmMock = {
       $store: {
         // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -875,7 +875,7 @@ describe('Services > Transaction', () => {
       spyTranslate.mockRestore()
     })
 
-    it('should sign the transaction', async () => {
+    it('should schnorr sign the transaction', async () => {
       transactionObject.sign(senderPassphrase)
       const transactionJson = transactionObject.getStruct()
 
@@ -884,7 +884,7 @@ describe('Services > Transaction', () => {
       const signature = transactionObject.data.signature
 
       spyDispatch.mockImplementation((key) => {
-        if (key === 'ledger/signTransaction') {
+        if (key === 'ledger/signTransactionWithSchnorr') {
           return signature
         }
       })
@@ -910,7 +910,7 @@ describe('Services > Transaction', () => {
       const signature = transactionObject.data.signature
 
       spyDispatch.mockImplementation((key) => {
-        if (key === 'ledger/signTransaction') {
+        if (key === 'ledger/signTransactionWithSchnorr') {
           return signature
         }
       })
@@ -943,7 +943,7 @@ describe('Services > Transaction', () => {
       const signature = transactionObject.data.signature
 
       spyDispatch.mockImplementation((key) => {
-        if (key === 'ledger/signTransaction') {
+        if (key === 'ledger/signTransactionWithSchnorr') {
           return signature
         }
       })

--- a/__tests__/unit/store/modules/ledger.spec.js
+++ b/__tests__/unit/store/modules/ledger.spec.js
@@ -249,6 +249,37 @@ describe('ledger store module', () => {
     })
   })
 
+  describe('signTransactionWithSchnorr', () => {
+    it('should call ledger service', async () => {
+      await store.dispatch('ledger/connect')
+      await store.dispatch('ledger/setSlip44', 1234)
+
+      const spy = jest.spyOn(ledgerService, 'signTransactionWithSchnorr').mockReturnValue('SIGNATURE')
+
+      const response = await store.dispatch('ledger/signTransactionWithSchnorr', {
+        accountIndex: 1,
+        transactionBytes: 'abc'
+      })
+
+      expect(response).toBe('SIGNATURE')
+      expect(spy).toHaveBeenNthCalledWith(1, '44\'/1234\'/1\'/0/0', 'abc')
+
+      spy.mockRestore()
+    })
+
+    it('should fail with invalid accountIndex', async () => {
+      await expect(store.dispatch('ledger/signTransactionWithSchnorr')).rejects.toThrow(/.*accountIndex must be a Number$/)
+    })
+
+    it('should fail when not connected', async () => {
+      await disconnectLedger()
+      await expect(store.dispatch('ledger/signTransactionWithSchnorr', {
+        accountIndex: 1,
+        transactionBytes: 'abc'
+      })).rejects.toThrow(/.*Ledger not connected$/)
+    })
+  })
+
   describe('signMessage', () => {
     it('should call ledger service', async () => {
       await store.dispatch('ledger/connect')
@@ -276,6 +307,37 @@ describe('ledger store module', () => {
       await expect(store.dispatch('ledger/signMessage', {
         accountIndex: 1,
         messageBytes: Buffer.from('abc', 'utf-8')
+      })).rejects.toThrow(/.*Ledger not connected$/)
+    })
+  })
+
+  describe('signMessageWithSchnorr', () => {
+    it('should call ledger service', async () => {
+      await store.dispatch('ledger/connect')
+      await store.dispatch('ledger/setSlip44', 1234)
+
+      const spy = jest.spyOn(ledgerService, 'signMessageWithSchnorr').mockReturnValue('SIGNATURE')
+
+      const response = await store.dispatch('ledger/signMessageWithSchnorr', {
+        accountIndex: 1,
+        messageBytes: 'abc'
+      })
+
+      expect(response).toBe('SIGNATURE')
+      expect(spy).toHaveBeenNthCalledWith(1, '44\'/1234\'/1\'/0/0', 'abc')
+
+      spy.mockRestore()
+    })
+
+    it('should fail with invalid accountIndex', async () => {
+      await expect(store.dispatch('ledger/signMessageWithSchnorr')).rejects.toThrow(/.*accountIndex must be a Number$/)
+    })
+
+    it('should fail when not connected', async () => {
+      await disconnectLedger()
+      await expect(store.dispatch('ledger/signMessageWithSchnorr', {
+        accountIndex: 1,
+        messageBytes: 'abc'
       })).rejects.toThrow(/.*Ledger not connected$/)
     })
   })

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@arkecosystem/client": "^1.0.5",
     "@arkecosystem/core-magistrate-crypto": "^2.6.27",
     "@arkecosystem/crypto": "^2.6.27",
-    "@arkecosystem/ledger-transport": "^1.1.1",
+    "@arkecosystem/ledger-transport": "^1.1.2",
     "@arkecosystem/peers": "^0.3.0",
     "@arkecosystem/platform-sdk": "^0.0.2",
     "@babel/runtime": "^7.4.2",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@arkecosystem/client": "^1.0.5",
     "@arkecosystem/core-magistrate-crypto": "^2.6.27",
     "@arkecosystem/crypto": "^2.6.27",
-    "@arkecosystem/ledger-transport": "^1.0.5",
+    "@arkecosystem/ledger-transport": "^1.1.0",
     "@arkecosystem/peers": "^0.3.0",
     "@arkecosystem/platform-sdk": "^0.0.2",
     "@babel/runtime": "^7.4.2",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@arkecosystem/client": "^1.0.5",
     "@arkecosystem/core-magistrate-crypto": "^2.6.27",
     "@arkecosystem/crypto": "^2.6.27",
-    "@arkecosystem/ledger-transport": "^1.1.0",
+    "@arkecosystem/ledger-transport": "^1.1.1",
     "@arkecosystem/peers": "^0.3.0",
     "@arkecosystem/platform-sdk": "^0.0.2",
     "@babel/runtime": "^7.4.2",

--- a/src/renderer/services/ledger-service.js
+++ b/src/renderer/services/ledger-service.js
@@ -126,7 +126,12 @@ class LedgerService {
    */
   async signTransactionWithSchnorr (path, transactionBytes) {
     return this.__performAction(async () => {
-      return this.ledger.signTransactionWithSchnorr(path, transactionBytes)
+      try {
+        return await this.ledger.signTransactionWithSchnorr(path, transactionBytes)
+      } catch {
+        console.warn('Schnorr Signatures Unsupported; Trying Ecdsa..')
+        return this.ledger.signTransaction(path, transactionBytes)
+      }
     })
   }
 

--- a/src/renderer/services/ledger-service.js
+++ b/src/renderer/services/ledger-service.js
@@ -107,7 +107,7 @@ class LedgerService {
   }
 
   /**
-   * Sign transaction for ledger wallet.
+   * Sign transaction for ledger wallet using ecdsa signatures.
    * @param  {string} path Path for wallet location.
    * @param  {Buffer} transactionBytes bytes of transaction.
    * @return {Promise<string>}
@@ -119,7 +119,19 @@ class LedgerService {
   }
 
   /**
-   * Sign message for wallet.
+   * Sign transaction for ledger wallet using schnorr signatures.
+   * @param  {string} path Path for wallet location.
+   * @param  {Buffer} transactionBytes bytes of transaction.
+   * @return {Promise<string>}
+   */
+  async signTransactionWithSchnorr (path, transactionBytes) {
+    return this.__performAction(async () => {
+      return this.ledger.signTransactionWithSchnorr(path, transactionBytes)
+    })
+  }
+
+  /**
+   * Sign message for ledger wallet using ecdsa signatures.
    * @param  {string} path Path for wallet location.
    * @param  {Buffer} messageBytes bytes to sign.
    * @return {Promise<string>}
@@ -131,7 +143,19 @@ class LedgerService {
   }
 
   /**
-   * Get version from ledger app.
+   * Sign message for ledger wallet using schnorr signatures.
+   * @param  {string} path Path for wallet location.
+   * @param  {Buffer} messageBytes bytes to sign.
+   * @return {Promise<string>}
+   */
+  async signMessageWithSchnorr (path, messageBytes) {
+    return this.__performAction(async () => {
+      return this.ledger.signMessageWithSchnorr(path, messageBytes)
+    })
+  }
+
+  /**
+   * Get version of ledger wallet.
    * @return {Promise<string>}
    */
   async getVersion () {

--- a/src/renderer/services/transaction.js
+++ b/src/renderer/services/transaction.js
@@ -96,8 +96,13 @@ export default class TransactionService {
       transaction.recipientId = wallet.address
     }
 
-    transaction.signature = await vm.$store.dispatch('ledger/signTransaction', {
-      transactionBytes: this.getBytes(transaction),
+    const operation = transaction.version >= 2
+      ? 'ledger/signTransactionWithSchnorr'
+      : 'ledger/signTransaction'
+
+    const transactionBytes = this.getBytes(transaction)
+    transaction.signature = await vm.$store.dispatch(operation, {
+      transactionBytes: transactionBytes,
       accountIndex: wallet.ledgerIndex
     })
 

--- a/src/renderer/store/modules/ledger.js
+++ b/src/renderer/store/modules/ledger.js
@@ -532,7 +532,7 @@ export default {
     },
 
     /**
-     * Sign transaction for ledger wallet.
+     * Sign transaction for ledger wallet using ecdsa signatures.
      * @param  {Object} obj
      * @param  {Buffer} obj.transactionBytes Bytes of transaction.
      * @param  {Number} obj.accountIndex Index of wallet to sign transaction for.
@@ -552,7 +552,27 @@ export default {
     },
 
     /**
-     * Sign message for ledger wallet.
+     * Sign transaction for ledger wallet using schnorr signatures.
+     * @param  {Object} obj
+     * @param  {String} obj.transactionBytes Bytes of transaction.
+     * @param  {Number} obj.accountIndex Index of wallet to sign transaction for.
+     * @return {(String|Boolean)}
+     */
+    async signTransactionWithSchnorr ({ dispatch }, { transactionBytes, accountIndex } = {}) {
+      try {
+        return await dispatch('action', {
+          action: 'signTransactionWithSchnorr',
+          accountIndex,
+          data: transactionBytes
+        })
+      } catch (error) {
+        logger.error(error)
+        throw new Error(`Could not sign transaction: ${error}`)
+      }
+    },
+
+    /**
+     * Sign message for ledger wallet using ecdsa signatures.
      * @param  {Object} obj
      * @param  {Buffer} obj.messageBytes Bytes to sign.
      * @param  {Number} obj.accountIndex Index of wallet to sign transaction for.
@@ -562,6 +582,26 @@ export default {
       try {
         return await dispatch('action', {
           action: 'signMessage',
+          accountIndex,
+          data: messageBytes
+        })
+      } catch (error) {
+        logger.error(error)
+        throw new Error(`Could not sign message: ${error}`)
+      }
+    },
+
+    /**
+     * Sign message for ledger wallet using schnorr signatures.
+     * @param  {Object} obj
+     * @param  {String} obj.messageBytes Bytes to sign.
+     * @param  {Number} obj.accountIndex Index of wallet to sign transaction for.
+     * @return {(String|Boolean)}
+     */
+    async signMessageWithSchnorr ({ dispatch }, { messageBytes, accountIndex } = {}) {
+      try {
+        return await dispatch('action', {
+          action: 'signMessageWithSchnorr',
           accountIndex,
           data: messageBytes
         })
@@ -614,8 +654,14 @@ export default {
         async signTransaction () {
           return ledgerService.signTransaction(path, data)
         },
+        async signTransactionWithSchnorr () {
+          return ledgerService.signTransactionWithSchnorr(path, data)
+        },
         async signMessage () {
           return ledgerService.signMessage(path, data)
+        },
+        async signMessageWithSchnorr () {
+          return ledgerService.signMessageWithSchnorr(path, data)
         },
         async getVersion () {
           return ledgerService.getVersion()

--- a/yarn.lock
+++ b/yarn.lock
@@ -75,10 +75,10 @@
     tiny-glob "^0.2.6"
     wif "^2.0.6"
 
-"@arkecosystem/ledger-transport@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@arkecosystem/ledger-transport/-/ledger-transport-1.1.0.tgz#2143fce7e19d1e4cdc3e51b29421da5a56663aa7"
-  integrity sha512-IdByYdgGYsHA1Hdc8EfRpzjMztOvPsC2EjLeD1OYlS63hjj3l67WorYFXpyWkiIjzYAnnPyptKVwwR7sOXUnvg==
+"@arkecosystem/ledger-transport@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@arkecosystem/ledger-transport/-/ledger-transport-1.1.1.tgz#4936a4bf4f2101dc098e7a6bd22fe319c0bfb28e"
+  integrity sha512-yLGpEDuv15TDKE4jOvP7ifPxw+VEqIvrUeioNQCkNVRBJiNTYuvbDkYv4WVRrT0LxaOwra8xORsMHFG/qGPGfw==
   dependencies:
     "@ledgerhq/errors" "^5.13.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -75,10 +75,12 @@
     tiny-glob "^0.2.6"
     wif "^2.0.6"
 
-"@arkecosystem/ledger-transport@^1.0.5":
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/@arkecosystem/ledger-transport/-/ledger-transport-1.0.5.tgz#7b3a1186709d7bfeb680fe428223a7a402bb22cd"
-  integrity sha512-xag/HeOrkiY3nGnvF6SpP5gEBjXbx6lKjjR+RsQU4bqIfJKhxQmaOw+mGKxwFp/lJ5uEyObn1SNbRnMu0HLvsg==
+"@arkecosystem/ledger-transport@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@arkecosystem/ledger-transport/-/ledger-transport-1.1.0.tgz#2143fce7e19d1e4cdc3e51b29421da5a56663aa7"
+  integrity sha512-IdByYdgGYsHA1Hdc8EfRpzjMztOvPsC2EjLeD1OYlS63hjj3l67WorYFXpyWkiIjzYAnnPyptKVwwR7sOXUnvg==
+  dependencies:
+    "@ledgerhq/errors" "^5.13.1"
 
 "@arkecosystem/peers@^0.3.0":
   version "0.3.0"
@@ -1206,6 +1208,11 @@
     "@ledgerhq/errors" "^5.7.0"
     "@ledgerhq/logs" "^5.6.0"
     rxjs "^6.5.4"
+
+"@ledgerhq/errors@^5.13.1":
+  version "5.15.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/errors/-/errors-5.15.0.tgz#e5d5b5ad48fc07f6308b78b065242e158bc044a2"
+  integrity sha512-ZlLhR7qaChPgEbvcqOptRepWGm8VhhwOM6kC1gx3WErutbtaOjUX8lLA4ButWFU2f+xTl2rS/5c86wC7qGqGXQ==
 
 "@ledgerhq/errors@^5.7.0":
   version "5.7.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -75,10 +75,10 @@
     tiny-glob "^0.2.6"
     wif "^2.0.6"
 
-"@arkecosystem/ledger-transport@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@arkecosystem/ledger-transport/-/ledger-transport-1.1.1.tgz#4936a4bf4f2101dc098e7a6bd22fe319c0bfb28e"
-  integrity sha512-yLGpEDuv15TDKE4jOvP7ifPxw+VEqIvrUeioNQCkNVRBJiNTYuvbDkYv4WVRrT0LxaOwra8xORsMHFG/qGPGfw==
+"@arkecosystem/ledger-transport@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@arkecosystem/ledger-transport/-/ledger-transport-1.1.2.tgz#bac586bbbe6efaa103f1fc9a37deed364f15832d"
+  integrity sha512-c2jKvdxKEucCCOq3E7KXv4gYj7r12YOzYL7+gIpyT1BlwRfUZcZTFIHYSR1t/LE01ISencJkt1eXC/K3wfkQ2A==
   dependencies:
     "@ledgerhq/errors" "^5.13.1"
 


### PR DESCRIPTION
## Summary

- update `Ledger-Transport` package, `1.0.5` -> `1.1.1`.
- add support for Schnorr signatures w/Ledger.
   - \+ `signMessageWithSchnorr`
   - \+ `signTransactionWithSchnorr`
- add check for tx-versions >= 2 in `services/transaction.js`.
- add/update unit tests for additions/changes.

## Checklist

- [x] Tests
- [ ] Ready to be merged

## Additional Comments

~WIP until [Ledger-Transport](https://github.com/ArkEcosystem/ledger-transport) [1.1.0](https://github.com/ArkEcosystem/ledger-transport/pull/35) is released and can be updated here.~
WIP until testing is done and functionality is confirmed for NanoS & NanoX.
