### PR TITLE
test: mock date globally

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,9 @@
+import MockDate from "mockdate";
+
+beforeEach(() => {
+	MockDate.set(new Date("2020-07-01T00:00:00.000Z"));
+});
+
+afterEach(() => {
+	MockDate.reset();
+});

--- a/package.json
+++ b/package.json
@@ -272,6 +272,9 @@
 		}
 	},
 	"jest": {
+		"setupFilesAfterEnv": [
+			"<rootDir>/jest.setup.js"
+		],
 		"automock": false,
 		"collectCoverageFrom": [
 			"src/**/*.{js,jsx,ts,tsx}",

--- a/src/domains/plugin/components/Comments/Comments.test.tsx
+++ b/src/domains/plugin/components/Comments/Comments.test.tsx
@@ -1,14 +1,9 @@
 import { act, fireEvent, render } from "@testing-library/react";
 import { i18n } from "app/i18n";
-import MockDate from "mockdate";
 import React from "react";
 import { I18nextProvider } from "react-i18next";
 
 import { Comments } from "./Comments";
-
-beforeEach(() => MockDate.set(new Date("2020-06-22T14:48:00.000Z")));
-
-afterEach(() => MockDate.reset());
 
 describe("Comments", () => {
 	const comments = [

--- a/src/domains/plugin/components/Comments/__snapshots__/Comments.test.tsx.snap
+++ b/src/domains/plugin/components/Comments/__snapshots__/Comments.test.tsx.snap
@@ -89,7 +89,7 @@ exports[`Comments should handle sortBy properly 1`] = `
               <span
                 class="text-theme-neutral-400"
               >
-                3 days ago
+                11 days ago
               </span>
             </div>
           </div>
@@ -144,7 +144,7 @@ exports[`Comments should handle sortBy properly 1`] = `
               <span
                 class="text-theme-neutral-400"
               >
-                3 days ago
+                11 days ago
               </span>
             </div>
           </div>
@@ -183,7 +183,7 @@ exports[`Comments should handle sortBy properly 1`] = `
                 <span
                   class="px-3"
                 >
-                  3 days ago
+                  11 days ago
                 </span>
               </div>
             </div>
@@ -391,7 +391,7 @@ exports[`Comments should render properly 1`] = `
               <span
                 class="text-theme-neutral-400"
               >
-                3 days ago
+                11 days ago
               </span>
             </div>
           </div>
@@ -446,7 +446,7 @@ exports[`Comments should render properly 1`] = `
               <span
                 class="text-theme-neutral-400"
               >
-                3 days ago
+                11 days ago
               </span>
             </div>
           </div>
@@ -485,7 +485,7 @@ exports[`Comments should render properly 1`] = `
                 <span
                   class="px-3"
                 >
-                  3 days ago
+                  11 days ago
                 </span>
               </div>
             </div>

--- a/src/domains/plugin/components/Comments/components/Reply/Reply.test.tsx
+++ b/src/domains/plugin/components/Comments/components/Reply/Reply.test.tsx
@@ -1,15 +1,7 @@
 import { render } from "@testing-library/react";
-import MockDate from "mockdate";
 import React from "react";
-jest.mock("moment", () => {
-	return () => jest.requireActual("moment")("2020-06-19T14:48:00.000Z");
-});
 
 import { Reply } from "./Reply";
-
-beforeEach(() => MockDate.set(new Date("2020-06-22T14:48:00.000Z")));
-
-afterEach(() => MockDate.reset());
 
 describe("Reply", () => {
 	it("should render properly", () => {

--- a/src/domains/plugin/components/Comments/components/Reply/__snapshots__/Reply.test.tsx.snap
+++ b/src/domains/plugin/components/Comments/components/Reply/__snapshots__/Reply.test.tsx.snap
@@ -28,7 +28,7 @@ exports[`Reply should render properly 1`] = `
         <span
           class="px-3"
         >
-          3 days ago
+          11 days ago
         </span>
       </div>
     </div>

--- a/src/domains/plugin/components/Comments/utils.test.ts
+++ b/src/domains/plugin/components/Comments/utils.test.ts
@@ -2,8 +2,8 @@ import { getDateDifferenceFromNow } from "./utils";
 
 describe("getDateDifferenceFromNow", () => {
 	it("should return string with days ago from now", () => {
-		const targetDate = "2020-06-22T14:48:00.000Z";
+		const targetDate = "2020-07-01T00:00:00.000Z";
 
-		expect(getDateDifferenceFromNow(targetDate)).toEqual("8 days ago");
+		expect(getDateDifferenceFromNow(targetDate)).toEqual("0 day ago");
 	});
 });

--- a/src/domains/plugin/components/Comments/utils.test.ts
+++ b/src/domains/plugin/components/Comments/utils.test.ts
@@ -1,15 +1,9 @@
-import MockDate from "mockdate";
-
 import { getDateDifferenceFromNow } from "./utils";
-
-beforeEach(() => MockDate.set(new Date("2020-06-22T14:48:00.000Z")));
-
-afterEach(() => MockDate.reset());
 
 describe("getDateDifferenceFromNow", () => {
 	it("should return string with days ago from now", () => {
 		const targetDate = "2020-06-22T14:48:00.000Z";
 
-		expect(getDateDifferenceFromNow(targetDate)).toEqual("0 day ago");
+		expect(getDateDifferenceFromNow(targetDate)).toEqual("8 days ago");
 	});
 });

--- a/src/domains/plugin/components/Comments/utils.ts
+++ b/src/domains/plugin/components/Comments/utils.ts
@@ -5,7 +5,7 @@ export const getDateDifferenceFromNow = (targetDate: string): string => {
 	const dateToCompare = DateTime.make(targetDate);
 	const dateDifference = currentDateObj.diffInDays(dateToCompare);
 
-	const dateComplement = dateDifference > 1 ? "days" : "day";
+	const dateComplement = dateDifference !== 1 ? "days" : "day";
 
 	return `${dateDifference} ${dateComplement} ago`;
 };

--- a/src/domains/plugin/components/Comments/utils.ts
+++ b/src/domains/plugin/components/Comments/utils.ts
@@ -5,7 +5,7 @@ export const getDateDifferenceFromNow = (targetDate: string): string => {
 	const dateToCompare = DateTime.make(targetDate);
 	const dateDifference = currentDateObj.diffInDays(dateToCompare);
 
-	const dateComplement = dateDifference !== 1 ? "days" : "day";
+	const dateComplement = dateDifference > 1 ? "days" : "day";
 
 	return `${dateDifference} ${dateComplement} ago`;
 };

--- a/src/domains/plugin/pages/PluginDetails/PluginDetails.test.tsx
+++ b/src/domains/plugin/pages/PluginDetails/PluginDetails.test.tsx
@@ -1,6 +1,5 @@
 import { render } from "@testing-library/react";
 import { i18n } from "app/i18n";
-import MockDate from "mockdate";
 import React from "react";
 import { I18nextProvider } from "react-i18next";
 
@@ -9,10 +8,6 @@ jest.mock("moment", () => {
 });
 
 import { PluginDetails } from "./PluginDetails";
-
-beforeEach(() => MockDate.set(new Date("2020-06-22T14:48:00.000Z")));
-
-afterEach(() => MockDate.reset());
 
 describe("PluginDetails", () => {
 	const ratings = [

--- a/src/domains/plugin/pages/PluginDetails/__snapshots__/PluginDetails.test.tsx.snap
+++ b/src/domains/plugin/pages/PluginDetails/__snapshots__/PluginDetails.test.tsx.snap
@@ -440,7 +440,7 @@ exports[`PluginDetails should render properly 1`] = `
                       <span
                         class="text-theme-neutral-400"
                       >
-                        3 days ago
+                        11 days ago
                       </span>
                     </div>
                   </div>
@@ -495,7 +495,7 @@ exports[`PluginDetails should render properly 1`] = `
                       <span
                         class="text-theme-neutral-400"
                       >
-                        3 days ago
+                        11 days ago
                       </span>
                     </div>
                   </div>
@@ -534,7 +534,7 @@ exports[`PluginDetails should render properly 1`] = `
                         <span
                           class="px-3"
                         >
-                          3 days ago
+                          11 days ago
                         </span>
                       </div>
                     </div>
@@ -591,7 +591,7 @@ exports[`PluginDetails should render properly 1`] = `
                       <span
                         class="text-theme-neutral-400"
                       >
-                        3 days ago
+                        11 days ago
                       </span>
                     </div>
                   </div>
@@ -646,7 +646,7 @@ exports[`PluginDetails should render properly 1`] = `
                       <span
                         class="text-theme-neutral-400"
                       >
-                        3 days ago
+                        11 days ago
                       </span>
                     </div>
                   </div>
@@ -1472,7 +1472,7 @@ exports[`PluginDetails should render properly as installed 1`] = `
                       <span
                         class="text-theme-neutral-400"
                       >
-                        3 days ago
+                        11 days ago
                       </span>
                     </div>
                   </div>
@@ -1527,7 +1527,7 @@ exports[`PluginDetails should render properly as installed 1`] = `
                       <span
                         class="text-theme-neutral-400"
                       >
-                        3 days ago
+                        11 days ago
                       </span>
                     </div>
                   </div>
@@ -1566,7 +1566,7 @@ exports[`PluginDetails should render properly as installed 1`] = `
                         <span
                           class="px-3"
                         >
-                          3 days ago
+                          11 days ago
                         </span>
                       </div>
                     </div>
@@ -1623,7 +1623,7 @@ exports[`PluginDetails should render properly as installed 1`] = `
                       <span
                         class="text-theme-neutral-400"
                       >
-                        3 days ago
+                        11 days ago
                       </span>
                     </div>
                   </div>
@@ -1678,7 +1678,7 @@ exports[`PluginDetails should render properly as installed 1`] = `
                       <span
                         class="text-theme-neutral-400"
                       >
-                        3 days ago
+                        11 days ago
                       </span>
                     </div>
                   </div>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Adds a jest setup to set a mockdate before each test. The mocked date has been arbitrarily set to `2020-07-01T00:00:00.000Z`.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
