### PR TITLE
fix: use darker color when no wallet name given

### DIFF
--- a/src/app/components/Address/Address.stories.tsx
+++ b/src/app/components/Address/Address.stories.tsx
@@ -1,4 +1,4 @@
-import { number, text, withKnobs } from "@storybook/addon-knobs";
+import { number, select, text, withKnobs } from "@storybook/addon-knobs";
 import React from "react";
 
 import { Address } from "./Address";
@@ -12,12 +12,13 @@ export const Default = () => {
 	const address = text("Address", "ASuusXSW9kfWnicScSgUTjttP6T9GQ3kqT");
 	const walletName = text("Wallet Name", "My wallet");
 	const maxChars = number("Maximum characters", 20);
+	const size = select("Size", ["small", "default", "large"], "default");
 
 	return (
 		<div className="">
 			<div className="mb-10 text-md">Formatted (truncated) address with optional wallet name</div>
 			<div className="mb-10">
-				<Address address={address} maxChars={maxChars} walletName={walletName} />
+				<Address address={address} maxChars={maxChars} walletName={walletName} size={size} />
 			</div>
 		</div>
 	);

--- a/src/app/components/Address/Address.tsx
+++ b/src/app/components/Address/Address.tsx
@@ -34,7 +34,9 @@ export const Address = ({ address, addressClass, walletName, maxChars, size }: P
 			)}
 			<span
 				data-testid="address__wallet-address"
-				className={`${addressClass || "text-theme-neutral-400"} font-semibold ${size && fontSizes[size]}`}
+				className={`${
+					addressClass || (walletName ? "text-theme-neutral-400" : "text-theme-neutral-800")
+				} font-semibold ${size && fontSizes[size]}`}
 			>
 				{truncateStringMiddle(address, maxChars)}
 			</span>

--- a/src/app/components/Address/__snapshots__/Address.test.tsx.snap
+++ b/src/app/components/Address/__snapshots__/Address.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`Formatted Address should render address only 1`] = `
     class="inline-block truncate"
   >
     <span
-      class="text-theme-neutral-400 font-semibold text-base"
+      class="text-theme-neutral-800 font-semibold text-base"
       data-testid="address__wallet-address"
     >
       ASuusX...GQ3kqT


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Fixes the address font color when there's no name and adds size knobs to the storyboard, e.g.

![image](https://user-images.githubusercontent.com/6547002/85130511-59556180-b235-11ea-8439-96c0267a15e2.png)

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
