### PR TITLE
refactor: avoid default exports

### DIFF
--- a/.storybook/Layout.tsx
+++ b/.storybook/Layout.tsx
@@ -2,8 +2,6 @@ import React from "react";
 
 import "../src/styles/app.css";
 
-const Layout = ({ children }) => (
-	<div className="p-5 w-full h-full">{children}</div>
+export const Layout = ({ children }) => (
+	<div className="w-full h-full p-5">{children}</div>
 );
-
-export default Layout;

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -2,9 +2,9 @@ import React from "react";
 import { addDecorator, addParameters } from "@storybook/react";
 import { setIntlConfig, withIntl } from "storybook-addon-intl";
 // Preview layout
-import Layout from "./Layout";
+import { Layout } from "./Layout";
 // i18n
-import translations from "../src/i18n";
+import { translations } from "../src/i18n";
 
 const getMessages = (locale) => translations[locale];
 

--- a/src/app/components/Alert/Alert.stories.tsx
+++ b/src/app/components/Alert/Alert.stories.tsx
@@ -1,14 +1,14 @@
 import React from "react";
-import Alert from "./Alert";
+import { Alert } from "./Alert";
 import { withKnobs, select, text } from "@storybook/addon-knobs";
 
 export default {
 	title: "Components / Alert",
-	decorators: [withKnobs]
+	decorators: [withKnobs],
 };
 
 export const Default = () => {
-	const variant = select("Variant", ["primary","success","warning","danger","neutral"], "warning");
+	const variant = select("Variant", ["primary", "success", "warning", "danger", "neutral"], "warning");
 	const size = select("Size", ["small", "default", "large"], "default");
 	const title = text("Title", "Titlle");
 

--- a/src/app/components/Alert/Alert.tsx
+++ b/src/app/components/Alert/Alert.tsx
@@ -43,4 +43,4 @@ Alert.defaultProps = {
 	size: "default",
 };
 
-export default Alert;
+export { Alert };

--- a/src/app/components/Alert/__tests__/Alert.spec.tsx
+++ b/src/app/components/Alert/__tests__/Alert.spec.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { render } from "@testing-library/react";
 
-import Alert from "../Alert";
+import { Alert } from "../Alert";
 
 describe("Alert", () => {
 	it("should render", () => {

--- a/src/app/components/Alert/__tests__/__snapshots__/Alert.spec.tsx.snap
+++ b/src/app/components/Alert/__tests__/__snapshots__/Alert.spec.tsx.snap
@@ -6,7 +6,7 @@ exports[`Alert should render 1`] = `
     class="flex rounded-lg overflow-hidden bg-theme-warning"
   >
     <div
-      class="sc-AxjAm eNuzhx w-24 flex items-center justify-center text-theme-warning bg-theme-warning-200"
+      class="sc-AxjAm iVJDF w-24 flex items-center justify-center text-theme-warning bg-theme-warning-200"
     >
       <svg
         class="w-8 h-8"
@@ -43,7 +43,7 @@ exports[`Alert should render a large one 1`] = `
     class="flex rounded-lg overflow-hidden bg-theme-warning"
   >
     <div
-      class="sc-AxjAm ekjqDp w-24 flex items-center justify-center text-theme-warning bg-theme-warning-200"
+      class="sc-AxjAm bLURlN w-24 flex items-center justify-center text-theme-warning bg-theme-warning-200"
     >
       <svg
         class="w-8 h-8"
@@ -80,7 +80,7 @@ exports[`Alert should render a small one 1`] = `
     class="flex rounded-lg overflow-hidden bg-theme-warning"
   >
     <div
-      class="sc-AxjAm icqokl w-24 flex items-center justify-center text-theme-warning bg-theme-warning-200"
+      class="sc-AxjAm bEpGSJ w-24 flex items-center justify-center text-theme-warning bg-theme-warning-200"
     >
       <svg
         class="w-8 h-8"

--- a/src/app/components/Alert/style.ts
+++ b/src/app/components/Alert/style.ts
@@ -5,16 +5,14 @@ const baseStyle = [tw`flex overflow-hidden`];
 const getSize = (size: string): any => {
 	switch (size) {
 		case "small":
-			return tw`py-4 px-2`;
+			return tw`px-2 py-4`;
 		case "default":
-			return tw`py-8 px-4`;
+			return tw`px-4 py-8`;
 		case "large":
-			return tw`py-12 px-8`;
+			return tw`px-8 py-12`;
 	}
 };
 
 export const getStyles = ({ size }: { size?: string }) => {
 	return [getSize(size!), ...baseStyle];
 };
-
-export default getStyles;

--- a/src/app/components/Button/__tests__/__snapshots__/Button.spec.tsx.snap
+++ b/src/app/components/Button/__tests__/__snapshots__/Button.spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Button should render 1`] = `
 <div>
   <button
-    class="sc-AxjAm kujxw"
+    class="sc-AxjAm gYunbo"
     color="primary"
   />
 </div>
@@ -12,7 +12,7 @@ exports[`Button should render 1`] = `
 exports[`Button should render a large one 1`] = `
 <div>
   <button
-    class="sc-AxjAm iHJcKA"
+    class="sc-AxjAm iNvhWA"
     color="primary"
   />
 </div>
@@ -21,7 +21,7 @@ exports[`Button should render a large one 1`] = `
 exports[`Button should render a small one 1`] = `
 <div>
   <button
-    class="sc-AxjAm bjceaN"
+    class="sc-AxjAm dKDEMp"
     color="primary"
   />
 </div>
@@ -30,7 +30,7 @@ exports[`Button should render a small one 1`] = `
 exports[`Button should render as outline 1`] = `
 <div>
   <button
-    class="sc-AxjAm dDaLsr"
+    class="sc-AxjAm cBDrIr"
     color="primary"
   />
 </div>
@@ -39,7 +39,7 @@ exports[`Button should render as outline 1`] = `
 exports[`Button should render as plain 1`] = `
 <div>
   <button
-    class="sc-AxjAm lhSfbA"
+    class="sc-AxjAm GWdpI"
     color="primary"
   />
 </div>

--- a/src/app/components/Button/style.ts
+++ b/src/app/components/Button/style.ts
@@ -1,7 +1,7 @@
 import tw, { css } from "twin.macro";
 
 const baseStyle = [
-	tw`rounded focus:outline-none focus:shadow-outline font-semibold text-center transition-all ease-linear duration-100`,
+	tw`font-semibold text-center transition-all duration-100 ease-linear rounded focus:outline-none focus:shadow-outline`,
 	css`
 		&:disabled {
 			${tw`cursor-not-allowed bg-theme-neutral-light text-theme-neutral`}
@@ -51,16 +51,14 @@ const getVariant = (name: string, color: ReturnType<typeof getColorsVariable>): 
 const getSize = (size: string): any => {
 	switch (size) {
 		case "small":
-			return tw`text-sm px-2 py-1`;
+			return tw`px-2 py-1 text-sm`;
 		case "default":
-			return tw`text-base px-4 py-2`;
+			return tw`px-4 py-2 text-base`;
 		case "large":
-			return tw`text-lg px-5 py-3`;
+			return tw`px-5 py-3 text-lg`;
 	}
 };
 
 export const getStyles = ({ variant, color, size }: { variant?: string; color?: string; size?: string }) => {
 	return [getSize(size!), ...baseStyle, ...getVariant(variant!, getColorsVariable(color!))];
 };
-
-export default getStyles;

--- a/src/app/components/ListDivided/ListDivided.tsx
+++ b/src/app/components/ListDivided/ListDivided.tsx
@@ -24,4 +24,4 @@ ListDivided.defaultProps = {
 	items: [],
 };
 
-export default ListDivided;
+export { ListDivided };

--- a/src/app/components/ListDivided/index.tsx
+++ b/src/app/components/ListDivided/index.tsx
@@ -1,5 +1,3 @@
-import ListDivided from "./ListDivided";
+export * from "./ListDivided";
 
 export * from "./ListDividedItem";
-
-export { ListDivided };

--- a/src/app/components/SvgIcon/SvgIcon.tsx
+++ b/src/app/components/SvgIcon/SvgIcon.tsx
@@ -35,4 +35,4 @@ SvgIcon.defaultProps = {
 	height: 20,
 };
 
-export default SvgIcon;
+export { SvgIcon };

--- a/src/app/components/SvgIcon/SvgIcon.tsx
+++ b/src/app/components/SvgIcon/SvgIcon.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { ReactSVG } from "react-svg";
 import styled from "styled-components";
 // Assets
-import SvgCollection from "resources/assets/svg";
+import { SvgCollection } from "resources/assets/svg";
 
 type Props = {
 	name: string;

--- a/src/app/components/SvgIcon/index.tsx
+++ b/src/app/components/SvgIcon/index.tsx
@@ -1,3 +1,1 @@
-import SvgIcon from "./SvgIcon";
-
-export { SvgIcon };
+export * from "./SvgIcon";

--- a/src/domains/profile/pages/CreateProfile/__tests__/__snapshots__/CreateProfile.spec.tsx.snap
+++ b/src/domains/profile/pages/CreateProfile/__tests__/__snapshots__/CreateProfile.spec.tsx.snap
@@ -50,7 +50,7 @@ exports[`CreateProfile should render 1`] = `
           class="mx-4 mt-5 md:mx-8 xl:mx-16"
         >
           <button
-            class="sc-AxjAm kujxw w-full"
+            class="sc-AxjAm gYunbo w-full"
             color="primary"
           >
             <div
@@ -199,13 +199,13 @@ exports[`CreateProfile should render 1`] = `
           class="mx-4 md:mx-8 xl:mx-16"
         >
           <button
-            class="sc-AxjAm lhSfbA"
+            class="sc-AxjAm GWdpI"
             color="primary"
           >
             Back
           </button>
           <button
-            class="sc-AxjAm kujxw ml-2"
+            class="sc-AxjAm gYunbo ml-2"
             color="primary"
             data-testid="create-profile__form--submit"
             form="create-profile__form"

--- a/src/domains/profile/pages/Welcome/__tests__/Welcome.spec.tsx
+++ b/src/domains/profile/pages/Welcome/__tests__/Welcome.spec.tsx
@@ -4,7 +4,7 @@ import { render } from "@testing-library/react";
 
 import { Welcome } from "../";
 // i18n
-import translations from "i18n/locales";
+import { locales } from "i18n/locales";
 
 describe("Welcome", () => {
 	it("should render", () => {
@@ -18,7 +18,7 @@ describe("Welcome", () => {
 		];
 
 		const { container, asFragment } = render(
-			<IntlProvider locale="en-US" messages={translations["en-US"].messages}>
+			<IntlProvider locale="en-US" messages={locales["en-US"].messages}>
 				<Welcome profiles={profiles} />
 			</IntlProvider>,
 		);

--- a/src/domains/profile/pages/Welcome/__tests__/__snapshots__/Welcome.spec.tsx.snap
+++ b/src/domains/profile/pages/Welcome/__tests__/__snapshots__/Welcome.spec.tsx.snap
@@ -154,13 +154,13 @@ exports[`Welcome should render 1`] = `
         class="flex justify-center w-full mb-10"
       >
         <button
-          class="sc-AxjAm kujxw w-1/5 mr-2"
+          class="sc-AxjAm gYunbo w-1/5 mr-2"
           color="primary"
         >
           Sign in to MarketSquare
         </button>
         <button
-          class="sc-AxjAm lhSfbA w-1/5"
+          class="sc-AxjAm GWdpI w-1/5"
           color="primary"
         >
           Create Profile

--- a/src/domains/profile/routing.tsx
+++ b/src/domains/profile/routing.tsx
@@ -1,6 +1,6 @@
 import { CreateProfile, Welcome } from "./pages";
 
-export default [
+export const ProfileRoutes = [
 	{
 		path: "/",
 		exact: true,

--- a/src/domains/wallets/pages/ImportWallet/__tests__/ImportWallet.spec.tsx
+++ b/src/domains/wallets/pages/ImportWallet/__tests__/ImportWallet.spec.tsx
@@ -3,7 +3,7 @@ import { IntlProvider } from "react-intl";
 import { act, fireEvent, render, RenderResult } from "@testing-library/react";
 import { ImportWallet } from "../";
 // i18n
-import translations from "i18n/locales";
+import { locales } from "i18n/locales";
 
 describe("Wallet / Import", () => {
 	let rendered: RenderResult;
@@ -27,7 +27,7 @@ describe("Wallet / Import", () => {
 
 	beforeEach(() => {
 		rendered = render(
-			<IntlProvider locale="en-US" messages={translations["en-US"].messages}>
+			<IntlProvider locale="en-US" messages={locales["en-US"].messages}>
 				<ImportWallet networks={networks} />
 			</IntlProvider>,
 		);

--- a/src/domains/wallets/pages/ImportWallet/__tests__/__snapshots__/ImportWallet.spec.tsx.snap
+++ b/src/domains/wallets/pages/ImportWallet/__tests__/__snapshots__/ImportWallet.spec.tsx.snap
@@ -178,7 +178,7 @@ exports[`Wallet / Import should render 1`] = `
             class="mt-10"
           >
             <button
-              class="sc-AxjAm kujxw"
+              class="sc-AxjAm gYunbo"
               color="primary"
               data-testid="import-wallet__next-step--button"
             >

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,5 +1,5 @@
-import locales from "./locales";
+import { locales } from "./locales";
 
-export default {
+export const translations = {
 	"en-US": locales["en-US"].messages,
 };

--- a/src/i18n/locales/en-US/config.ts
+++ b/src/i18n/locales/en-US/config.ts
@@ -1,6 +1,6 @@
-import messages from "./messages";
+import { messages } from "./messages";
 
-export default {
+export const config = {
 	locale: "en-US",
 
 	messages,

--- a/src/i18n/locales/en-US/messages.ts
+++ b/src/i18n/locales/en-US/messages.ts
@@ -1,4 +1,4 @@
-export default {
+export const messages = {
 	COMMON_ADAPTER: "Adapter",
 	COMMON_ADDRESS: "Address",
 	COMMON_ALL: "All",

--- a/src/i18n/locales/index.ts
+++ b/src/i18n/locales/index.ts
@@ -1,6 +1,5 @@
-/* eslint-disable import/prefer-default-export */
-import enUS from "./en-US/config";
+import { config } from "./en-US/config";
 
-export default {
-	"en-US": enUS,
+export const locales = {
+	"en-US": config,
 };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,7 +5,7 @@ import { renderRoutes } from "react-router-config";
 import { IntlProvider } from "react-intl";
 
 // i18n
-import translations from "./i18n/locales";
+import { locales } from "./i18n/locales";
 // Routes
 import { routes } from "./router";
 // Styles
@@ -18,7 +18,7 @@ ReactDOM.render(
 		<IntlProvider
 			locale={locale}
 			// @ts-ignore
-			messages={translations["en-US"].messages}
+			messages={locales["en-US"].messages}
 		>
 			{renderRoutes(routes)}
 		</IntlProvider>

--- a/src/resources/assets/images/index.ts
+++ b/src/resources/assets/images/index.ts
@@ -1,7 +1,7 @@
 import ARKLogo from "./ark-logo.png";
 import OnboardingBanner from "./pages/profile/onboarding-banner.svg";
 
-const imagesConfig = {
+export const imagesConfig = {
 	common: { ARKLogo },
 	pages: {
 		profile: {
@@ -9,5 +9,3 @@ const imagesConfig = {
 		},
 	},
 };
-
-export { imagesConfig };

--- a/src/resources/assets/svg/index.ts
+++ b/src/resources/assets/svg/index.ts
@@ -6,7 +6,7 @@ import qrcode from "./qrcode.svg";
 import settings from "./settings.svg";
 import upload from "./upload.svg";
 
-const SvgCollection: any = {
+export const SvgCollection: any = {
 	ark,
 	btc,
 	close,
@@ -15,5 +15,3 @@ const SvgCollection: any = {
 	settings,
 	upload,
 };
-
-export default SvgCollection;

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -1,3 +1,3 @@
-import ProfileRoutes from "domains/profile/routing";
+import { ProfileRoutes } from "domains/profile/routing";
 
 export const routes: Array<Object> = [...ProfileRoutes];


### PR DESCRIPTION
As previously mentioned it should be avoided to use default exports because they lead to inconsistent naming and imports because you can use any name you want instead of being forced to use a specific one.