### PR TITLE
fix: add minimum colored bg width to `InputRange`

### DIFF
--- a/src/app/components/Input/InputRange.tsx
+++ b/src/app/components/Input/InputRange.tsx
@@ -25,12 +25,14 @@ export const InputRange = React.forwardRef<HTMLInputElement, Props>(
 			setValues([amount.toNumber()]);
 		};
 
+		const trackBackgroundMinValue = Math.max(values[0], 3);
+
 		return (
 			<InputGroup>
 				<InputCurrency
 					style={{
 						background: getTrackBackground({
-							values,
+							values: [trackBackgroundMinValue],
 							colors: ["rgba(var(--theme-color-primary-rgb), 0.1)", "transparent"],
 							min,
 							max,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Fix background width of `InputRange` when value is zero. 
Should still show a minimum background color when zero.
![2020-06-23-195906_354x115_scrot](https://user-images.githubusercontent.com/22020168/85432959-61423800-b58c-11ea-9b23-a78683c0f2e4.png)

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
