### PR TITLE
feat: add `extra` prop to wallet header

### DIFF
--- a/src/app/components/Header/Header.stories.tsx
+++ b/src/app/components/Header/Header.stories.tsx
@@ -1,0 +1,25 @@
+import { text, withKnobs } from "@storybook/addon-knobs";
+import { Button } from "app/components/Button";
+import React from "react";
+
+import { Header } from "./Header";
+
+export default {
+	title: "Basic / Header",
+	decorators: [withKnobs],
+};
+
+export const Default = () => <Header title={text("Title", "Title")} subtitle={text("Subtitle", "Subtitle")} />;
+
+export const WithExtra = () => (
+	<Header
+		title={text("Title", "Title")}
+		subtitle={text("Subtitle", "Subtitle")}
+		extra={
+			<div className="flex justify-end space-x-3">
+				<Button>Extra 1</Button>
+				<Button>Extra 2</Button>
+			</div>
+		}
+	/>
+);

--- a/src/app/components/Header/Header.test.tsx
+++ b/src/app/components/Header/Header.test.tsx
@@ -1,4 +1,5 @@
 import { render } from "@testing-library/react";
+import { Button } from "app/components/Button";
 import React from "react";
 
 import { Header } from "./Header";
@@ -18,6 +19,27 @@ describe("Header", () => {
 		expect(container).toBeTruthy();
 		expect(getByTestId("header__title")).toHaveTextContent("Header test");
 		expect(getByTestId("header__subtitle")).toHaveTextContent("Subtitle test");
+		expect(asFragment()).toMatchSnapshot();
+	});
+
+	it("should render an header with extra", () => {
+		const { container, asFragment, getAllByTestId, getByTestId } = render(
+			<Header
+				title="Header test"
+				subtitle="Subtitle test"
+				extra={
+					<div className="flex justify-end space-x-3">
+						<Button data-testid="header__extra">Extra 1</Button>
+						<Button data-testid="header__extra">Extra 2</Button>
+					</div>
+				}
+			/>,
+		);
+
+		expect(container).toBeTruthy();
+		expect(getByTestId("header__title")).toHaveTextContent("Header test");
+		expect(getByTestId("header__subtitle")).toHaveTextContent("Subtitle test");
+		expect(getAllByTestId("header__extra")).toHaveLength(2);
 		expect(asFragment()).toMatchSnapshot();
 	});
 });

--- a/src/app/components/Header/Header.tsx
+++ b/src/app/components/Header/Header.tsx
@@ -3,17 +3,21 @@ import React from "react";
 type Props = {
 	title: string;
 	subtitle?: string;
+	extra?: React.ReactNode;
 };
 
-export const Header = ({ title, subtitle }: Props) => (
-	<div className="flex flex-col items-start">
-		<h1 className="text-3xl font-bold md:text-4xl" data-testid="header__title">
-			{title}
-		</h1>
-		{subtitle && (
-			<div className="mt-2 text-theme-neutral-dark" data-testid="header__subtitle">
-				{subtitle}
-			</div>
-		)}
+export const Header = ({ title, subtitle, extra }: Props) => (
+	<div className="flex items-center justify-between">
+		<div className="flex flex-col items-start">
+			<h1 className="text-3xl font-bold md:text-4xl" data-testid="header__title">
+				{title}
+			</h1>
+			{subtitle && (
+				<div className="mt-2 text-theme-neutral-dark" data-testid="header__subtitle">
+					{subtitle}
+				</div>
+			)}
+		</div>
+		{extra}
 	</div>
 );

--- a/src/app/components/Header/__snapshots__/Header.test.tsx.snap
+++ b/src/app/components/Header/__snapshots__/Header.test.tsx.snap
@@ -3,14 +3,18 @@
 exports[`Header should render an header 1`] = `
 <DocumentFragment>
   <div
-    class="flex flex-col items-start"
+    class="flex items-center justify-between"
   >
-    <h1
-      class="text-3xl font-bold md:text-4xl"
-      data-testid="header__title"
+    <div
+      class="flex flex-col items-start"
     >
-      Header test
-    </h1>
+      <h1
+        class="text-3xl font-bold md:text-4xl"
+        data-testid="header__title"
+      >
+        Header test
+      </h1>
+    </div>
   </div>
 </DocumentFragment>
 `;
@@ -18,19 +22,68 @@ exports[`Header should render an header 1`] = `
 exports[`Header should render an header with a subtitle 1`] = `
 <DocumentFragment>
   <div
-    class="flex flex-col items-start"
+    class="flex items-center justify-between"
   >
-    <h1
-      class="text-3xl font-bold md:text-4xl"
-      data-testid="header__title"
-    >
-      Header test
-    </h1>
     <div
-      class="mt-2 text-theme-neutral-dark"
-      data-testid="header__subtitle"
+      class="flex flex-col items-start"
     >
-      Subtitle test
+      <h1
+        class="text-3xl font-bold md:text-4xl"
+        data-testid="header__title"
+      >
+        Header test
+      </h1>
+      <div
+        class="mt-2 text-theme-neutral-dark"
+        data-testid="header__subtitle"
+      >
+        Subtitle test
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`Header should render an header with extra 1`] = `
+<DocumentFragment>
+  <div
+    class="flex items-center justify-between"
+  >
+    <div
+      class="flex flex-col items-start"
+    >
+      <h1
+        class="text-3xl font-bold md:text-4xl"
+        data-testid="header__title"
+      >
+        Header test
+      </h1>
+      <div
+        class="mt-2 text-theme-neutral-dark"
+        data-testid="header__subtitle"
+      >
+        Subtitle test
+      </div>
+    </div>
+    <div
+      class="flex justify-end space-x-3"
+    >
+      <button
+        class="sc-AxjAm eixJcU"
+        color="primary"
+        data-testid="header__extra"
+        type="button"
+      >
+        Extra 1
+      </button>
+      <button
+        class="sc-AxjAm eixJcU"
+        color="primary"
+        data-testid="header__extra"
+        type="button"
+      >
+        Extra 2
+      </button>
     </div>
   </div>
 </DocumentFragment>

--- a/src/app/components/Header/__snapshots__/Header.test.tsx.snap
+++ b/src/app/components/Header/__snapshots__/Header.test.tsx.snap
@@ -69,7 +69,7 @@ exports[`Header should render an header with extra 1`] = `
       class="flex justify-end space-x-3"
     >
       <button
-        class="sc-AxjAm eixJcU"
+        class="sc-AxjAm ddQVWI"
         color="primary"
         data-testid="header__extra"
         type="button"
@@ -77,7 +77,7 @@ exports[`Header should render an header with extra 1`] = `
         Extra 1
       </button>
       <button
-        class="sc-AxjAm eixJcU"
+        class="sc-AxjAm ddQVWI"
         color="primary"
         data-testid="header__extra"
         type="button"

--- a/src/domains/settings/pages/Settings/__snapshots__/Settings.test.tsx.snap
+++ b/src/domains/settings/pages/Settings/__snapshots__/Settings.test.tsx.snap
@@ -104,19 +104,23 @@ exports[`Settings should render 1`] = `
       class="w-3/5 pl-20 mx-12 border-l-1 border-theme-primary-contrast"
     >
       <div
-        class="flex flex-col items-start"
+        class="flex items-center justify-between"
       >
-        <h1
-          class="text-3xl font-bold md:text-4xl"
-          data-testid="header__title"
-        >
-          Wallet Settings
-        </h1>
         <div
-          class="mt-2 text-theme-neutral-dark"
-          data-testid="header__subtitle"
+          class="flex flex-col items-start"
         >
-          Customize your wallet to suit your needs.
+          <h1
+            class="text-3xl font-bold md:text-4xl"
+            data-testid="header__title"
+          >
+            Wallet Settings
+          </h1>
+          <div
+            class="mt-2 text-theme-neutral-dark"
+            data-testid="header__subtitle"
+          >
+            Customize your wallet to suit your needs.
+          </div>
         </div>
       </div>
       <form
@@ -527,14 +531,18 @@ exports[`Settings should render 1`] = `
           class="relative mt-5"
         >
           <div
-            class="flex flex-col items-start"
+            class="flex items-center justify-between"
           >
-            <h1
-              class="text-3xl font-bold md:text-4xl"
-              data-testid="header__title"
+            <div
+              class="flex flex-col items-start"
             >
-              Security
-            </h1>
+              <h1
+                class="text-3xl font-bold md:text-4xl"
+                data-testid="header__title"
+              >
+                Security
+              </h1>
+            </div>
           </div>
           <ul
             class="sc-fzplWN krwTau"
@@ -718,14 +726,18 @@ exports[`Settings should render 1`] = `
           class="relative mt-5"
         >
           <div
-            class="flex flex-col items-start"
+            class="flex items-center justify-between"
           >
-            <h1
-              class="text-3xl font-bold md:text-4xl"
-              data-testid="header__title"
+            <div
+              class="flex flex-col items-start"
             >
-              Other
-            </h1>
+              <h1
+                class="text-3xl font-bold md:text-4xl"
+                data-testid="header__title"
+              >
+                Other
+              </h1>
+            </div>
           </div>
           <ul
             class="sc-fzplWN krwTau"
@@ -1125,19 +1137,23 @@ exports[`Settings should render peer settings 1`] = `
       class="w-3/5 pl-20 mx-12 border-l-1 border-theme-primary-contrast"
     >
       <div
-        class="flex flex-col items-start"
+        class="flex items-center justify-between"
       >
-        <h1
-          class="text-3xl font-bold md:text-4xl"
-          data-testid="header__title"
-        >
-          Peer Settings
-        </h1>
         <div
-          class="mt-2 text-theme-neutral-dark"
-          data-testid="header__subtitle"
+          class="flex flex-col items-start"
         >
-          Customize your wallet to suit your needs.
+          <h1
+            class="text-3xl font-bold md:text-4xl"
+            data-testid="header__title"
+          >
+            Peer Settings
+          </h1>
+          <div
+            class="mt-2 text-theme-neutral-dark"
+            data-testid="header__subtitle"
+          >
+            Customize your wallet to suit your needs.
+          </div>
         </div>
       </div>
       <form
@@ -1711,19 +1727,23 @@ exports[`Settings should render plugin settings 1`] = `
       class="w-3/5 pl-20 mx-12 border-l-1 border-theme-primary-contrast"
     >
       <div
-        class="flex flex-col items-start"
+        class="flex items-center justify-between"
       >
-        <h1
-          class="text-3xl font-bold md:text-4xl"
-          data-testid="header__title"
-        >
-          Plugin Settings
-        </h1>
         <div
-          class="mt-2 text-theme-neutral-dark"
-          data-testid="header__subtitle"
+          class="flex flex-col items-start"
         >
-          Customize your wallet to suit your needs.
+          <h1
+            class="text-3xl font-bold md:text-4xl"
+            data-testid="header__title"
+          >
+            Plugin Settings
+          </h1>
+          <div
+            class="mt-2 text-theme-neutral-dark"
+            data-testid="header__subtitle"
+          >
+            Customize your wallet to suit your needs.
+          </div>
         </div>
       </div>
       <form

--- a/src/domains/wallets/pages/CreateWallet/__snapshots__/CreateWallet.test.tsx.snap
+++ b/src/domains/wallets/pages/CreateWallet/__snapshots__/CreateWallet.test.tsx.snap
@@ -351,14 +351,18 @@ exports[`CreateWallet should render 2nd step 1`] = `
     data-testid="CreateWallet__second-step"
   >
     <div
-      class="flex flex-col items-start"
+      class="flex items-center justify-between"
     >
-      <h1
-        class="text-3xl font-bold md:text-4xl"
-        data-testid="header__title"
+      <div
+        class="flex flex-col items-start"
       >
-        Your Passphrase
-      </h1>
+        <h1
+          class="text-3xl font-bold md:text-4xl"
+          data-testid="header__title"
+        >
+          Your Passphrase
+        </h1>
+      </div>
     </div>
     <div
       class="space-y-8"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Adds an `extra` prop to the Header component, useful for buttons or the like.

<img width="881" alt="image" src="https://user-images.githubusercontent.com/6547002/85251390-86825980-b459-11ea-8055-73595b4e2a7e.png">

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
