### PR TITLE
feat: add plugin info section component

### DIFF
--- a/src/domains/plugins/components/PluginInfo/PluginInfo.spec.tsx
+++ b/src/domains/plugins/components/PluginInfo/PluginInfo.spec.tsx
@@ -1,0 +1,23 @@
+import { render } from "@testing-library/react";
+import React from "react";
+
+import { PluginInfo } from "./PluginInfo";
+
+describe("PluginInfo", () => {
+	const about =
+		"Use the ARK Explorer to get full visibility of critical data from the ARK network. Data such as the latest blocks, wallet addresses and transactions. Plus monitor delegate status, their position and more.";
+	const permissions = ["Embedded Webpages", "API Requests", "Access to Profiles"];
+
+	it("should render properly", () => {
+		const { asFragment, getByTestId, getAllByTestId } = render(
+			<PluginInfo about={about} permissions={permissions} screenshots={[1, 2, 3]} />,
+		);
+
+		expect(getByTestId("plugin-info__about")).toHaveTextContent(about);
+		expect(getByTestId("plugin-info__permissions")).toHaveTextContent(permissions.join(", "));
+		expect(getByTestId("plugin-info__screenshots--pagination")).toBeTruthy();
+		expect(getAllByTestId("plugin-info__screenshot")).toHaveLength(9);
+		expect(asFragment()).toMatchSnapshot();
+	});
+});
+w;

--- a/src/domains/plugins/components/PluginInfo/PluginInfo.spec.tsx
+++ b/src/domains/plugins/components/PluginInfo/PluginInfo.spec.tsx
@@ -20,4 +20,3 @@ describe("PluginInfo", () => {
 		expect(asFragment()).toMatchSnapshot();
 	});
 });
-w;

--- a/src/domains/plugins/components/PluginInfo/PluginInfo.stories.tsx
+++ b/src/domains/plugins/components/PluginInfo/PluginInfo.stories.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+
+import { PluginInfo } from "./PluginInfo";
+
+export default { title: "Plugins / Components / Plugin Info" };
+
+export const Default = () => (
+	<PluginInfo
+		about="Use the ARK Explorer to get full visibility of critical data from the ARK network. Data such as the latest blocks, wallet addresses and transactions. Plus monitor delegate status, their position and more."
+		permissions={["Embedded Webpages", "API Requests", "Access to Profiles"]}
+		screenshots={[1, 2, 3]}
+	/>
+);

--- a/src/domains/plugins/components/PluginInfo/PluginInfo.tsx
+++ b/src/domains/plugins/components/PluginInfo/PluginInfo.tsx
@@ -9,7 +9,7 @@ type Props = {
 };
 
 export const PluginInfo = ({ about, permissions, screenshots }: Props) => (
-	<div className="mt-5 p-10 bg-theme-background">
+	<div className="p-10 mt-5 bg-theme-background">
 		<div>
 			<p className="font-bold">About the plugin</p>
 			<p className="mt-3 text-theme-neutral-600" data-testid="plugin-info__about">
@@ -22,10 +22,10 @@ export const PluginInfo = ({ about, permissions, screenshots }: Props) => (
 				{permissions.join(", ")}
 			</p>
 		</div>
-		<div className="mt-10 relative">
+		<div className="relative mt-10">
 			<p className="font-bold">Screenshots</p>
 			<div
-				className="absolute top-0 right-0 pr-4 flex space-x-3 screenshots-pagination"
+				className="absolute top-0 right-0 flex pr-4 space-x-3 screenshots-pagination"
 				data-testid="plugin-info__screenshots--pagination"
 			/>
 			<div className="pb-10">
@@ -39,12 +39,12 @@ export const PluginInfo = ({ about, permissions, screenshots }: Props) => (
 					}}
 				>
 					{(screenshotGroup: any) => (
-						<div className="mt-3 flex space-x-4 pb-10 mr-3">
+						<div className="flex pb-10 mt-3 mr-3 space-x-4">
 							{screenshotGroup.map((screenshot: any, idx: number) => (
 								<div
 									data-testid="plugin-info__screenshot"
 									key={idx}
-									className="rounded-lg w-1/3 h-56 bg-theme-neutral-500"
+									className="w-1/3 h-56 rounded-lg bg-theme-neutral-500"
 								/>
 							))}
 						</div>

--- a/src/domains/plugins/components/PluginInfo/PluginInfo.tsx
+++ b/src/domains/plugins/components/PluginInfo/PluginInfo.tsx
@@ -1,0 +1,63 @@
+import { Alert } from "app/components/Alert";
+import { Slider } from "app/components/Slider";
+import React from "react";
+
+type Props = {
+	about: string;
+	permissions: any;
+	screenshots: any;
+};
+
+export const PluginInfo = ({ about, permissions, screenshots }: Props) => (
+	<div className="mt-5 p-10 bg-theme-background">
+		<div>
+			<p className="font-bold">About the plugin</p>
+			<p className="mt-3 text-theme-neutral-600" data-testid="plugin-info__about">
+				{about}
+			</p>
+		</div>
+		<div className="mt-10">
+			<p className="font-bold">Permissions</p>
+			<p className="mt-3 text-theme-neutral-600" data-testid="plugin-info__permissions">
+				{permissions.join(", ")}
+			</p>
+		</div>
+		<div className="mt-10 relative">
+			<p className="font-bold">Screenshots</p>
+			<div
+				className="absolute top-0 right-0 pr-4 flex space-x-3 screenshots-pagination"
+				data-testid="plugin-info__screenshots--pagination"
+			/>
+			<div className="pb-10">
+				<Slider
+					data={[screenshots, screenshots, screenshots]}
+					options={{
+						pagination: {
+							el: ".screenshots-pagination",
+							clickable: true,
+						},
+					}}
+				>
+					{(screenshotGroup: any) => (
+						<div className="mt-3 flex space-x-4 pb-10 mr-3">
+							{screenshotGroup.map((screenshot: any, idx: number) => (
+								<div
+									data-testid="plugin-info__screenshot"
+									key={idx}
+									className="rounded-lg w-1/3 h-56 bg-theme-neutral-500"
+								/>
+							))}
+						</div>
+					)}
+				</Slider>
+			</div>
+			<div className="pb-10">
+				<Alert variant="warning" title="Disclaimer">
+					The availability of this plugin in the ARK Desktop Wallet does not mean that either ARK.io or ARK
+					SCIC is directly involved in the development or affiliated with the developer providing this plugin.
+					By installing it on your wallet, you assume every responsibility
+				</Alert>
+			</div>
+		</div>
+	</div>
+);

--- a/src/domains/plugins/components/PluginInfo/__snapshots__/PluginInfo.spec.tsx.snap
+++ b/src/domains/plugins/components/PluginInfo/__snapshots__/PluginInfo.spec.tsx.snap
@@ -1,0 +1,172 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PluginInfo should render properly 1`] = `
+<DocumentFragment>
+  <div
+    class="mt-5 p-10 bg-theme-background"
+  >
+    <div>
+      <p
+        class="font-bold"
+      >
+        About the plugin
+      </p>
+      <p
+        class="mt-3 text-theme-neutral-600"
+        data-testid="plugin-info__about"
+      >
+        Use the ARK Explorer to get full visibility of critical data from the ARK network. Data such as the latest blocks, wallet addresses and transactions. Plus monitor delegate status, their position and more.
+      </p>
+    </div>
+    <div
+      class="mt-10"
+    >
+      <p
+        class="font-bold"
+      >
+        Permissions
+      </p>
+      <p
+        class="mt-3 text-theme-neutral-600"
+        data-testid="plugin-info__permissions"
+      >
+        Embedded Webpages, API Requests, Access to Profiles
+      </p>
+    </div>
+    <div
+      class="mt-10 relative"
+    >
+      <p
+        class="font-bold"
+      >
+        Screenshots
+      </p>
+      <div
+        class="absolute top-0 right-0 pr-4 flex space-x-3 screenshots-pagination swiper-pagination-clickable swiper-pagination-bullets"
+        data-testid="plugin-info__screenshots--pagination"
+      />
+      <div
+        class="pb-10"
+      >
+        <div
+          class="relative"
+        >
+          <div
+            class="swiper-container swiper-container-initialized swiper-container-horizontal"
+            style="height: 234px;"
+          >
+            <div
+              class="h-full swiper-wrapper "
+              style="webkit-transition-duration: 0ms; transition-duration: 0ms; webkit-transform: translate3d(NaNpx, 0px, 0px); transform: translate3d(NaNpx, 0px, 0px);"
+            >
+              <div
+                class="swiper-slide"
+                style="height: 180px;"
+              >
+                <div
+                  class="mt-3 flex space-x-4 pb-10 mr-3"
+                >
+                  <div
+                    class="rounded-lg w-1/3 h-56 bg-theme-neutral-500"
+                    data-testid="plugin-info__screenshot"
+                  />
+                  <div
+                    class="rounded-lg w-1/3 h-56 bg-theme-neutral-500"
+                    data-testid="plugin-info__screenshot"
+                  />
+                  <div
+                    class="rounded-lg w-1/3 h-56 bg-theme-neutral-500"
+                    data-testid="plugin-info__screenshot"
+                  />
+                </div>
+              </div>
+              <div
+                class="swiper-slide"
+                style="height: 180px;"
+              >
+                <div
+                  class="mt-3 flex space-x-4 pb-10 mr-3"
+                >
+                  <div
+                    class="rounded-lg w-1/3 h-56 bg-theme-neutral-500"
+                    data-testid="plugin-info__screenshot"
+                  />
+                  <div
+                    class="rounded-lg w-1/3 h-56 bg-theme-neutral-500"
+                    data-testid="plugin-info__screenshot"
+                  />
+                  <div
+                    class="rounded-lg w-1/3 h-56 bg-theme-neutral-500"
+                    data-testid="plugin-info__screenshot"
+                  />
+                </div>
+              </div>
+              <div
+                class="swiper-slide"
+                style="height: 180px;"
+              >
+                <div
+                  class="mt-3 flex space-x-4 pb-10 mr-3"
+                >
+                  <div
+                    class="rounded-lg w-1/3 h-56 bg-theme-neutral-500"
+                    data-testid="plugin-info__screenshot"
+                  />
+                  <div
+                    class="rounded-lg w-1/3 h-56 bg-theme-neutral-500"
+                    data-testid="plugin-info__screenshot"
+                  />
+                  <div
+                    class="rounded-lg w-1/3 h-56 bg-theme-neutral-500"
+                    data-testid="plugin-info__screenshot"
+                  />
+                </div>
+              </div>
+            </div>
+            <div
+              class="swiper-pagination"
+            />
+            <span
+              aria-atomic="true"
+              aria-live="assertive"
+              class="swiper-notification"
+            />
+          </div>
+        </div>
+      </div>
+      <div
+        class="pb-10"
+      >
+        <div
+          class="flex rounded-lg overflow-hidden bg-theme-warning"
+        >
+          <div
+            class="sc-AxiKw cPQbnD flex items-center justify-center text-theme-warning bg-theme-warning-200"
+          >
+            <div
+              class="sc-AxjAm bIZXgI"
+              height="30"
+              width="30"
+            >
+              <svg>
+                alert-default.svg
+              </svg>
+            </div>
+          </div>
+          <div
+            class="sc-AxirZ evPsEn flex-1 bg-theme-warning-100"
+          >
+            <p
+              class="text-xl font-bold text-theme-warning"
+              data-testid="alert__title"
+            >
+              Disclaimer
+            </p>
+            The availability of this plugin in the ARK Desktop Wallet does not mean that either ARK.io or ARK SCIC is directly involved in the development or affiliated with the developer providing this plugin. By installing it on your wallet, you assume every responsibility
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/src/domains/plugins/components/PluginInfo/__snapshots__/PluginInfo.spec.tsx.snap
+++ b/src/domains/plugins/components/PluginInfo/__snapshots__/PluginInfo.spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`PluginInfo should render properly 1`] = `
 <DocumentFragment>
   <div
-    class="mt-5 p-10 bg-theme-background"
+    class="p-10 mt-5 bg-theme-background"
   >
     <div>
       <p
@@ -34,7 +34,7 @@ exports[`PluginInfo should render properly 1`] = `
       </p>
     </div>
     <div
-      class="mt-10 relative"
+      class="relative mt-10"
     >
       <p
         class="font-bold"
@@ -42,7 +42,7 @@ exports[`PluginInfo should render properly 1`] = `
         Screenshots
       </p>
       <div
-        class="absolute top-0 right-0 pr-4 flex space-x-3 screenshots-pagination swiper-pagination-clickable swiper-pagination-bullets"
+        class="absolute top-0 right-0 flex pr-4 space-x-3 screenshots-pagination swiper-pagination-clickable swiper-pagination-bullets"
         data-testid="plugin-info__screenshots--pagination"
       />
       <div
@@ -64,18 +64,18 @@ exports[`PluginInfo should render properly 1`] = `
                 style="height: 180px;"
               >
                 <div
-                  class="mt-3 flex space-x-4 pb-10 mr-3"
+                  class="flex pb-10 mt-3 mr-3 space-x-4"
                 >
                   <div
-                    class="rounded-lg w-1/3 h-56 bg-theme-neutral-500"
+                    class="w-1/3 h-56 rounded-lg bg-theme-neutral-500"
                     data-testid="plugin-info__screenshot"
                   />
                   <div
-                    class="rounded-lg w-1/3 h-56 bg-theme-neutral-500"
+                    class="w-1/3 h-56 rounded-lg bg-theme-neutral-500"
                     data-testid="plugin-info__screenshot"
                   />
                   <div
-                    class="rounded-lg w-1/3 h-56 bg-theme-neutral-500"
+                    class="w-1/3 h-56 rounded-lg bg-theme-neutral-500"
                     data-testid="plugin-info__screenshot"
                   />
                 </div>
@@ -85,18 +85,18 @@ exports[`PluginInfo should render properly 1`] = `
                 style="height: 180px;"
               >
                 <div
-                  class="mt-3 flex space-x-4 pb-10 mr-3"
+                  class="flex pb-10 mt-3 mr-3 space-x-4"
                 >
                   <div
-                    class="rounded-lg w-1/3 h-56 bg-theme-neutral-500"
+                    class="w-1/3 h-56 rounded-lg bg-theme-neutral-500"
                     data-testid="plugin-info__screenshot"
                   />
                   <div
-                    class="rounded-lg w-1/3 h-56 bg-theme-neutral-500"
+                    class="w-1/3 h-56 rounded-lg bg-theme-neutral-500"
                     data-testid="plugin-info__screenshot"
                   />
                   <div
-                    class="rounded-lg w-1/3 h-56 bg-theme-neutral-500"
+                    class="w-1/3 h-56 rounded-lg bg-theme-neutral-500"
                     data-testid="plugin-info__screenshot"
                   />
                 </div>
@@ -106,18 +106,18 @@ exports[`PluginInfo should render properly 1`] = `
                 style="height: 180px;"
               >
                 <div
-                  class="mt-3 flex space-x-4 pb-10 mr-3"
+                  class="flex pb-10 mt-3 mr-3 space-x-4"
                 >
                   <div
-                    class="rounded-lg w-1/3 h-56 bg-theme-neutral-500"
+                    class="w-1/3 h-56 rounded-lg bg-theme-neutral-500"
                     data-testid="plugin-info__screenshot"
                   />
                   <div
-                    class="rounded-lg w-1/3 h-56 bg-theme-neutral-500"
+                    class="w-1/3 h-56 rounded-lg bg-theme-neutral-500"
                     data-testid="plugin-info__screenshot"
                   />
                   <div
-                    class="rounded-lg w-1/3 h-56 bg-theme-neutral-500"
+                    class="w-1/3 h-56 rounded-lg bg-theme-neutral-500"
                     data-testid="plugin-info__screenshot"
                   />
                 </div>

--- a/src/domains/plugins/components/PluginInfo/index.ts
+++ b/src/domains/plugins/components/PluginInfo/index.ts
@@ -1,0 +1,1 @@
+export * from "./PluginInfo";


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
- Adds plugin info section to be used in the plugin details page

_Quick note:_ screenshots will be handled differently depending on the received data, the idea is to load images in the place of the current gray box placeholder

## UI Preview
![Screen Shot 2020-06-23 at 09 26 50](https://user-images.githubusercontent.com/6919712/85403620-1563a480-b534-11ea-9885-9fb6bbc0668d.png)

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
