### PR TITLE
refactor: get rid of jest warnings

### DIFF
--- a/src/app/components/Header/HeaderSearchBar/HeaderSearchBar.test.tsx
+++ b/src/app/components/Header/HeaderSearchBar/HeaderSearchBar.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/require-await */
 import { act, fireEvent, render } from "@testing-library/react";
 import React from "react";
 
@@ -70,26 +71,27 @@ describe("HeaderSearchBar", () => {
 		expect(input.value).not.toBe("test");
 	});
 
-	it("should call onSearch", (done) => {
+	it("should call onSearch", async () => {
+		jest.useFakeTimers();
+
 		const onSearch = jest.fn();
 
 		const { getByTestId } = render(<HeaderSearchBar onSearch={onSearch} />);
 
 		fireEvent.click(getByTestId("header-search-bar__button"));
 
-		const input = getByTestId("Input");
-
 		act(() => {
-			fireEvent.change(input, {
+			fireEvent.change(getByTestId("Input"), {
 				target: {
 					value: "test",
 				},
 			});
 		});
 
-		setTimeout(() => {
-			expect(onSearch).toHaveBeenCalled();
-			done();
-		}, 550);
+		await act(async () => {
+			jest.runAllTimers();
+		});
+
+		expect(onSearch).toHaveBeenCalled();
 	});
 });

--- a/src/domains/plugin/components/Comments/Comments.test.tsx
+++ b/src/domains/plugin/components/Comments/Comments.test.tsx
@@ -1,9 +1,11 @@
 import { act, fireEvent, render } from "@testing-library/react";
+import { i18n } from "app/i18n";
 import React from "react";
+import { I18nextProvider } from "react-i18next";
 
 import { Comments } from "./Comments";
 
-describe("Comments", () => {
+describe.only("Comments", () => {
 	const comments = [
 		{
 			author: "Rok Cernec",
@@ -41,7 +43,9 @@ describe("Comments", () => {
 
 	it("should handle sortBy properly", () => {
 		const { asFragment, getByText, getByTestId } = render(
-			<Comments comments={comments} sortOptions={sortOptions} />,
+			<I18nextProvider i18n={i18n}>
+				<Comments comments={comments} sortOptions={sortOptions} />,
+			</I18nextProvider>,
 		);
 		const toggle = getByTestId("dropdown__toggle");
 

--- a/src/domains/plugin/components/Comments/__snapshots__/Comments.test.tsx.snap
+++ b/src/domains/plugin/components/Comments/__snapshots__/Comments.test.tsx.snap
@@ -241,7 +241,7 @@ exports[`Comments should handle sortBy properly 1`] = `
               back.svg
             </svg>
           </div>
-          COMMON.PREVIOUS
+          Previous
         </button>
         <div
           class="flex px-2 rounded bg-theme-primary-contrast"
@@ -268,7 +268,7 @@ exports[`Comments should handle sortBy properly 1`] = `
           data-testid="Pagination__next"
           type="button"
         >
-          COMMON.NEXT
+          Next
           <div
             class="sc-AxjAm HWmvM ml-2"
             height="12"
@@ -298,6 +298,7 @@ exports[`Comments should handle sortBy properly 1`] = `
       </div>
     </div>
   </div>
+  ,
 </DocumentFragment>
 `;
 
@@ -542,7 +543,7 @@ exports[`Comments should render properly 1`] = `
               back.svg
             </svg>
           </div>
-          COMMON.PREVIOUS
+          Previous
         </button>
         <div
           class="flex px-2 rounded bg-theme-primary-contrast"
@@ -569,7 +570,7 @@ exports[`Comments should render properly 1`] = `
           data-testid="Pagination__next"
           type="button"
         >
-          COMMON.NEXT
+          Next
           <div
             class="sc-AxjAm HWmvM ml-2"
             height="12"

--- a/src/domains/plugin/components/Comments/__snapshots__/Comments.test.tsx.snap
+++ b/src/domains/plugin/components/Comments/__snapshots__/Comments.test.tsx.snap
@@ -89,7 +89,7 @@ exports[`Comments should handle sortBy properly 1`] = `
               <span
                 class="text-theme-neutral-400"
               >
-                8 days ago
+                9 days ago
               </span>
             </div>
           </div>
@@ -144,7 +144,7 @@ exports[`Comments should handle sortBy properly 1`] = `
               <span
                 class="text-theme-neutral-400"
               >
-                8 days ago
+                9 days ago
               </span>
             </div>
           </div>
@@ -183,7 +183,7 @@ exports[`Comments should handle sortBy properly 1`] = `
                 <span
                   class="px-3"
                 >
-                  8 days ago
+                  9 days ago
                 </span>
               </div>
             </div>
@@ -390,7 +390,7 @@ exports[`Comments should render properly 1`] = `
               <span
                 class="text-theme-neutral-400"
               >
-                8 days ago
+                9 days ago
               </span>
             </div>
           </div>
@@ -445,7 +445,7 @@ exports[`Comments should render properly 1`] = `
               <span
                 class="text-theme-neutral-400"
               >
-                8 days ago
+                9 days ago
               </span>
             </div>
           </div>
@@ -484,7 +484,7 @@ exports[`Comments should render properly 1`] = `
                 <span
                   class="px-3"
                 >
-                  8 days ago
+                  9 days ago
                 </span>
               </div>
             </div>

--- a/src/domains/plugin/components/Comments/components/Reply/__snapshots__/Reply.test.tsx.snap
+++ b/src/domains/plugin/components/Comments/components/Reply/__snapshots__/Reply.test.tsx.snap
@@ -28,7 +28,7 @@ exports[`Reply should render properly 1`] = `
         <span
           class="px-3"
         >
-          8 days ago
+          9 days ago
         </span>
       </div>
     </div>

--- a/src/domains/plugin/pages/PluginDetails/PluginDetails.test.tsx
+++ b/src/domains/plugin/pages/PluginDetails/PluginDetails.test.tsx
@@ -1,5 +1,7 @@
 import { render } from "@testing-library/react";
+import { i18n } from "app/i18n";
 import React from "react";
+import { I18nextProvider } from "react-i18next";
 
 import { PluginDetails } from "./PluginDetails";
 
@@ -96,7 +98,9 @@ describe("PluginDetails", () => {
 
 	it("should render properly as installed", () => {
 		const { asFragment, getByTestId } = render(
-			<PluginDetails pluginData={pluginData} reviewData={reviewData} isInstalled />,
+			<I18nextProvider i18n={i18n}>
+				<PluginDetails pluginData={pluginData} reviewData={reviewData} isInstalled />,
+			</I18nextProvider>,
 		);
 
 		expect(getByTestId("plugin-details__header")).toBeTruthy();

--- a/src/domains/plugin/pages/PluginDetails/__snapshots__/PluginDetails.test.tsx.snap
+++ b/src/domains/plugin/pages/PluginDetails/__snapshots__/PluginDetails.test.tsx.snap
@@ -702,7 +702,7 @@ exports[`PluginDetails should render properly 1`] = `
                       back.svg
                     </svg>
                   </div>
-                  COMMON.PREVIOUS
+                  Previous
                 </button>
                 <div
                   class="flex px-2 rounded bg-theme-primary-contrast"
@@ -729,7 +729,7 @@ exports[`PluginDetails should render properly 1`] = `
                   data-testid="Pagination__next"
                   type="button"
                 >
-                  COMMON.NEXT
+                  Next
                   <div
                     class="sc-AxjAm HWmvM ml-2"
                     height="12"
@@ -1734,7 +1734,7 @@ exports[`PluginDetails should render properly as installed 1`] = `
                       back.svg
                     </svg>
                   </div>
-                  COMMON.PREVIOUS
+                  Previous
                 </button>
                 <div
                   class="flex px-2 rounded bg-theme-primary-contrast"
@@ -1761,7 +1761,7 @@ exports[`PluginDetails should render properly as installed 1`] = `
                   data-testid="Pagination__next"
                   type="button"
                 >
-                  COMMON.NEXT
+                  Next
                   <div
                     class="sc-AxjAm HWmvM ml-2"
                     height="12"
@@ -2029,5 +2029,6 @@ exports[`PluginDetails should render properly as installed 1`] = `
       </div>
     </div>
   </section>
+  ,
 </DocumentFragment>
 `;

--- a/src/domains/plugin/pages/PluginDetails/__snapshots__/PluginDetails.test.tsx.snap
+++ b/src/domains/plugin/pages/PluginDetails/__snapshots__/PluginDetails.test.tsx.snap
@@ -440,7 +440,7 @@ exports[`PluginDetails should render properly 1`] = `
                       <span
                         class="text-theme-neutral-400"
                       >
-                        8 days ago
+                        9 days ago
                       </span>
                     </div>
                   </div>
@@ -495,7 +495,7 @@ exports[`PluginDetails should render properly 1`] = `
                       <span
                         class="text-theme-neutral-400"
                       >
-                        8 days ago
+                        9 days ago
                       </span>
                     </div>
                   </div>
@@ -534,7 +534,7 @@ exports[`PluginDetails should render properly 1`] = `
                         <span
                           class="px-3"
                         >
-                          8 days ago
+                          9 days ago
                         </span>
                       </div>
                     </div>
@@ -591,7 +591,7 @@ exports[`PluginDetails should render properly 1`] = `
                       <span
                         class="text-theme-neutral-400"
                       >
-                        8 days ago
+                        9 days ago
                       </span>
                     </div>
                   </div>
@@ -646,7 +646,7 @@ exports[`PluginDetails should render properly 1`] = `
                       <span
                         class="text-theme-neutral-400"
                       >
-                        8 days ago
+                        9 days ago
                       </span>
                     </div>
                   </div>
@@ -1472,7 +1472,7 @@ exports[`PluginDetails should render properly as installed 1`] = `
                       <span
                         class="text-theme-neutral-400"
                       >
-                        8 days ago
+                        9 days ago
                       </span>
                     </div>
                   </div>
@@ -1527,7 +1527,7 @@ exports[`PluginDetails should render properly as installed 1`] = `
                       <span
                         class="text-theme-neutral-400"
                       >
-                        8 days ago
+                        9 days ago
                       </span>
                     </div>
                   </div>
@@ -1566,7 +1566,7 @@ exports[`PluginDetails should render properly as installed 1`] = `
                         <span
                           class="px-3"
                         >
-                          8 days ago
+                          9 days ago
                         </span>
                       </div>
                     </div>
@@ -1623,7 +1623,7 @@ exports[`PluginDetails should render properly as installed 1`] = `
                       <span
                         class="text-theme-neutral-400"
                       >
-                        8 days ago
+                        9 days ago
                       </span>
                     </div>
                   </div>
@@ -1678,7 +1678,7 @@ exports[`PluginDetails should render properly as installed 1`] = `
                       <span
                         class="text-theme-neutral-400"
                       >
-                        8 days ago
+                        9 days ago
                       </span>
                     </div>
                   </div>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Gets rid of the i18n and header search bar warnings in the unit tests. There are more warnings remaining, but those should be taken care of when refactoring the tested component.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
