### PR TITLE
chore: add tailwindcss debug screens

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,9 +107,10 @@
 		"prettier": "^2.0.5",
 		"react-app-rewired": "^2.1.6",
 		"react-docgen-typescript-loader": "^3.7.2",
-		"storybook-react-router": "^1.0.8",
 		"react-test-renderer": "^16.13.1",
+		"storybook-react-router": "^1.0.8",
 		"tailwindcss": "^1.4.6",
+		"tailwindcss-debug-screens": "^0.1.0",
 		"wait-on": "^5.0.0"
 	},
 	"babelMacros": {

--- a/src/__tests__/__snapshots__/index.spec.ts.snap
+++ b/src/__tests__/__snapshots__/index.spec.ts.snap
@@ -74,18 +74,22 @@ exports[`Application root should render without crashing 1`] = `
           onError={[Function]}
           textComponent={Symbol(react.fragment)}
         >
-          <Switch>
-            <Route
-              exact={true}
-              path="/"
-              render={[Function]}
-            />
-            <Route
-              exact={true}
-              path="/profile/create"
-              render={[Function]}
-            />
-          </Switch>
+          <main
+            className=""
+          >
+            <Switch>
+              <Route
+                exact={true}
+                path="/"
+                render={[Function]}
+              />
+              <Route
+                exact={true}
+                path="/profile/create"
+                render={[Function]}
+              />
+            </Switch>
+          </main>
         </IntlProvider>
       </HashRouter>,
       <div

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -20,7 +20,9 @@ ReactDOM.render(
 			// @ts-ignore
 			messages={locales["en-US"].messages}
 		>
-			{renderRoutes(routes)}
+			<main className={process.env.NODE_ENV === "development" ? "debug-screens" : ""}>
+				{renderRoutes(routes)}
+			</main>
 		</IntlProvider>
 	</HashRouter>,
 	document.getElementById("root"),

--- a/src/tailwind.config.js
+++ b/src/tailwind.config.js
@@ -1,5 +1,6 @@
 const defaultConfig = require("tailwindcss/defaultConfig");
 const tailwindUI = require("@tailwindcss/ui");
+const tailwindcssDebugScreens = require("tailwindcss-debug-screens");
 
 module.exports = {
 	purge: ["./src/renderer/**/*.html", "./src/renderer/**/*.tsx?"],
@@ -172,5 +173,5 @@ module.exports = {
 		borderRadius: [...defaultConfig.variants.borderRadius, "first", "last"],
 		borderWidth: [...defaultConfig.variants.borderWidth, "last"],
 	},
-	plugins: [tailwindUI],
+	plugins: [tailwindUI, tailwindcssDebugScreens],
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -14743,6 +14743,11 @@ table@^5.2.3:
     slice-ansi "^2.1.0"
     string-width "^3.0.0"
 
+tailwindcss-debug-screens@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/tailwindcss-debug-screens/-/tailwindcss-debug-screens-0.1.0.tgz#13c20d38ac5e036ceb64899af727c11843d68e2e"
+  integrity sha512-LZr2jQWqlhi/IcDGul1SegiWY/0gR5BvgysR4eXYG5nph2uQ3KidwdR9Y/udR7cZgIqimZDV7blWqU9gPI4fZQ==
+
 tailwindcss@^1.4.4, tailwindcss@^1.4.6:
   version "1.4.6"
   resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-1.4.6.tgz#17b37166ccda08d7e7f9ca995ea48ce1e0089700"


### PR DESCRIPTION
## Summary

The [TailwindCSS Debug Screens](https://github.com/jorenvanhee/tailwindcss-debug-screens) plugin will display the currently active screen in development mode.

![Peek 2020-06-08 15-42](https://user-images.githubusercontent.com/1894191/84069509-03fd9280-a9a1-11ea-9c86-7084d00c4c52.gif)

## Checklist

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged
