### PR TITLE
chore: add toggle content prop on `Dropdown`

### DIFF
--- a/src/app/components/Dropdown/Dropdown.stories.tsx
+++ b/src/app/components/Dropdown/Dropdown.stories.tsx
@@ -52,3 +52,20 @@ export const CustomToggleIcon = () => {
 		</div>
 	);
 };
+
+export const CustomToggleContent = () => {
+	return (
+		<div className="">
+			Custom toggle html:
+			<div className="w-20 mt-10 ml-40">
+				<Dropdown
+					toggleContent={(isOpen) => <div>{isOpen ? "open" : "closed"}</div>}
+					toggleIcon="Upload"
+					onSelect={(option: any) => console.log(option)}
+				>
+					<div className="p-5">Custom content (default slot)</div>
+				</Dropdown>
+			</div>
+		</div>
+	);
+};

--- a/src/app/components/Dropdown/Dropdown.stories.tsx
+++ b/src/app/components/Dropdown/Dropdown.stories.tsx
@@ -59,7 +59,7 @@ export const CustomToggleContent = () => {
 			Custom toggle html:
 			<div className="w-20 mt-10 ml-40">
 				<Dropdown
-					toggleContent={(isOpen) => <div>{isOpen ? "open" : "closed"}</div>}
+					toggleContent={(isOpen: boolean) => <div>{isOpen ? "open" : "closed"}</div>}
 					toggleIcon="Upload"
 					onSelect={(option: any) => console.log(option)}
 				>

--- a/src/app/components/Dropdown/Dropdown.tsx
+++ b/src/app/components/Dropdown/Dropdown.tsx
@@ -16,6 +16,7 @@ type Props = {
 	onSelect?: any;
 	options?: any;
 	toggleIcon: string;
+	toggleContent?: any;
 };
 
 export const Wrapper = styled.div`
@@ -41,7 +42,24 @@ const renderOptions = (options: any[], onSelect: any) => (
 	</ul>
 );
 
-export const Dropdown = ({ children, options, onSelect, toggleIcon }: Props) => {
+const renderToggle = (children: any, toggleIcon: string, isOpen: boolean) => {
+	// Default with toggleIcon
+	if (!children) {
+		return (
+			<button data-testid="dropdown__toggle" className="float-right outline-none focus:outline-none">
+				<Icon name={toggleIcon} width={20} height={20} />
+			</button>
+		);
+	}
+
+	// Call children as a function and provide isOpen state
+	if (typeof children === "function") return children(isOpen);
+
+	// Render children as provided
+	return children;
+};
+
+export const Dropdown = ({ children, options, onSelect, toggleIcon, toggleContent }: Props) => {
 	const [isOpen, setIsOpen] = useState(false);
 
 	const toggle = () => setIsOpen(!isOpen);
@@ -58,18 +76,14 @@ export const Dropdown = ({ children, options, onSelect, toggleIcon }: Props) => 
 	if (!isOpen) {
 		return (
 			<div onClick={toggle} ref={ref} className="relative">
-				<button data-testid="dropdown__toggle" className="float-right outline-none focus:outline-none">
-					<Icon name={toggleIcon} width={20} height={20} />
-				</button>
+				{renderToggle(toggleContent, toggleIcon, isOpen)}
 			</div>
 		);
 	}
 
 	return (
 		<div ref={ref} className="relative">
-			<button onClick={toggle} className="float-right outline-none focus:outline-none">
-				<Icon name={toggleIcon} width={20} height={20} />
-			</button>
+			<span onClick={toggle}>{renderToggle(toggleContent, toggleIcon, isOpen)}</span>
 
 			<Wrapper>
 				<div data-testid="dropdown__content">{renderOptions(options, select)}</div>

--- a/src/app/components/Dropdown/__tests__/Dropdown.test.tsx
+++ b/src/app/components/Dropdown/__tests__/Dropdown.test.tsx
@@ -125,6 +125,18 @@ describe("Dropdown", () => {
 
 		expect(container.querySelectorAll("ul").length).toEqual(0);
 	});
+
+	it("should render with custom toggle content as react element", () => {
+		const { container } = render(<Dropdown toggleContent={<div>custom toggle</div>}></Dropdown>);
+		expect(container).toMatchSnapshot();
+	});
+
+	it("should render with custom toggle content as function", () => {
+		const { container } = render(
+			<Dropdown toggleContent={(isOpen) => <div>Dropdown is open: {isOpen}</div>}></Dropdown>,
+		);
+		expect(container).toMatchSnapshot();
+	});
 });
 
 describe("ClickOutside Hook", () => {

--- a/src/app/components/Dropdown/__tests__/Dropdown.test.tsx
+++ b/src/app/components/Dropdown/__tests__/Dropdown.test.tsx
@@ -133,7 +133,7 @@ describe("Dropdown", () => {
 
 	it("should render with custom toggle content as function", () => {
 		const { container } = render(
-			<Dropdown toggleContent={(isOpen) => <div>Dropdown is open: {isOpen}</div>}></Dropdown>,
+			<Dropdown toggleContent={(isOpen: boolean) => <div>Dropdown is open: {isOpen}</div>}></Dropdown>,
 		);
 		expect(container).toMatchSnapshot();
 	});

--- a/src/app/components/Dropdown/__tests__/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/app/components/Dropdown/__tests__/__snapshots__/Dropdown.test.tsx.snap
@@ -46,6 +46,30 @@ exports[`Dropdown should render toggle icon 1`] = `
 </div>
 `;
 
+exports[`Dropdown should render with custom toggle content as function 1`] = `
+<div>
+  <div
+    class="relative"
+  >
+    <div>
+      Dropdown is open: 
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Dropdown should render with custom toggle content as react element 1`] = `
+<div>
+  <div
+    class="relative"
+  >
+    <div>
+      custom toggle
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Dropdown should render with options 1`] = `
 <div>
   <div


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Adds the feature to accept `toggleContent` to render custom elements.
Accepts function as a prop and provides `isOpen` state to render dynamically.

Example:

As element:
```jsx
<Dropdown
	options={options}
	toggleContent={<div>sample toggle content</div>}>
</Dropdown>

```

As a function:
```jsx
<Dropdown
	options={options}
	toggleContent={(isOpen) => (<div>sample toggle content</div>)}>
</Dropdown>

```
<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
