### PR TITLE
feat: add compact variant to `TransactionListItem`

### DIFF
--- a/src/app/components/TransactionListItem/TransactionListItem.stories.tsx
+++ b/src/app/components/TransactionListItem/TransactionListItem.stories.tsx
@@ -7,28 +7,28 @@ export default {
 	title: "Transactions / Components / TransactionListItem",
 };
 
-export const Default = () => {
-	const data = [
-		{
-			date: "17 Mar 2020 22:02:10",
-			avatarId: "test",
-			type: "receive",
-			address: "ASuusXSW9kfWnicScSgUTjttP6T9GQ3kqT",
-			walletName: "My Wallet",
-			amount: "100 BTC",
-			fiat: "1,000,000 USD",
-		},
-		{
-			date: "17 Mar 2020 22:02:10",
-			avatarId: "test",
-			type: "send",
-			address: "ASuusXSW9kfWnicScSgUTjttP6T9GQ3kqT",
-			walletName: "My Wallet",
-			amount: "- 100 BTC",
-			fiat: "1,000,000 USD",
-		},
-	];
+const data = [
+	{
+		date: "17 Mar 2020 22:02:10",
+		avatarId: "test",
+		type: "receive",
+		address: "ASuusXSW9kfWnicScSgUTjttP6T9GQ3kqT",
+		walletName: "My Wallet",
+		amount: "100 BTC",
+		fiat: "1,000,000 USD",
+	},
+	{
+		date: "17 Mar 2020 22:02:10",
+		avatarId: "test",
+		type: "send",
+		address: "ASuusXSW9kfWnicScSgUTjttP6T9GQ3kqT",
+		walletName: "My Wallet",
+		amount: "- 100 BTC",
+		fiat: "1,000,000 USD",
+	},
+];
 
+export const Default = () => {
 	const columns = [
 		{
 			Header: "Date",
@@ -55,6 +55,31 @@ export const Default = () => {
 			<div>
 				<Table columns={columns} data={data}>
 					{(rowData: any) => <TransactionListItem {...rowData}></TransactionListItem>}
+				</Table>
+			</div>
+		</div>
+	);
+};
+
+export const Compact = () => {
+	const compactColumns = [
+		{
+			Header: "Type",
+		},
+		{
+			Header: "Wallet Address",
+		},
+		{
+			Header: "Amount",
+			className: "float-right",
+		},
+	];
+
+	return (
+		<div>
+			<div>
+				<Table columns={compactColumns} data={data}>
+					{(rowData: any) => <TransactionListItem variant="compact" {...rowData}></TransactionListItem>}
 				</Table>
 			</div>
 		</div>

--- a/src/app/components/TransactionListItem/TransactionListItem.test.tsx
+++ b/src/app/components/TransactionListItem/TransactionListItem.test.tsx
@@ -1,5 +1,6 @@
-import { render } from "@testing-library/react";
+import { fireEvent,render } from "@testing-library/react";
 import React from "react";
+import { act } from "react-dom/test-utils";
 
 import { TransactionListItem } from "./TransactionListItem";
 
@@ -60,5 +61,110 @@ describe("TransactionListItem", () => {
 			</table>,
 		);
 		expect(container).toMatchSnapshot();
+	});
+
+	it("should render compact variant", () => {
+		const tx = {
+			date: "17 Mar 2020 22:02:10",
+			avatarId: "test",
+			type: "receive",
+			address: "ASuusXSW9kfWnicScSgUTjttP6T9GQ3kqT",
+			walletName: "My Wallet",
+			amount: "100 BTC",
+			fiat: "1,000,000 USD",
+		};
+
+		const { container } = render(
+			<table>
+				<tbody>
+					<TransactionListItem
+						variant="compact"
+						date={tx.date}
+						avatarId={tx.avatarId}
+						type={tx.type}
+						address={tx.address}
+						walletName={tx.walletName}
+						amount={tx.amount}
+						fiat={tx.fiat}
+					></TransactionListItem>
+				</tbody>
+			</table>,
+		);
+		expect(container).toMatchSnapshot();
+	});
+
+	it("should emit onClick event", () => {
+		const fn = jest.fn();
+
+		const tx = {
+			date: "17 Mar 2020 22:02:10",
+			avatarId: "test",
+			type: "receive",
+			address: "ASuusXSW9kfWnicScSgUTjttP6T9GQ3kqT",
+			walletName: "My Wallet",
+			amount: "100 BTC",
+			fiat: "1,000,000 USD",
+		};
+
+		const { getByTestId } = render(
+			<table>
+				<tbody>
+					<TransactionListItem
+						date={tx.date}
+						avatarId={tx.avatarId}
+						type={tx.type}
+						address={tx.address}
+						walletName={tx.walletName}
+						amount={tx.amount}
+						fiat={tx.fiat}
+						onClick={fn}
+					></TransactionListItem>
+				</tbody>
+			</table>,
+		);
+		const txRow = getByTestId("transaction__row");
+
+		act(() => {
+			fireEvent.click(txRow);
+		});
+
+		expect(fn).toBeCalled();
+	});
+
+	it("should prevent onClick event when callback not provided", () => {
+		const fn = jest.fn();
+
+		const tx = {
+			date: "17 Mar 2020 22:02:10",
+			avatarId: "test",
+			type: "receive",
+			address: "ASuusXSW9kfWnicScSgUTjttP6T9GQ3kqT",
+			walletName: "My Wallet",
+			amount: "100 BTC",
+			fiat: "1,000,000 USD",
+		};
+
+		const { getByTestId } = render(
+			<table>
+				<tbody>
+					<TransactionListItem
+						date={tx.date}
+						avatarId={tx.avatarId}
+						type={tx.type}
+						address={tx.address}
+						walletName={tx.walletName}
+						amount={tx.amount}
+						fiat={tx.fiat}
+					></TransactionListItem>
+				</tbody>
+			</table>,
+		);
+		const txRow = getByTestId("transaction__row");
+
+		act(() => {
+			fireEvent.click(txRow);
+		});
+
+		expect(fn).not.toBeCalled();
 	});
 });

--- a/src/app/components/TransactionListItem/TransactionListItem.tsx
+++ b/src/app/components/TransactionListItem/TransactionListItem.tsx
@@ -40,7 +40,7 @@ export const TransactionListItem = ({
 		return (
 			<tr
 				onClick={onTxClick}
-				className="border-b cursor-pointer border-theme-neutral-200"
+				className="border-b border-theme-neutral-200 cursor-pointer"
 				data-testid="transaction__row"
 			>
 				<td className="w-20 py-4 mt-1">
@@ -64,7 +64,7 @@ export const TransactionListItem = ({
 	return (
 		<tr
 			onClick={onTxClick}
-			className="border-b cursor-pointer border-theme-neutral-200"
+			className="border-b border-theme-neutral-200 cursor-pointer"
 			data-testid="transaction__row"
 		>
 			<td className="w-48 py-1 text-sm text-theme-neutral-600"> {date} </td>
@@ -92,5 +92,4 @@ export const TransactionListItem = ({
 TransactionListItem.defaultProps = {
 	walletTypeIcons: [],
 	actions: [],
-	variant: "default",
 };

--- a/src/app/components/TransactionListItem/TransactionListItem.tsx
+++ b/src/app/components/TransactionListItem/TransactionListItem.tsx
@@ -4,7 +4,7 @@ import { Icon } from "app/components/Icon";
 import { Label } from "app/components/Label";
 import React from "react";
 
-type TransactionListItemProps = {
+export type TransactionListItemProps = {
 	date: string;
 	avatarId: string;
 	type: string;
@@ -12,6 +12,8 @@ type TransactionListItemProps = {
 	walletName?: string;
 	amount: string;
 	fiat: string;
+	variant?: "default" | "compact";
+	onClick?: any;
 };
 
 export const TransactionListItem = ({
@@ -22,6 +24,8 @@ export const TransactionListItem = ({
 	walletName,
 	amount,
 	fiat,
+	variant,
+	onClick,
 }: TransactionListItemProps) => {
 	const iconName: any = {
 		send: "Sent",
@@ -38,8 +42,41 @@ export const TransactionListItem = ({
 		receive: "success",
 	};
 
+	const onTxClick = () => {
+		if (typeof onClick === "function") onClick();
+	};
+
+	if (variant === "compact") {
+		return (
+			<tr
+				onClick={onTxClick}
+				className="border-b border-theme-neutral-200 cursor-pointer"
+				data-testid="transaction__row"
+			>
+				<td className="w-20 py-4 mt-1">
+					<Circle size="small" className={`${iconClasses[type]} -mr-1`}>
+						<Icon name={iconName[type]} width={40} height={40}></Icon>
+					</Circle>
+					<Circle size="small" avatarId={avatarId}></Circle>
+				</td>
+				<td className="w-56 py-1">
+					<Address walletName={walletName} address={address} maxChars={16} size="small"></Address>
+				</td>
+				<td className="py-1 text-sm text-right">
+					<Label color={amountLabelColor[type]} size="small">
+						{amount}
+					</Label>
+				</td>
+			</tr>
+		);
+	}
+
 	return (
-		<tr className="border-b border-theme-neutral-200">
+		<tr
+			onClick={onTxClick}
+			className="border-b border-theme-neutral-200 cursor-pointer"
+			data-testid="transaction__row"
+		>
 			<td className="w-48 py-1 text-sm text-theme-neutral-600"> {date} </td>
 			<td className="w-32 py-4 mt-1">
 				<Circle className={`${iconClasses[type]} -mr-1`}>
@@ -65,4 +102,5 @@ export const TransactionListItem = ({
 TransactionListItem.defaultProps = {
 	walletTypeIcons: [],
 	actions: [],
+	variant: "default",
 };

--- a/src/app/components/TransactionListItem/TransactionListItem.tsx
+++ b/src/app/components/TransactionListItem/TransactionListItem.tsx
@@ -4,17 +4,7 @@ import { Icon } from "app/components/Icon";
 import { Label } from "app/components/Label";
 import React from "react";
 
-export type TransactionListItemProps = {
-	date: string;
-	avatarId: string;
-	type: string;
-	address?: string;
-	walletName?: string;
-	amount: string;
-	fiat: string;
-	variant?: "default" | "compact";
-	onClick?: any;
-};
+import { TransactionListItemProps } from "./models";
 
 export const TransactionListItem = ({
 	date,
@@ -50,7 +40,7 @@ export const TransactionListItem = ({
 		return (
 			<tr
 				onClick={onTxClick}
-				className="border-b cursor-pointer border-theme-neutral-200"
+				className="border-b border-theme-neutral-200 cursor-pointer"
 				data-testid="transaction__row"
 			>
 				<td className="w-20 py-4 mt-1">
@@ -74,7 +64,7 @@ export const TransactionListItem = ({
 	return (
 		<tr
 			onClick={onTxClick}
-			className="border-b cursor-pointer border-theme-neutral-200"
+			className="border-b border-theme-neutral-200 cursor-pointer"
 			data-testid="transaction__row"
 		>
 			<td className="w-48 py-1 text-sm text-theme-neutral-600"> {date} </td>

--- a/src/app/components/TransactionListItem/TransactionListItem.tsx
+++ b/src/app/components/TransactionListItem/TransactionListItem.tsx
@@ -50,7 +50,7 @@ export const TransactionListItem = ({
 		return (
 			<tr
 				onClick={onTxClick}
-				className="border-b border-theme-neutral-200 cursor-pointer"
+				className="border-b cursor-pointer border-theme-neutral-200"
 				data-testid="transaction__row"
 			>
 				<td className="w-20 py-4 mt-1">
@@ -74,7 +74,7 @@ export const TransactionListItem = ({
 	return (
 		<tr
 			onClick={onTxClick}
-			className="border-b border-theme-neutral-200 cursor-pointer"
+			className="border-b cursor-pointer border-theme-neutral-200"
 			data-testid="transaction__row"
 		>
 			<td className="w-48 py-1 text-sm text-theme-neutral-600"> {date} </td>

--- a/src/app/components/TransactionListItem/TransactionListItem.tsx
+++ b/src/app/components/TransactionListItem/TransactionListItem.tsx
@@ -40,7 +40,7 @@ export const TransactionListItem = ({
 		return (
 			<tr
 				onClick={onTxClick}
-				className="border-b border-theme-neutral-200 cursor-pointer"
+				className="border-b cursor-pointer border-theme-neutral-200"
 				data-testid="transaction__row"
 			>
 				<td className="w-20 py-4 mt-1">
@@ -64,7 +64,7 @@ export const TransactionListItem = ({
 	return (
 		<tr
 			onClick={onTxClick}
-			className="border-b border-theme-neutral-200 cursor-pointer"
+			className="border-b cursor-pointer border-theme-neutral-200"
 			data-testid="transaction__row"
 		>
 			<td className="w-48 py-1 text-sm text-theme-neutral-600"> {date} </td>

--- a/src/app/components/TransactionListItem/__snapshots__/TransactionListItem.test.tsx.snap
+++ b/src/app/components/TransactionListItem/__snapshots__/TransactionListItem.test.tsx.snap
@@ -5,7 +5,8 @@ exports[`TransactionListItem should render a received transaction 1`] = `
   <table>
     <tbody>
       <tr
-        class="border-b border-theme-neutral-200"
+        class="border-b border-theme-neutral-200 cursor-pointer"
+        data-testid="transaction__row"
       >
         <td
           class="w-48 py-1 text-sm text-theme-neutral-600"
@@ -82,7 +83,8 @@ exports[`TransactionListItem should render a send transaction 1`] = `
   <table>
     <tbody>
       <tr
-        class="border-b border-theme-neutral-200"
+        class="border-b border-theme-neutral-200 cursor-pointer"
+        data-testid="transaction__row"
       >
         <td
           class="w-48 py-1 text-sm text-theme-neutral-600"
@@ -146,6 +148,70 @@ exports[`TransactionListItem should render a send transaction 1`] = `
         >
           <div>
             1,000,000 USD
+          </div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
+exports[`TransactionListItem should render compact variant 1`] = `
+<div>
+  <table>
+    <tbody>
+      <tr
+        class="border-b border-theme-neutral-200 cursor-pointer"
+        data-testid="transaction__row"
+      >
+        <td
+          class="w-20 py-4 mt-1"
+        >
+          <div
+            class="sc-AxjAm cQQGeT border-theme-success-300 text-theme-success-400 -mr-1"
+          >
+            <div
+              class="sc-AxirZ RbXVX"
+              height="40"
+              width="40"
+            >
+              <svg>
+                received.svg
+              </svg>
+            </div>
+          </div>
+          <div
+            class="sc-AxjAm GVDWW"
+          />
+        </td>
+        <td
+          class="w-56 py-1"
+        >
+          <div
+            class="inline-block truncate"
+          >
+            <span
+              class="text-theme-neutral-800 font-semibold max-w-24 flex-auto truncate mt-4 mr-1 text-sm"
+              data-testid="address__wallet-name"
+            >
+              My Wallet
+            </span>
+            <span
+              class="text-theme-neutral-400 font-semibold text-sm"
+              data-testid="address__wallet-address"
+            >
+              ASuusX...GQ3kqT
+            </span>
+          </div>
+        </td>
+        <td
+          class="py-1 text-sm text-right"
+        >
+          <div
+            class="sc-AxiKw kNsium"
+            color="success"
+          >
+            100 BTC
           </div>
         </td>
       </tr>

--- a/src/app/components/TransactionListItem/__snapshots__/TransactionListItem.test.tsx.snap
+++ b/src/app/components/TransactionListItem/__snapshots__/TransactionListItem.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`TransactionListItem should render a received transaction 1`] = `
   <table>
     <tbody>
       <tr
-        class="border-b border-theme-neutral-200 cursor-pointer"
+        class="border-b cursor-pointer border-theme-neutral-200"
         data-testid="transaction__row"
       >
         <td
@@ -83,7 +83,7 @@ exports[`TransactionListItem should render a send transaction 1`] = `
   <table>
     <tbody>
       <tr
-        class="border-b border-theme-neutral-200 cursor-pointer"
+        class="border-b cursor-pointer border-theme-neutral-200"
         data-testid="transaction__row"
       >
         <td
@@ -161,7 +161,7 @@ exports[`TransactionListItem should render compact variant 1`] = `
   <table>
     <tbody>
       <tr
-        class="border-b border-theme-neutral-200 cursor-pointer"
+        class="border-b cursor-pointer border-theme-neutral-200"
         data-testid="transaction__row"
       >
         <td

--- a/src/app/components/TransactionListItem/__snapshots__/TransactionListItem.test.tsx.snap
+++ b/src/app/components/TransactionListItem/__snapshots__/TransactionListItem.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`TransactionListItem should render a received transaction 1`] = `
   <table>
     <tbody>
       <tr
-        class="border-b cursor-pointer border-theme-neutral-200"
+        class="border-b border-theme-neutral-200 cursor-pointer"
         data-testid="transaction__row"
       >
         <td
@@ -83,7 +83,7 @@ exports[`TransactionListItem should render a send transaction 1`] = `
   <table>
     <tbody>
       <tr
-        class="border-b cursor-pointer border-theme-neutral-200"
+        class="border-b border-theme-neutral-200 cursor-pointer"
         data-testid="transaction__row"
       >
         <td
@@ -161,7 +161,7 @@ exports[`TransactionListItem should render compact variant 1`] = `
   <table>
     <tbody>
       <tr
-        class="border-b cursor-pointer border-theme-neutral-200"
+        class="border-b border-theme-neutral-200 cursor-pointer"
         data-testid="transaction__row"
       >
         <td

--- a/src/app/components/TransactionListItem/models.ts
+++ b/src/app/components/TransactionListItem/models.ts
@@ -6,6 +6,6 @@ export type TransactionListItemProps = {
 	walletName?: string;
 	amount: string;
 	fiat: string;
-	variant?: "default" | "compact";
+	variant?: "compact";
 	onClick?: any;
 };

--- a/src/app/components/TransactionListItem/models.ts
+++ b/src/app/components/TransactionListItem/models.ts
@@ -1,0 +1,11 @@
+export type TransactionListItemProps = {
+	date: string;
+	avatarId: string;
+	type: string;
+	address?: string;
+	walletName?: string;
+	amount: string;
+	fiat: string;
+	variant?: "default" | "compact";
+	onClick?: any;
+};

--- a/src/domains/dashboard/components/Transactions/__snapshots__/Transactions.test.tsx.snap
+++ b/src/domains/dashboard/components/Transactions/__snapshots__/Transactions.test.tsx.snap
@@ -266,7 +266,8 @@ exports[`Transactions should render with with transactions 1`] = `
           role="rowgroup"
         >
           <tr
-            class="border-b border-theme-neutral-200"
+            class="border-b border-theme-neutral-200 cursor-pointer"
+            data-testid="transaction__row"
           >
             <td
               class="w-48 py-1 text-sm text-theme-neutral-600"
@@ -334,7 +335,8 @@ exports[`Transactions should render with with transactions 1`] = `
             </td>
           </tr>
           <tr
-            class="border-b border-theme-neutral-200"
+            class="border-b border-theme-neutral-200 cursor-pointer"
+            data-testid="transaction__row"
           >
             <td
               class="w-48 py-1 text-sm text-theme-neutral-600"
@@ -402,7 +404,8 @@ exports[`Transactions should render with with transactions 1`] = `
             </td>
           </tr>
           <tr
-            class="border-b border-theme-neutral-200"
+            class="border-b border-theme-neutral-200 cursor-pointer"
+            data-testid="transaction__row"
           >
             <td
               class="w-48 py-1 text-sm text-theme-neutral-600"
@@ -470,7 +473,8 @@ exports[`Transactions should render with with transactions 1`] = `
             </td>
           </tr>
           <tr
-            class="border-b border-theme-neutral-200"
+            class="border-b border-theme-neutral-200 cursor-pointer"
+            data-testid="transaction__row"
           >
             <td
               class="w-48 py-1 text-sm text-theme-neutral-600"
@@ -538,7 +542,8 @@ exports[`Transactions should render with with transactions 1`] = `
             </td>
           </tr>
           <tr
-            class="border-b border-theme-neutral-200"
+            class="border-b border-theme-neutral-200 cursor-pointer"
+            data-testid="transaction__row"
           >
             <td
               class="w-48 py-1 text-sm text-theme-neutral-600"
@@ -606,7 +611,8 @@ exports[`Transactions should render with with transactions 1`] = `
             </td>
           </tr>
           <tr
-            class="border-b border-theme-neutral-200"
+            class="border-b border-theme-neutral-200 cursor-pointer"
+            data-testid="transaction__row"
           >
             <td
               class="w-48 py-1 text-sm text-theme-neutral-600"
@@ -674,7 +680,8 @@ exports[`Transactions should render with with transactions 1`] = `
             </td>
           </tr>
           <tr
-            class="border-b border-theme-neutral-200"
+            class="border-b border-theme-neutral-200 cursor-pointer"
+            data-testid="transaction__row"
           >
             <td
               class="w-48 py-1 text-sm text-theme-neutral-600"
@@ -742,7 +749,8 @@ exports[`Transactions should render with with transactions 1`] = `
             </td>
           </tr>
           <tr
-            class="border-b border-theme-neutral-200"
+            class="border-b border-theme-neutral-200 cursor-pointer"
+            data-testid="transaction__row"
           >
             <td
               class="w-48 py-1 text-sm text-theme-neutral-600"

--- a/src/domains/dashboard/components/Transactions/__snapshots__/Transactions.test.tsx.snap
+++ b/src/domains/dashboard/components/Transactions/__snapshots__/Transactions.test.tsx.snap
@@ -266,7 +266,7 @@ exports[`Transactions should render with with transactions 1`] = `
           role="rowgroup"
         >
           <tr
-            class="border-b border-theme-neutral-200 cursor-pointer"
+            class="border-b cursor-pointer border-theme-neutral-200"
             data-testid="transaction__row"
           >
             <td
@@ -335,7 +335,7 @@ exports[`Transactions should render with with transactions 1`] = `
             </td>
           </tr>
           <tr
-            class="border-b border-theme-neutral-200 cursor-pointer"
+            class="border-b cursor-pointer border-theme-neutral-200"
             data-testid="transaction__row"
           >
             <td
@@ -404,7 +404,7 @@ exports[`Transactions should render with with transactions 1`] = `
             </td>
           </tr>
           <tr
-            class="border-b border-theme-neutral-200 cursor-pointer"
+            class="border-b cursor-pointer border-theme-neutral-200"
             data-testid="transaction__row"
           >
             <td
@@ -473,7 +473,7 @@ exports[`Transactions should render with with transactions 1`] = `
             </td>
           </tr>
           <tr
-            class="border-b border-theme-neutral-200 cursor-pointer"
+            class="border-b cursor-pointer border-theme-neutral-200"
             data-testid="transaction__row"
           >
             <td
@@ -542,7 +542,7 @@ exports[`Transactions should render with with transactions 1`] = `
             </td>
           </tr>
           <tr
-            class="border-b border-theme-neutral-200 cursor-pointer"
+            class="border-b cursor-pointer border-theme-neutral-200"
             data-testid="transaction__row"
           >
             <td
@@ -611,7 +611,7 @@ exports[`Transactions should render with with transactions 1`] = `
             </td>
           </tr>
           <tr
-            class="border-b border-theme-neutral-200 cursor-pointer"
+            class="border-b cursor-pointer border-theme-neutral-200"
             data-testid="transaction__row"
           >
             <td
@@ -680,7 +680,7 @@ exports[`Transactions should render with with transactions 1`] = `
             </td>
           </tr>
           <tr
-            class="border-b border-theme-neutral-200 cursor-pointer"
+            class="border-b cursor-pointer border-theme-neutral-200"
             data-testid="transaction__row"
           >
             <td
@@ -749,7 +749,7 @@ exports[`Transactions should render with with transactions 1`] = `
             </td>
           </tr>
           <tr
-            class="border-b border-theme-neutral-200 cursor-pointer"
+            class="border-b cursor-pointer border-theme-neutral-200"
             data-testid="transaction__row"
           >
             <td

--- a/src/domains/dashboard/components/Transactions/__snapshots__/Transactions.test.tsx.snap
+++ b/src/domains/dashboard/components/Transactions/__snapshots__/Transactions.test.tsx.snap
@@ -266,7 +266,7 @@ exports[`Transactions should render with with transactions 1`] = `
           role="rowgroup"
         >
           <tr
-            class="border-b cursor-pointer border-theme-neutral-200"
+            class="border-b border-theme-neutral-200 cursor-pointer"
             data-testid="transaction__row"
           >
             <td
@@ -335,7 +335,7 @@ exports[`Transactions should render with with transactions 1`] = `
             </td>
           </tr>
           <tr
-            class="border-b cursor-pointer border-theme-neutral-200"
+            class="border-b border-theme-neutral-200 cursor-pointer"
             data-testid="transaction__row"
           >
             <td
@@ -404,7 +404,7 @@ exports[`Transactions should render with with transactions 1`] = `
             </td>
           </tr>
           <tr
-            class="border-b cursor-pointer border-theme-neutral-200"
+            class="border-b border-theme-neutral-200 cursor-pointer"
             data-testid="transaction__row"
           >
             <td
@@ -473,7 +473,7 @@ exports[`Transactions should render with with transactions 1`] = `
             </td>
           </tr>
           <tr
-            class="border-b cursor-pointer border-theme-neutral-200"
+            class="border-b border-theme-neutral-200 cursor-pointer"
             data-testid="transaction__row"
           >
             <td
@@ -542,7 +542,7 @@ exports[`Transactions should render with with transactions 1`] = `
             </td>
           </tr>
           <tr
-            class="border-b cursor-pointer border-theme-neutral-200"
+            class="border-b border-theme-neutral-200 cursor-pointer"
             data-testid="transaction__row"
           >
             <td
@@ -611,7 +611,7 @@ exports[`Transactions should render with with transactions 1`] = `
             </td>
           </tr>
           <tr
-            class="border-b cursor-pointer border-theme-neutral-200"
+            class="border-b border-theme-neutral-200 cursor-pointer"
             data-testid="transaction__row"
           >
             <td
@@ -680,7 +680,7 @@ exports[`Transactions should render with with transactions 1`] = `
             </td>
           </tr>
           <tr
-            class="border-b cursor-pointer border-theme-neutral-200"
+            class="border-b border-theme-neutral-200 cursor-pointer"
             data-testid="transaction__row"
           >
             <td
@@ -749,7 +749,7 @@ exports[`Transactions should render with with transactions 1`] = `
             </td>
           </tr>
           <tr
-            class="border-b cursor-pointer border-theme-neutral-200"
+            class="border-b border-theme-neutral-200 cursor-pointer"
             data-testid="transaction__row"
           >
             <td


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Add `compact` variant to `TransactionListItem` component. Uses same data fields as `default` variant.

Seen in Notifications transactions lists.

Preview:

![2020-06-16-151729_705x161_scrot](https://user-images.githubusercontent.com/22020168/84773091-9545b800-afe4-11ea-9d49-c0c5a123a2ee.png)

Usage: 
```jsx
<TransactionListItem variant="compact" {...data}></TransactionListItem>
```


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
