### PR TITLE
feat: add singleAction variant to wallet list item component

### DIFF
--- a/src/app/components/WalletListItem/WalletListItem.stories.tsx
+++ b/src/app/components/WalletListItem/WalletListItem.stories.tsx
@@ -7,63 +7,75 @@ export default {
 	title: "Wallets / Components / WalletListItem",
 };
 
+const data = [
+	{
+		coin: "Btc",
+		coinClassName: "text-theme-warning-400 border-theme-warning-200",
+		avatarId: "test",
+		address: "ASuusXSW9kfWnicScSgUTjttP6T9GQ3kqT",
+		walletName: "My Wallet",
+		balance: "100 BTC",
+		fiat: "1,000,000 USD",
+		walletTypeIcons: ["Star", "Multisig", "Ledger"],
+		actions: [
+			{
+				label: "Action 1",
+				value: "1",
+			},
+			{
+				label: "Action 2",
+				value: "2",
+			},
+			{
+				label: "Action 3",
+				value: "3",
+			},
+		],
+	},
+];
+
+const columns = [
+	{
+		Header: "Asset Type",
+		accessor: "avatarId",
+	},
+	{
+		Header: "Wallet Address",
+		accessor: "address",
+	},
+	{
+		Header: "Wallet Type",
+	},
+	{
+		Header: "Balance",
+		accessor: "balance",
+		className: "float-right",
+	},
+	{
+		Header: "Fiat Value",
+		accessor: "fiat",
+		className: "float-right",
+	},
+];
+
 export const Default = () => {
-	const data = [
-		{
-			coin: "Btc",
-			coinClassName: "text-theme-warning-400 border-theme-warning-200",
-			avatarId: "test",
-			address: "ASuusXSW9kfWnicScSgUTjttP6T9GQ3kqT",
-			walletName: "My Wallet",
-			balance: "100 BTC",
-			fiat: "1,000,000 USD",
-			walletTypeIcons: ["Star", "Multisig", "Ledger"],
-			actions: [
-				{
-					label: "Action 1",
-					value: "1",
-				},
-				{
-					label: "Action 2",
-					value: "2",
-				},
-				{
-					label: "Action 3",
-					value: "3",
-				},
-			],
-		},
-	];
-
-	const columns = [
-		{
-			Header: "Asset Type",
-			accessor: "avatarId",
-		},
-		{
-			Header: "Wallet Address",
-			accessor: "address",
-		},
-		{
-			Header: "Wallet Type",
-		},
-		{
-			Header: "Balance",
-			accessor: "balance",
-			className: "float-right",
-		},
-		{
-			Header: "Fiat Value",
-			accessor: "fiat",
-			className: "float-right",
-		},
-	];
-
 	return (
 		<div>
 			<div>
 				<Table columns={columns} data={data}>
-					{(rowData: any) => <WalletListItem {...rowData}></WalletListItem>}
+					{(rowData: any) => <WalletListItem {...rowData} />}
+				</Table>
+			</div>
+		</div>
+	);
+};
+
+export const SingleAction = () => {
+	return (
+		<div>
+			<div>
+				<Table columns={columns} data={data}>
+					{(rowData: any) => <WalletListItem {...rowData} variant="singleAction" />}
 				</Table>
 			</div>
 		</div>

--- a/src/app/components/WalletListItem/WalletListItem.test.tsx
+++ b/src/app/components/WalletListItem/WalletListItem.test.tsx
@@ -16,6 +16,22 @@ describe("WalletListItem", () => {
 		expect(container).toMatchSnapshot();
 	});
 
+	it("should render a button if variant is 'singleAction'", () => {
+		const actions = [{ label: "Option 1", value: "1" }];
+
+		const { container, getByTestId } = render(
+			<table>
+				<tbody>
+					<WalletListItem actions={actions} variant="singleAction" />
+				</tbody>
+			</table>,
+		);
+
+		expect(() => getByTestId("dropdown__toggle")).toThrow(/Unable to find an element by/);
+		expect(getByTestId("button")).toHaveTextContent(actions[0].label);
+		expect(container).toMatchSnapshot();
+	});
+
 	it("should trigger onAction callback if provided", () => {
 		const fn = jest.fn();
 		const options = [

--- a/src/app/components/WalletListItem/WalletListItem.tsx
+++ b/src/app/components/WalletListItem/WalletListItem.tsx
@@ -1,4 +1,5 @@
 import { Address } from "app/components/Address";
+import { Button } from "app/components/Button";
 import { Circle } from "app/components/Circle";
 import { Icon } from "app/components/Icon";
 import React from "react";
@@ -13,8 +14,9 @@ type WalletListItemProps = {
 	walletName?: string;
 	balance?: string;
 	fiat?: string;
-	walletTypeIcons?: any[];
+	walletTypeIcons?: any[] | null;
 	actions?: any[];
+	variant?: "singleAction";
 	onAction?: any;
 };
 
@@ -28,6 +30,7 @@ export const WalletListItem = ({
 	fiat,
 	walletTypeIcons,
 	actions,
+	variant,
 	onAction,
 }: WalletListItemProps) => {
 	const getIconTypeClass = (icon: string) => {
@@ -50,16 +53,17 @@ export const WalletListItem = ({
 			<td className="py-1">
 				<Address walletName={walletName} address={address} size="small" maxChars={22}></Address>
 			</td>
-			<td className="py-1 text-sm font-bold">
-				{walletTypeIcons &&
-					walletTypeIcons.map((type: string, index: number) => {
+			{walletTypeIcons && (
+				<td className="py-1 text-sm font-bold">
+					{walletTypeIcons.map((type: string, index: number) => {
 						return (
 							<div key={index} className={`inline-block mr-2 text ${getIconTypeClass(type)}`}>
 								<Icon name={type} />
 							</div>
 						);
 					})}
-			</td>
+				</td>
+			)}
 			<td className="py-1 text-sm font-bold text-right">
 				<div>{balance}</div>
 			</td>
@@ -67,7 +71,19 @@ export const WalletListItem = ({
 				<div>{fiat}</div>
 			</td>
 			<td>
-				{actions && actions.length > 0 && <Dropdown options={actions} onSelect={onDropdownAction}></Dropdown>}
+				{actions &&
+					actions.length &&
+					(() => {
+						if (variant === "singleAction") {
+							return (
+								<Button data-testid="button" className="ml-6" onClick={onDropdownAction}>
+									{actions[0].label}
+								</Button>
+							);
+						}
+
+						return <Dropdown options={actions} onSelect={onDropdownAction} />;
+					})()}
 			</td>
 		</tr>
 	);

--- a/src/app/components/WalletListItem/__snapshots__/WalletListItem.test.tsx.snap
+++ b/src/app/components/WalletListItem/__snapshots__/WalletListItem.test.tsx.snap
@@ -11,16 +11,16 @@ exports[`WalletListItem should render 1`] = `
           class="py-4 mt-1"
         >
           <div
-            class="sc-AxjAm BXGDK"
+            class="sc-AxirZ jGEfIx"
           >
             <div
-              class="sc-AxirZ iQaTP"
+              class="sc-AxiKw dzBdqj"
               height="1em"
               width="1em"
             />
           </div>
           <div
-            class="sc-AxjAm BXGDK"
+            class="sc-AxirZ jGEfIx"
           />
         </td>
         <td
@@ -33,7 +33,7 @@ exports[`WalletListItem should render 1`] = `
             class="inline-block mr-2 text text-theme-warning-400"
           >
             <div
-              class="sc-AxirZ iQaTP"
+              class="sc-AxiKw dzBdqj"
               height="1em"
               width="1em"
             >
@@ -46,7 +46,7 @@ exports[`WalletListItem should render 1`] = `
             class="inline-block mr-2 text text-theme-primary-300"
           >
             <div
-              class="sc-AxirZ iQaTP"
+              class="sc-AxiKw dzBdqj"
               height="1em"
               width="1em"
             />
@@ -62,7 +62,64 @@ exports[`WalletListItem should render 1`] = `
         >
           <div />
         </td>
-        <td />
+        <td>
+          0
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
+exports[`WalletListItem should render a button if variant is 'singleAction' 1`] = `
+<div>
+  <table>
+    <tbody>
+      <tr
+        class="border-b border-theme-neutral-200"
+      >
+        <td
+          class="py-4 mt-1"
+        >
+          <div
+            class="sc-AxirZ jGEfIx"
+          >
+            <div
+              class="sc-AxiKw dzBdqj"
+              height="1em"
+              width="1em"
+            />
+          </div>
+          <div
+            class="sc-AxirZ jGEfIx"
+          />
+        </td>
+        <td
+          class="py-1"
+        />
+        <td
+          class="py-1 text-sm font-bold"
+        />
+        <td
+          class="py-1 text-sm font-bold text-right"
+        >
+          <div />
+        </td>
+        <td
+          class="py-1 text-sm font-bold text-right text-theme-neutral-400"
+        >
+          <div />
+        </td>
+        <td>
+          <button
+            class="sc-AxjAm jTpTok ml-6"
+            color="primary"
+            data-testid="button"
+            type="button"
+          >
+            Option 1
+          </button>
+        </td>
       </tr>
     </tbody>
   </table>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Adds a variant prop to the WalletListItem component which if set to `singleAction` will display a button instead of the dropdown.

Also allows to not render the table cell for the wallet type icons by setting the `walletTypeIcons` prop to `null`.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
