### PR TITLE
feat: add Badge component

### DIFF
--- a/src/app/assets/svg/ark.svg
+++ b/src/app/assets/svg/ark.svg
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 22.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+<svg fill="currentColor" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 17 14" style="enable-background:new 0 0 17 14;" xml:space="preserve">
-<style type="text/css">
-	.st0{fill:#DE5846;}
-</style>
-<path id="Фигура_3_копия_3" class="st0" d="M8.5,4.9L0,14L8.5,0L17,14L8.5,4.9z M4.8,11.6l1.3-1.7h4.7l1.3,1.7H4.8z
+<path fill="currentColor" id="Фигура_3_копия_3" d="M8.5,4.9L0,14L8.5,0L17,14L8.5,4.9z M4.8,11.6l1.3-1.7h4.7l1.3,1.7H4.8z
 	 M6.5,9.1l2.1-2.5l2,2.5H6.5z"/>
 </svg>

--- a/src/app/assets/svg/btc.svg
+++ b/src/app/assets/svg/btc.svg
@@ -2,10 +2,7 @@
 <!-- Generator: Adobe Illustrator 22.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 13 20" style="enable-background:new 0 0 13 20;" xml:space="preserve">
-<style type="text/css">
-	.st0{fill:#E7AC42;}
-</style>
-<path id="Прямоугольник_скругл._углы_6_копия_3" class="st0" d="M5,19v-2H2v0H1c-0.6,0-1-0.4-1-1
+<path fill="currentColor" id="Прямоугольник_скругл._углы_6_копия_3" d="M5,19v-2H2v0H1c-0.6,0-1-0.4-1-1
 	c0-0.6,0.4-1,1-1h1V5H1C0.4,5,0,4.6,0,4s0.4-1,1-1h1v0h3V1c0-0.6,0.4-1,1-1s1,0.4,1,1v2h0.7c1.3-0.1,2.5,0.3,3.5,1
 	c0.8,0.6,1.2,1.6,1.2,2.6c0,0.7-0.2,1.5-0.7,2c-0.5,0.5-1.1,0.9-1.8,1v0.1c1.1,0,2.1,0.7,2.7,1.6c0.3,0.5,0.5,1.2,0.4,1.8
 	c0,0.7-0.2,1.4-0.6,2c-0.4,0.6-1,1.1-1.7,1.4C9.9,16.9,9,17,8.1,17H7v2c0,0.6-0.4,1-1,1S5,19.6,5,19z M5,14.6h2.5

--- a/src/app/assets/svg/eth.svg
+++ b/src/app/assets/svg/eth.svg
@@ -4,20 +4,20 @@
 	 viewBox="0 0 12.2 20.2" style="enable-background:new 0 0 12.2 20.2;" xml:space="preserve">
 <style type="text/css">
 	.st0{opacity:0.6;}
-	.st1{clip-path:url(#SVGID_2_);fill:#010101;}
+	.st1{clip-path:url(#SVGID_2_);}
 	.st2{opacity:0.45;}
-	.st3{clip-path:url(#SVGID_4_);fill:#010101;}
+	.st3{clip-path:url(#SVGID_4_);}
 	.st4{opacity:0.8;}
-	.st5{clip-path:url(#SVGID_6_);fill:#010101;}
-	.st6{clip-path:url(#SVGID_8_);fill:#010101;}
-	.st7{clip-path:url(#SVGID_10_);fill:#010101;}
-	.st8{clip-path:url(#SVGID_12_);fill:#010101;}
-	.st9{clip-path:url(#SVGID_14_);fill:#010101;}
-	.st10{clip-path:url(#SVGID_16_);fill:#010101;}
-	.st11{clip-path:url(#SVGID_18_);fill:#010101;}
-	.st12{clip-path:url(#SVGID_20_);fill:#010101;}
+	.st5{clip-path:url(#SVGID_6_);}
+	.st6{clip-path:url(#SVGID_8_);}
+	.st7{clip-path:url(#SVGID_10_);}
+	.st8{clip-path:url(#SVGID_12_);}
+	.st9{clip-path:url(#SVGID_14_);}
+	.st10{clip-path:url(#SVGID_16_);}
+	.st11{clip-path:url(#SVGID_18_);}
+	.st12{clip-path:url(#SVGID_20_);}
 </style>
-<g>
+<g fill="currentColor">
 	<g class="st0">
 		<g>
 			<defs>

--- a/src/app/components/Badge/Badge.stories.tsx
+++ b/src/app/components/Badge/Badge.stories.tsx
@@ -71,21 +71,21 @@ export const WithIcon = () => {
 		<div>
 			<div className="mt-3 mb-10">
 				<Circle className="relative border-theme-success-500 text-theme-success-500">
-					<Icon name="ark" color="success-600"></Icon>
+					<Icon name="ark"></Icon>
 					<Badge
 						className="-bottom-1 -right-4 bg-theme-success-500 text-theme-success-contrast"
 						icon="checkmark"
 					></Badge>
 				</Circle>
 				<Circle className="relative border-theme-success-500 text-theme-success-500 ml-5">
-					<Icon name="eth" color="success-600"></Icon>
+					<Icon name="eth"></Icon>
 					<Badge
 						className="bg-theme-success-500 -bottom-1 -right-4 text-theme-success-contrast"
 						icon="checkmark"
 					></Badge>
 				</Circle>
 				<Circle className="relative border-theme-success-500 text-theme-success-500 ml-5">
-					<Icon name="btc" color="success-600"></Icon>
+					<Icon name="btc"></Icon>
 					<Badge
 						className="bg-theme-success-500 -bottom-1 -right-4 text-theme-success-contrast"
 						icon="checkmark"

--- a/src/app/components/Badge/Badge.stories.tsx
+++ b/src/app/components/Badge/Badge.stories.tsx
@@ -1,0 +1,112 @@
+import React from "react";
+import { Badge } from "./Badge";
+import { Circle } from "app/components/Circle";
+import { Icon } from "app/components/Icon";
+
+export default {
+	title: "Components / Badge",
+};
+
+export const Default = () => {
+	return (
+		<div>
+			<div className="text--xs w-64">Parent must have relative class</div>
+			<div className="text--xs w-64">Colors, positions, size of badge controled by tailwind classes.</div>
+			<div className="my-10">
+				<Circle className="border-theme-neutral-200 relative">
+					<Badge className="border-theme-neutral-200 -bottom-2 -right-2"></Badge>
+				</Circle>
+			</div>
+			<div className="color--neutral-600 text-sm"></div>
+			<div className="mt-3 mb-10">
+				<Circle className="border-theme-neutral-200 relative mr-3">
+					<Badge className="border-theme-neutral-200 -bottom-2 -right-2"></Badge>
+				</Circle>
+				<Circle className="border-theme-neutral-200 relative mr-3">
+					<Badge className="border-theme-neutral-200 -right-2 -top-2"></Badge>
+				</Circle>
+				<Circle className="border-theme-neutral-200 relative mr-3">
+					<Badge className=" border-theme-neutral-200  -bottom-2 -left-2"></Badge>
+				</Circle>
+				<Circle className="border-theme-neutral-200 relative mr-3">
+					<Badge className="border-theme-neutral-200 -left-2 -top-2"></Badge>
+				</Circle>
+				<Circle className="border-theme-neutral-200 relative mr-3">
+					<Badge className="border-theme-neutral-200 -right-4 top-2"></Badge>
+				</Circle>
+			</div>
+		</div>
+	);
+};
+
+export const Colored = () => {
+	return (
+		<div>
+			<div className="mb-10">
+				<Circle className="border-theme-neutral-200 relative">
+					<Badge className="border-theme-neutral-200 -bottom-2 -right-2"></Badge>
+				</Circle>
+			</div>
+
+			<div className="mt-3 mb-10">
+				<Circle className="relative border-theme-success-500 text-white">
+					<Badge className="bg-theme-success-500 -top-1 -right-4"></Badge>
+				</Circle>
+				<Circle className="relative border-theme-warning-500 ml-5 text-white">
+					<Badge className="bg-theme-warning-500 -bottom-1 -right-4"></Badge>
+				</Circle>
+				<Circle className="relative border-theme-primary-500 ml-7 text-white">
+					<Badge className="border-theme-primary-500 -top-1 -left-4"></Badge>
+				</Circle>
+				<Circle className="relative border-theme-danger-400 ml-5 text-white">
+					<Badge className="border-theme-danger-400 top-2 -right-4"></Badge>
+				</Circle>
+			</div>
+		</div>
+	);
+};
+
+export const WithIcon = () => {
+	return (
+		<div>
+			<div className="mt-3 mb-10">
+				<Circle className="relative border-theme-success-500 text-theme-success-500">
+					<Icon name="ark" color="success-600"></Icon>
+					<Badge
+						className="-bottom-1 -right-4 bg-theme-success-500 text-theme-success-contrast"
+						icon="checkmark"
+					></Badge>
+				</Circle>
+				<Circle className="relative border-theme-success-500 text-theme-success-500 ml-5">
+					<Icon name="eth" color="success-600"></Icon>
+					<Badge
+						className="bg-theme-success-500 -bottom-1 -right-4 text-theme-success-contrast"
+						icon="checkmark"
+					></Badge>
+				</Circle>
+				<Circle className="relative border-theme-success-500 text-theme-success-500 ml-5">
+					<Icon name="btc" color="success-600"></Icon>
+					<Badge
+						className="bg-theme-success-500 -bottom-1 -right-4 text-theme-success-contrast"
+						icon="checkmark"
+					></Badge>
+				</Circle>
+				<Circle className="relative border-theme-neutral-200 ml-5">
+					<div className="text-md text-theme-neutral-200 italic">D</div>
+					<Badge className="border-theme-neutral-200 -bottom-1 -right-4"></Badge>
+				</Circle>
+				<Circle className="relative border-theme-neutral-200 ml-5">
+					<div className="text-md text-theme-neutral-200 italic">D</div>
+					<Badge className="border-theme-neutral-200 -bottom-1 -right-4"></Badge>
+				</Circle>
+				<Circle className="relative border-theme-primary-100 ml-5">
+					<div className="text-xs text-theme-primary-500">All</div>
+					<Badge
+						className="border-theme-primary-100 -bottom-1 -right-4 text-theme-primary-500"
+						icon="chevronDown"
+					></Badge>
+				</Circle>
+			</div>
+		</div>
+	);
+};

--- a/src/app/components/Badge/Badge.stories.tsx
+++ b/src/app/components/Badge/Badge.stories.tsx
@@ -71,24 +71,24 @@ export const WithIcon = () => {
 		<div>
 			<div className="mt-3 mb-10">
 				<Circle className="relative border-theme-success-500 text-theme-success-500">
-					<Icon name="ark"></Icon>
+					<Icon name="Ark"></Icon>
 					<Badge
 						className="-bottom-1 -right-4 bg-theme-success-500 text-theme-success-contrast"
-						icon="checkmark"
+						icon="Checkmark"
 					></Badge>
 				</Circle>
 				<Circle className="relative border-theme-success-500 text-theme-success-500 ml-5">
-					<Icon name="eth"></Icon>
+					<Icon name="Eth"></Icon>
 					<Badge
 						className="bg-theme-success-500 -bottom-1 -right-4 text-theme-success-contrast"
-						icon="checkmark"
+						icon="Checkmark"
 					></Badge>
 				</Circle>
 				<Circle className="relative border-theme-success-500 text-theme-success-500 ml-5">
-					<Icon name="btc"></Icon>
+					<Icon name="Btc"></Icon>
 					<Badge
 						className="bg-theme-success-500 -bottom-1 -right-4 text-theme-success-contrast"
-						icon="checkmark"
+						icon="Checkmark"
 					></Badge>
 				</Circle>
 				<Circle className="relative border-theme-neutral-200 ml-5">
@@ -103,7 +103,7 @@ export const WithIcon = () => {
 					<div className="text-xs text-theme-primary-500">All</div>
 					<Badge
 						className="border-theme-primary-100 -bottom-1 -right-4 text-theme-primary-500"
-						icon="chevronDown"
+						icon="ChevronDown"
 					></Badge>
 				</Circle>
 			</div>

--- a/src/app/components/Badge/Badge.tsx
+++ b/src/app/components/Badge/Badge.tsx
@@ -10,7 +10,7 @@ type BadgeProps = {
 	iconHeight?: number;
 };
 
-export const Badge = ({ className, children, icon, iconWidth, iconHeight, iconColor }: BadgeProps) => {
+export const Badge = ({ className, children, icon, iconWidth, iconHeight }: BadgeProps) => {
 	return (
 		<Wrapper className={`${defaultClasses} ${className}`}>
 			{!!icon && <Icon name={icon} width={iconWidth} height={iconHeight}></Icon>}

--- a/src/app/components/Badge/Badge.tsx
+++ b/src/app/components/Badge/Badge.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { Icon } from "../Icon";
+import { Wrapper, defaultClasses } from "./style";
+
+type BadgeProps = {
+	className?: string;
+	children?: React.ReactNode;
+	icon?: string;
+	iconWidth?: number;
+	iconHeight?: number;
+};
+
+export const Badge = ({ className, children, icon, iconWidth, iconHeight, iconColor }: BadgeProps) => {
+	return (
+		<Wrapper className={`${defaultClasses} ${className}`}>
+			{!!icon && <Icon name={icon} width={iconWidth} height={iconHeight}></Icon>}
+			<span>{children}</span>
+		</Wrapper>
+	);
+};
+
+Badge.defaultProps = {
+	iconWidth: 12,
+	iconHeight: 12,
+};

--- a/src/app/components/Badge/__tests__/Badge.spec.tsx
+++ b/src/app/components/Badge/__tests__/Badge.spec.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import { render } from "@testing-library/react";
+
+import { Badge } from "../Badge";
+
+describe("Badge", () => {
+	it("should render", () => {
+		const { container } = render(<Badge />);
+		expect(container).toMatchSnapshot();
+	});
+
+	it("should render with icon", () => {
+		const { container } = render(<Badge icon="settings" />);
+		expect(container).toMatchSnapshot();
+	});
+});

--- a/src/app/components/Badge/__tests__/__snapshots__/Badge.spec.tsx.snap
+++ b/src/app/components/Badge/__tests__/__snapshots__/Badge.spec.tsx.snap
@@ -1,0 +1,35 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Badge should render 1`] = `
+<div>
+  <span
+    class="style__Wrapper-ik37et-0 chXxec flex border-2 rounded-full justify-center w-5 h-5 items-center align-middle absolute bg-theme-background border-transparent undefined"
+  >
+    <span />
+  </span>
+</div>
+`;
+
+exports[`Badge should render with icon 1`] = `
+<div>
+  <span
+    class="style__Wrapper-ik37et-0 chXxec flex border-2 rounded-full justify-center w-5 h-5 items-center align-middle absolute bg-theme-background border-transparent undefined"
+  >
+    <div
+      class="sc-AxjAm HWmvM"
+      height="12"
+      width="12"
+    >
+      <div>
+        <div>
+          <div
+            data-src="settings.svg"
+            src=""
+          />
+        </div>
+      </div>
+    </div>
+    <span />
+  </span>
+</div>
+`;

--- a/src/app/components/Badge/__tests__/__snapshots__/Badge.spec.tsx.snap
+++ b/src/app/components/Badge/__tests__/__snapshots__/Badge.spec.tsx.snap
@@ -19,16 +19,7 @@ exports[`Badge should render with icon 1`] = `
       class="sc-AxjAm HWmvM"
       height="12"
       width="12"
-    >
-      <div>
-        <div>
-          <div
-            data-src="settings.svg"
-            src=""
-          />
-        </div>
-      </div>
-    </div>
+    />
     <span />
   </span>
 </div>

--- a/src/app/components/Badge/index.ts
+++ b/src/app/components/Badge/index.ts
@@ -1,0 +1,1 @@
+export * from "./Badge";

--- a/src/app/components/Badge/style.ts
+++ b/src/app/components/Badge/style.ts
@@ -1,0 +1,15 @@
+import { styled, css } from "twin.macro";
+
+const outline = css`
+	box-shadow: 0px 0px 0px 5px white;
+`;
+
+const shape = "flex border-2 rounded-full justify-center w-5 h-5 items-center align-middle";
+const colors = "bg-theme-background border-transparent";
+const position = "absolute";
+
+export const Wrapper = styled.span`
+	${outline}
+`;
+
+export const defaultClasses = `${shape} ${position} ${colors}`;


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
General purpose badge component to be used along with avatars, coin icons et. all
* requires a parent with relative positon.
* position, size, shape, colors, controlled by regular (tailwind) css classes  (e.g -right-2 -bottom-2).
* `icon="name"` prop to internally render an `Icon` component.
* accepts slot for custom content.

Preview:
![2020-06-10-142343_278x168_scrot](https://user-images.githubusercontent.com/22020168/84262319-16ed9f80-ab26-11ea-98bc-330dffb9eaa0.png)
![2020-06-10-142350_424x94_scrot](https://user-images.githubusercontent.com/22020168/84262322-18b76300-ab26-11ea-828f-7e177878b4c7.png)


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
