### PR TITLE
refactor: add form events on `SelectDropdown`

### DIFF
--- a/src/app/components/SelectDropdown/SelectDropdown.stories.tsx
+++ b/src/app/components/SelectDropdown/SelectDropdown.stories.tsx
@@ -28,6 +28,7 @@ export const Simple = () => {
 		<div className="">
 			<div className="mt-10 w-128">
 				<SelectDropdown
+					selected={{ label: "Option 1", value: "3" }}
 					option={(option: any) => {
 						return (
 							<div className="p-2 border-b border-theme-neutral-200 hover:bg-theme-neutral-100">
@@ -50,6 +51,7 @@ export const Simple = () => {
 						);
 					}}
 					options={options}
+					onChange={console.log}
 				/>
 			</div>
 		</div>

--- a/src/app/components/SelectDropdown/SelectDropdown.test.tsx
+++ b/src/app/components/SelectDropdown/SelectDropdown.test.tsx
@@ -24,6 +24,38 @@ describe("SelectDropdown", () => {
 		expect(container).toMatchSnapshot();
 	});
 
+	it("should render with initial value", () => {
+		const options = [
+			{
+				label: "Option 1",
+				value: "1",
+			},
+			{
+				label: "Option 2",
+				value: "2",
+			},
+			{
+				label: "Option 3",
+				value: "3",
+			},
+		];
+		const { container } = render(
+			<SelectDropdown
+				option={(option: any) => <div>{option.label}</div>}
+				toggle={() => {
+					return (
+						<div className="flex items-center flex-inline">
+							<div className="font-semibold text-theme-neutral-800">Select Option</div>
+						</div>
+					);
+				}}
+				selected={{ label: "Option 1", value: "1" }}
+				options={options}
+			/>,
+		);
+		expect(container).toMatchSnapshot();
+	});
+
 	it("should render with custom toggle and option templates", () => {
 		const options = [
 			{
@@ -129,6 +161,73 @@ describe("SelectDropdown", () => {
 		act(() => {
 			fireEvent.click(firstOption);
 		});
+	});
+
+	it("should call on change callback if provided", () => {
+		const fn = jest.fn();
+		const options = [{ label: "Option 1", value: "1" }];
+		const { getByTestId } = render(
+			<SelectDropdown
+				option={(option: any) => <div>{option.label}</div>}
+				toggle={() => {
+					return (
+						<div className="flex items-center flex-inline">
+							<div className="font-semibold text-theme-neutral-800">Select Option</div>
+						</div>
+					);
+				}}
+				options={options}
+				onChange={fn}
+			/>,
+		);
+		const toggle = getByTestId("select-dropdown__toggle");
+
+		act(() => {
+			fireEvent.click(toggle);
+		});
+
+		expect(getByTestId("select-dropdown__content")).toBeTruthy();
+
+		const firstOption = getByTestId("select-dropdown__option-0");
+
+		act(() => {
+			fireEvent.click(firstOption);
+		});
+
+		expect(fn).toHaveBeenCalled();
+	});
+
+	it("should ignore on change callback if not provided", () => {
+		const fn = jest.fn();
+		const options = [{ label: "Option 1", value: "1" }];
+		const { getByTestId } = render(
+			<SelectDropdown
+				option={(option: any) => <div>{option.label}</div>}
+				toggle={() => {
+					return (
+						<div className="flex items-center flex-inline">
+							<div className="font-semibold text-theme-neutral-800">Select Option</div>
+						</div>
+					);
+				}}
+				options={options}
+			/>,
+		);
+		const toggle = getByTestId("select-dropdown__toggle");
+
+		act(() => {
+			fireEvent.click(toggle);
+		});
+
+		expect(getByTestId("select-dropdown__content")).toBeTruthy();
+
+		const firstOption = getByTestId("select-dropdown__option-0");
+
+		act(() => {
+			fireEvent.click(firstOption);
+		});
+
+		expect(fn).not.toHaveBeenCalled();
 	});
 
 	it("should render without option content", () => {

--- a/src/app/components/SelectDropdown/SelectDropdown.tsx
+++ b/src/app/components/SelectDropdown/SelectDropdown.tsx
@@ -12,9 +12,11 @@ type Props = {
 	option?: any;
 	toggle?: any;
 	className?: string;
+	selected?: any;
+	onChange?: (selected: any) => void;
 };
 
-export const SelectDropdown = ({ className, toggle, options, option }: Props) => {
+export const SelectDropdown = ({ className, toggle, options, option, selected, onChange }: Props) => {
 	const renderOption = (rowData: any) => {
 		if (typeof option === "function") return option(rowData);
 	};
@@ -23,8 +25,12 @@ export const SelectDropdown = ({ className, toggle, options, option }: Props) =>
 		if (typeof toggle === "function") return toggle(selected, isOpen);
 	};
 
+	const onSelect = (selectedItem: any) => {
+		if (typeof onChange === "function") return onChange(selectedItem);
+	};
+
 	return (
-		<Downshift itemToString={(i) => i?.value}>
+		<Downshift itemToString={(i) => i?.value} onChange={onSelect} initialSelectedItem={selected}>
 			{({ getLabelProps, getInputProps, getItemProps, isOpen, toggleMenu, selectedItem }) => (
 				<div className={`relative ${className}`}>
 					<label {...getLabelProps({ htmlFor: "dropdown-select" })}>

--- a/src/app/components/SelectDropdown/__snapshots__/SelectDropdown.test.tsx.snap
+++ b/src/app/components/SelectDropdown/__snapshots__/SelectDropdown.test.tsx.snap
@@ -5,13 +5,13 @@ exports[`SelectDropdown should close if clicked outside 1`] = `
   <div
     aria-expanded="false"
     aria-haspopup="listbox"
-    aria-labelledby="downshift-2-label"
+    aria-labelledby="downshift-3-label"
     class="relative undefined"
     role="combobox"
   >
     <label
       for="dropdown-select"
-      id="downshift-2-label"
+      id="downshift-3-label"
     >
       <div
         class="relative flex items-center w-full flex-inline"
@@ -53,9 +53,9 @@ exports[`SelectDropdown should close if clicked outside 1`] = `
     >
       <input
         aria-autocomplete="list"
-        aria-labelledby="downshift-2-label"
+        aria-labelledby="downshift-3-label"
         autocomplete="off"
-        id="downshift-2-input"
+        id="downshift-3-input"
         readonly=""
         type="hidden"
         value=""
@@ -143,6 +143,80 @@ exports[`SelectDropdown should render with custom toggle and option templates 1`
   <div
     aria-expanded="false"
     aria-haspopup="listbox"
+    aria-labelledby="downshift-2-label"
+    class="relative undefined"
+    role="combobox"
+  >
+    <label
+      for="dropdown-select"
+      id="downshift-2-label"
+    >
+      <div
+        class="relative flex items-center w-full flex-inline"
+      >
+        <div
+          class="flex w-full px-4 py-3 pr-12 overflow-hidden border rounded cursor-pointer m-h-20 shadow-sm bg-theme-background border-theme-neutral-300 text-theme-neutral-900 transition-colors duration-200 hover:outline-none hover:border-theme-primary"
+        >
+          <div
+            class="flex items-center flex-inline"
+          >
+            <div
+              class="font-semibold text-theme-neutral-800"
+            >
+              Select Option
+            </div>
+          </div>
+        </div>
+        <div
+          class="w-12 px-4 py-4 -ml-12 text-lg pointer-events-none text-theme-neutral-dark"
+        >
+          <div
+            class=""
+          >
+            <div
+              class="sc-AxjAm cpczEI"
+              height="1em"
+              width="1em"
+            >
+              <svg>
+                chevron-down.svg
+              </svg>
+            </div>
+          </div>
+        </div>
+      </div>
+    </label>
+    <div
+      class="relative btn-group"
+    >
+      <input
+        aria-autocomplete="list"
+        aria-labelledby="downshift-2-label"
+        autocomplete="off"
+        id="downshift-2-input"
+        readonly=""
+        type="hidden"
+        value=""
+      />
+      <button
+        aria-expanded="false"
+        aria-haspopup="true"
+        class="hidden dropdown-toggle"
+        data-testid="select-dropdown__toggle"
+        data-toggle="dropdown"
+        id="dropdown-select"
+        type="button"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`SelectDropdown should render with initial value 1`] = `
+<div>
+  <div
+    aria-expanded="false"
+    aria-haspopup="listbox"
     aria-labelledby="downshift-1-label"
     class="relative undefined"
     role="combobox"
@@ -196,7 +270,7 @@ exports[`SelectDropdown should render with custom toggle and option templates 1`
         id="downshift-1-input"
         readonly=""
         type="hidden"
-        value=""
+        value="1"
       />
       <button
         aria-expanded="false"
@@ -217,13 +291,13 @@ exports[`SelectDropdown should render without option content 1`] = `
   <div
     aria-expanded="false"
     aria-haspopup="listbox"
-    aria-labelledby="downshift-4-label"
+    aria-labelledby="downshift-7-label"
     class="relative undefined"
     role="combobox"
   >
     <label
       for="dropdown-select"
-      id="downshift-4-label"
+      id="downshift-7-label"
     >
       <div
         class="relative flex items-center w-full flex-inline"
@@ -265,9 +339,9 @@ exports[`SelectDropdown should render without option content 1`] = `
     >
       <input
         aria-autocomplete="list"
-        aria-labelledby="downshift-4-label"
+        aria-labelledby="downshift-7-label"
         autocomplete="off"
-        id="downshift-4-input"
+        id="downshift-7-input"
         readonly=""
         type="hidden"
         value=""


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
* Add initial selected value on `SelectDropdown`
* Add `onChange` event

Usage:

```jsx
const options = [
	{
		label: "Option 1",
		value: "1",
	},
	{
		label: "Option 2",
		value: "2",
	},
	{
		label: "Option 3",
		value: "3",
	},
];
const { container } = render(
	<SelectDropdown
		option={(option: any) => <div>{option.label}</div>}
		toggle={() => {
			return (
				<div className="flex items-center flex-inline">Select</div>
			);
		}}
		selected={{ label: "Option 1", value: "1" }}
		options={options}
                onChange={(selectedItem) => console.log(selectedItem)}
	/>,
);

```
<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
