### PR TITLE
chore: apply width/height inside svg element

### DIFF
--- a/src/app/components/SvgIcon/SvgIcon.tsx
+++ b/src/app/components/SvgIcon/SvgIcon.tsx
@@ -16,8 +16,10 @@ type WrapperProps = {
 };
 
 const Wrapper = styled.div(({ width, height }: WrapperProps) => ({
-	width,
-	height,
+	svg: {
+		width,
+		height,
+	},
 }));
 
 const SvgIcon = ({ name, width, height }: Props) => {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Explicitly set `<svg>` width and height to respect parent's dimensions.
<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
