### PR TITLE
feat: add demo environment

### DIFF
--- a/cypress/integration/startup.spec.js
+++ b/cypress/integration/startup.spec.js
@@ -3,8 +3,8 @@ describe("Startup application", () => {
 		cy.visit("/");
 
 		cy.get("h1").should("have.text", "Welcome to ARK");
-		cy.get("img").should("have.length", 1);
-		cy.get("svg").should("have.length", 2);
+		cy.get("img").should("have.length", 2);
+		cy.get("svg").should("have.length", 3);
 		cy.get("button").should("have.length", 2);
 	});
 });

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
 		"test": "react-app-rewired test",
 		"test:coverage": "react-app-rewired test --coverage --watchAll=false",
 		"test:e2e": "cypress run --headless",
-		"test:e2e:ci": "yarn start & wait-on http-get://localhost:3000/ && yarn test:e2e",
+		"test:e2e:ci": "REACT_APP_BUILD_MODE=demo yarn start & wait-on http-get://localhost:3000/ && yarn test:e2e",
 		"cy:run": "cypress run",
 		"cy:open": "cypress open",
 		"cy:install": "cypress install --force",

--- a/src/__snapshots__/index.test.ts.snap
+++ b/src/__snapshots__/index.test.ts.snap
@@ -5,7 +5,7 @@ exports[`Application root should render without crashing 1`] = `
   "calls": Array [
     Array [
       <HashRouter>
-        <withRouter() />
+        <withRouter(App) />
       </HashRouter>,
       <div
         id="root"

--- a/src/__snapshots__/index.test.ts.snap
+++ b/src/__snapshots__/index.test.ts.snap
@@ -5,7 +5,7 @@ exports[`Application root should render without crashing 1`] = `
   "calls": Array [
     Array [
       <HashRouter>
-        <withRouter(App) />
+        <withRouter() />
       </HashRouter>,
       <div
         id="root"

--- a/src/app/contexts/Environment.tsx
+++ b/src/app/contexts/Environment.tsx
@@ -18,4 +18,6 @@ const EnvironmentProvider = ({ children }: Props) => {
 	return <EnvironmentContext.Provider value={{ env }}>{children}</EnvironmentContext.Provider>;
 };
 
-export { EnvironmentContext, EnvironmentProvider };
+const EnvironmentConsumer = EnvironmentContext.Consumer;
+
+export { EnvironmentContext, EnvironmentProvider, EnvironmentConsumer };

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -1,5 +1,7 @@
-// React
+// Platform SDK
 import { ARK } from "@arkecosystem/platform-sdk-ark";
+import { Environment } from "@arkecosystem/platform-sdk-profiles";
+// React
 import React from "react";
 import { I18nextProvider } from "react-i18next";
 import { renderRoutes } from "react-router-config";
@@ -16,9 +18,9 @@ import { EnvironmentConsumer, EnvironmentProvider } from "./contexts";
 // i18n
 import { i18n } from "./i18n";
 
-const routesWithoutNavBar = ["/", "/profile/create"];
+const routesWithoutNavBar = ["/", "s/create"];
 
-const buildMockEnvironment = async (env: any) => {
+const buildMockEnvironment = async (env: Environment) => {
 	const profile = env.profiles().create("Anne Doe");
 	await profile.wallets().import(identity.mnemonic, ARK, "devnet");
 
@@ -32,7 +34,6 @@ export const App = withRouter(({ location }: any) => (
 				<EnvironmentConsumer>
 					{({ env }: any) => {
 						if (process.env.REACT_APP_BUILD_MODE === "demo") buildMockEnvironment(env);
-						console.log({ route: location.pathname });
 
 						return (
 							<>

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -1,4 +1,5 @@
 // React
+import { ARK } from "@arkecosystem/platform-sdk-ark";
 import React from "react";
 import { I18nextProvider } from "react-i18next";
 import { renderRoutes } from "react-router-config";
@@ -6,22 +7,43 @@ import { withRouter } from "react-router-dom";
 
 // Routes
 import { routes } from "../router";
+// Fixtures
+import { identity } from "../tests/fixtures/identity";
+// UI Elements
 import { NavigationBar } from "./components/NavigationBar";
 // Context
-import { EnvironmentProvider } from "./contexts";
+import { EnvironmentConsumer, EnvironmentProvider } from "./contexts";
 // i18n
 import { i18n } from "./i18n";
 
 const routesWithoutNavBar = ["/", "/profile/create"];
 
+const buildMockEnvironment = async (env: any) => {
+	const profile = env.profiles().create("Anne Doe");
+	await profile.wallets().import(identity.mnemonic, ARK, "devnet");
+
+	env.persist();
+};
+
 export const App = withRouter(({ location }: any) => (
 	<I18nextProvider i18n={i18n}>
 		<main className={process.env.NODE_ENV === "development" ? "debug-screens" : ""}>
 			<EnvironmentProvider>
-				{!routesWithoutNavBar.includes(location.pathname) && (
-					<NavigationBar currencyIcon="Ark" balance="34,253.75" userInitials="IO" />
-				)}
-				{renderRoutes(routes)}
+				<EnvironmentConsumer>
+					{({ env }: any) => {
+						if (process.env.REACT_APP_BUILD_MODE === "demo") buildMockEnvironment(env);
+						console.log({ route: location.pathname });
+
+						return (
+							<>
+								{!routesWithoutNavBar.includes(location.pathname) && (
+									<NavigationBar currencyIcon="Ark" balance="34,253.75" userInitials="IO" />
+								)}
+								{renderRoutes(routes)}
+							</>
+						);
+					}}
+				</EnvironmentConsumer>
 			</EnvironmentProvider>
 		</main>
 	</I18nextProvider>

--- a/src/domains/profile/pages/Welcome/Welcome.test.tsx
+++ b/src/domains/profile/pages/Welcome/Welcome.test.tsx
@@ -79,7 +79,7 @@ describe("Welcome", () => {
 
 		expect(container).toBeTruthy();
 		fireEvent.click(getByText("caio"));
-		expect(history.location.pathname).toEqual(`/profiles/dashboard/${createdProfile.id()}`);
+		expect(history.location.pathname).toEqual(`/portfolio/${createdProfile.id()}`);
 		expect(asFragment()).toMatchSnapshot();
 	});
 });

--- a/src/domains/profile/pages/Welcome/Welcome.test.tsx
+++ b/src/domains/profile/pages/Welcome/Welcome.test.tsx
@@ -54,15 +54,16 @@ describe("Welcome", () => {
 		expect(container).toBeTruthy();
 		expect(asFragment()).toMatchSnapshot();
 		fireEvent.click(getByText("Create Profile"));
-		expect(history.location.pathname).toEqual("/profile/create");
+		expect(history.location.pathname).toEqual("/profiles/create");
 	});
 
 	it("should render with profiles", async () => {
 		const env: Environment = new Environment({ coins: { ARK }, httpClient, storage: "indexeddb" });
 
 		env.profiles().create("caio");
+		const createdProfile = env.profiles().all()[0];
 
-		const { container, asFragment } = render(
+		const { container, getByText, asFragment } = render(
 			<Router history={history}>
 				<EnvironmentContext.Provider value={{ env }}>
 					<Welcome />
@@ -77,6 +78,8 @@ describe("Welcome", () => {
 		});
 
 		expect(container).toBeTruthy();
+		fireEvent.click(getByText("caio"));
+		expect(history.location.pathname).toEqual(`/profiles/dashboard/${createdProfile.id()}`);
 		expect(asFragment()).toMatchSnapshot();
 	});
 });

--- a/src/domains/profile/pages/Welcome/Welcome.tsx
+++ b/src/domains/profile/pages/Welcome/Welcome.tsx
@@ -25,8 +25,6 @@ export const Welcome = () => {
 		setProfiles(env.profiles().all());
 	}, [env]);
 
-	console.log({ profiles });
-
 	return (
 		<div className="w-full h-full">
 			<div className="px-4 sm:px-6 lg:px-8">
@@ -76,7 +74,7 @@ export const Welcome = () => {
 						<Button
 							variant="plain"
 							className="w-full mt-2 md:mt-0"
-							onClick={() => history.push("/profile/create")}
+							onClick={() => history.push("/profiles/create")}
 						>
 							Create Profile
 						</Button>

--- a/src/domains/profile/pages/Welcome/Welcome.tsx
+++ b/src/domains/profile/pages/Welcome/Welcome.tsx
@@ -25,6 +25,8 @@ export const Welcome = () => {
 		setProfiles(env.profiles().all());
 	}, [env]);
 
+	console.log({ profiles });
+
 	return (
 		<div className="w-full h-full">
 			<div className="px-4 sm:px-6 lg:px-8">
@@ -52,7 +54,7 @@ export const Welcome = () => {
 							<div className="mt-6 mb-8 space-y-3">
 								{profiles.map((profile: any, index: number) => (
 									<ProfileCard
-										handleClick={history.push(`dashboard/${profile.id()}`)}
+										handleClick={() => history.push(`dashboard/${profile.id()}`)}
 										key={index}
 										profile={profile}
 										actions={profileCardActions}

--- a/src/domains/profile/pages/Welcome/Welcome.tsx
+++ b/src/domains/profile/pages/Welcome/Welcome.tsx
@@ -52,7 +52,7 @@ export const Welcome = () => {
 							<div className="mt-6 mb-8 space-y-3">
 								{profiles.map((profile: any, index: number) => (
 									<ProfileCard
-										handleClick={() => history.push(`dashboard/${profile.id()}`)}
+										handleClick={() => history.push(`/portfolio/${profile.id()}`)}
 										key={index}
 										profile={profile}
 										actions={profileCardActions}

--- a/src/domains/profile/routing.ts
+++ b/src/domains/profile/routing.ts
@@ -7,7 +7,7 @@ export const ProfileRoutes = [
 		component: Welcome,
 	},
 	{
-		path: "/profile/create",
+		path: "/profiles/create",
 		exact: true,
 		component: CreateProfile,
 	},

--- a/src/tests/fixtures/identity.ts
+++ b/src/tests/fixtures/identity.ts
@@ -1,0 +1,7 @@
+export const identity = {
+	privateKey: "d8839c2432bfd0a67ef10a804ba991eabba19f154a3d707917681d45822a5712",
+	publicKey: "034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed192",
+	address: "D61mfSggzbvQgTUe6JhYKH2doHaqJ3Dyib",
+	wif: "SGq4xLgZKCGxs7bjmwnBrWcT4C1ADFEermj846KC97FSv1WFD1dA",
+	mnemonic: "this is a top secret passphrase",
+};


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

- Adds an extra step for when the app detects an env var called `REACT_APP_BUILD_MODE` equal to `demo` firing a demo bootstrap adding only a profile.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
