### PR TITLE
refactor: add renderWithRouter helper method

### DIFF
--- a/src/app/components/Breadcrumbs/Breadcrumbs.test.tsx
+++ b/src/app/components/Breadcrumbs/Breadcrumbs.test.tsx
@@ -1,11 +1,16 @@
 import React from "react";
+import { MemoryRouter as Router } from "react-router-dom";
 import { render } from "testing-library";
 
 import { Breadcrumbs } from "./Breadcrumbs";
 
 describe("Breadcrumbs", () => {
 	it("should not render without crumbs", () => {
-		const { asFragment, getByTestId } = render(<Breadcrumbs crumbs={[]} />);
+		const { asFragment, getByTestId } = render(
+			<Router>
+				<Breadcrumbs crumbs={[]} />
+			</Router>,
+		);
 
 		expect(() => getByTestId("breadcrumbs__wrapper")).toThrow(/Unable to find an element by/);
 		expect(asFragment()).toMatchSnapshot();
@@ -13,7 +18,9 @@ describe("Breadcrumbs", () => {
 
 	it("should render", () => {
 		const { asFragment, getByTestId } = render(
-			<Breadcrumbs crumbs={[{ route: "dashboard", label: "Dashboard" }]} />,
+			<Router>
+				<Breadcrumbs crumbs={[{ route: "dashboard", label: "Dashboard" }]} />
+			</Router>,
 		);
 
 		expect(getByTestId("breadcrumbs__wrapper")).toHaveTextContent("arrow-back.svg");
@@ -23,13 +30,15 @@ describe("Breadcrumbs", () => {
 
 	it("should render with custom classes", () => {
 		const { asFragment, getByTestId } = render(
-			<Breadcrumbs
-				crumbs={[
-					{ route: "wallets", label: "Wallets" },
-					{ route: "wallets/my_wallet", label: "My Wallet" },
-				]}
-				className="class-name"
-			/>,
+			<Router>
+				<Breadcrumbs
+					crumbs={[
+						{ route: "wallets", label: "Wallets" },
+						{ route: "wallets/my_wallet", label: "My Wallet" },
+					]}
+					className="class-name"
+				/>
+			</Router>,
 		);
 
 		expect(getByTestId("breadcrumbs__wrapper")).toHaveClass("class-name");

--- a/src/app/components/Breadcrumbs/Breadcrumbs.test.tsx
+++ b/src/app/components/Breadcrumbs/Breadcrumbs.test.tsx
@@ -1,26 +1,19 @@
 import React from "react";
-import { MemoryRouter as Router } from "react-router-dom";
-import { render } from "testing-library";
+import { renderWithRouter } from "testing-library";
 
 import { Breadcrumbs } from "./Breadcrumbs";
 
 describe("Breadcrumbs", () => {
 	it("should not render without crumbs", () => {
-		const { asFragment, getByTestId } = render(
-			<Router>
-				<Breadcrumbs crumbs={[]} />
-			</Router>,
-		);
+		const { asFragment, getByTestId } = renderWithRouter(<Breadcrumbs crumbs={[]} />);
 
 		expect(() => getByTestId("breadcrumbs__wrapper")).toThrow(/Unable to find an element by/);
 		expect(asFragment()).toMatchSnapshot();
 	});
 
 	it("should render", () => {
-		const { asFragment, getByTestId } = render(
-			<Router>
-				<Breadcrumbs crumbs={[{ route: "dashboard", label: "Dashboard" }]} />
-			</Router>,
+		const { asFragment, getByTestId } = renderWithRouter(
+			<Breadcrumbs crumbs={[{ route: "dashboard", label: "Dashboard" }]} />,
 		);
 
 		expect(getByTestId("breadcrumbs__wrapper")).toHaveTextContent("arrow-back.svg");
@@ -29,16 +22,14 @@ describe("Breadcrumbs", () => {
 	});
 
 	it("should render with custom classes", () => {
-		const { asFragment, getByTestId } = render(
-			<Router>
-				<Breadcrumbs
-					crumbs={[
-						{ route: "wallets", label: "Wallets" },
-						{ route: "wallets/my_wallet", label: "My Wallet" },
-					]}
-					className="class-name"
-				/>
-			</Router>,
+		const { asFragment, getByTestId } = renderWithRouter(
+			<Breadcrumbs
+				crumbs={[
+					{ route: "wallets", label: "Wallets" },
+					{ route: "wallets/my_wallet", label: "My Wallet" },
+				]}
+				className="class-name"
+			/>,
 		);
 
 		expect(getByTestId("breadcrumbs__wrapper")).toHaveClass("class-name");

--- a/src/app/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/app/components/Breadcrumbs/Breadcrumbs.tsx
@@ -1,7 +1,7 @@
 import { Divider } from "app/components/Divider";
 import { Icon } from "app/components/Icon";
 import React from "react";
-import { BrowserRouter as Router, NavLink } from "react-router-dom";
+import { NavLink } from "react-router-dom";
 
 type Crumb = {
 	route: string;
@@ -19,32 +19,30 @@ export const Breadcrumbs = ({ crumbs, className }: BreadcrumbsProps) => {
 	};
 
 	return crumbs.length ? (
-		<Router>
-			<div
-				data-testid="breadcrumbs__wrapper"
-				className={`flex items-center space-x-2 ${className} ${
-					crumbs.length === 1 ? "text-theme-neutral-700" : "text-theme-neutral-500"
-				}`}
-			>
-				{crumbs.length && <Icon name="ArrowBack" width={19} height={10} />}
+		<div
+			data-testid="breadcrumbs__wrapper"
+			className={`flex items-center space-x-2 ${className} ${
+				crumbs.length === 1 ? "text-theme-neutral-700" : "text-theme-neutral-500"
+			}`}
+		>
+			{crumbs.length && <Icon name="ArrowBack" width={19} height={10} />}
 
-				{crumbs.map((crumb: Crumb, index: number) => {
-					return (
-						<div key={index} className="space-x-2">
-							<NavLink to={crumb.route} className={`${isLast(index) ? "text-theme-neutral-700" : ""}`}>
-								<span>{crumb.label}</span>
-							</NavLink>
+			{crumbs.map((crumb: Crumb, index: number) => {
+				return (
+					<div key={index} className="space-x-2">
+						<NavLink to={crumb.route} className={`${isLast(index) ? "text-theme-neutral-700" : ""}`}>
+							<span>{crumb.label}</span>
+						</NavLink>
 
-							{!isLast(index) && (
-								<span>
-									<Divider className="border-1 border-theme-neutral-500" type="vertical" />
-								</span>
-							)}
-						</div>
-					);
-				})}
-			</div>
-		</Router>
+						{!isLast(index) && (
+							<span>
+								<Divider className="border-1 border-theme-neutral-500" type="vertical" />
+							</span>
+						)}
+					</div>
+				);
+			})}
+		</div>
 	) : null;
 };
 

--- a/src/app/components/Link/Link.test.tsx
+++ b/src/app/components/Link/Link.test.tsx
@@ -1,27 +1,20 @@
-import { act, fireEvent, render } from "@testing-library/react";
 import React from "react";
-import { MemoryRouter } from "react-router-dom";
+import { act, fireEvent, renderWithRouter } from "testing-library";
 
 import { Link } from "./Link";
 
 describe("Link", () => {
 	it("should render", () => {
-		const { getByTestId, asFragment } = render(
-			<MemoryRouter>
-				<Link to="/test">Test</Link>
-			</MemoryRouter>,
-		);
+		const { getByTestId, asFragment } = renderWithRouter(<Link to="/test">Test</Link>);
 		expect(getByTestId("Link")).toHaveTextContent("Test");
 		expect(asFragment()).toMatchSnapshot();
 	});
 
 	it("should render external", () => {
-		const { getByTestId, asFragment } = render(
-			<MemoryRouter>
-				<Link to={{ pathname: "https://ark.io" }} isExternal>
-					ARK.io
-				</Link>
-			</MemoryRouter>,
+		const { getByTestId, asFragment } = renderWithRouter(
+			<Link to={{ pathname: "https://ark.io" }} isExternal>
+				ARK.io
+			</Link>,
 		);
 		expect(getByTestId("Link")).toHaveAttribute("rel", "noopener noreferrer");
 		expect(getByTestId("Link")).toHaveAttribute("target", "_blank");
@@ -30,22 +23,16 @@ describe("Link", () => {
 	});
 
 	it("should render external without children", () => {
-		const { getByTestId, asFragment } = render(
-			<MemoryRouter>
-				<Link to={{ pathname: "https://ark.io" }} isExternal />
-			</MemoryRouter>,
-		);
+		const { getByTestId, asFragment } = renderWithRouter(<Link to={{ pathname: "https://ark.io" }} isExternal />);
 		expect(getByTestId("Link__external")).toBeTruthy();
 		expect(asFragment()).toMatchSnapshot();
 	});
 
 	it("should render with tooltip", () => {
-		const { getByTestId, baseElement } = render(
-			<MemoryRouter>
-				<Link to="/test" tooltip="Custom Tooltip">
-					Test
-				</Link>
-			</MemoryRouter>,
+		const { getByTestId, baseElement } = renderWithRouter(
+			<Link to="/test" tooltip="Custom Tooltip">
+				Test
+			</Link>,
 		);
 
 		act(() => {

--- a/src/app/components/NavigationBar/NavigationBar.test.tsx
+++ b/src/app/components/NavigationBar/NavigationBar.test.tsx
@@ -1,17 +1,12 @@
 import React from "react";
 import { act } from "react-dom/test-utils";
-import { BrowserRouter as Router } from "react-router-dom";
-import { fireEvent, render } from "testing-library";
+import { fireEvent, renderWithRouter } from "testing-library";
 
 import { NavigationBar } from "./NavigationBar";
 
 describe("NavigationBar", () => {
 	it("should render", () => {
-		const { container, asFragment } = render(
-			<Router>
-				<NavigationBar />
-			</Router>,
-		);
+		const { container, asFragment } = renderWithRouter(<NavigationBar />);
 
 		expect(container).toBeTruthy();
 		expect(asFragment()).toMatchSnapshot();
@@ -28,11 +23,7 @@ describe("NavigationBar", () => {
 				path: "/test",
 			},
 		];
-		const { container, asFragment } = render(
-			<Router>
-				<NavigationBar menu={menu} />
-			</Router>,
-		);
+		const { container, asFragment } = renderWithRouter(<NavigationBar menu={menu} />);
 
 		expect(container).toBeTruthy();
 		expect(asFragment()).toMatchSnapshot();
@@ -43,11 +34,7 @@ describe("NavigationBar", () => {
 			{ label: "Option 1", value: "1" },
 			{ label: "Option 2", value: -"2" },
 		];
-		const { getByTestId, getByText } = render(
-			<Router>
-				<NavigationBar userActions={options} />
-			</Router>,
-		);
+		const { getByTestId, getByText } = renderWithRouter(<NavigationBar userActions={options} />);
 		const toggle = getByTestId("navbar__useractions");
 
 		act(() => {

--- a/src/app/components/SideBar/SideBar.test.tsx
+++ b/src/app/components/SideBar/SideBar.test.tsx
@@ -1,12 +1,11 @@
 import React from "react";
-import { MemoryRouter } from "react-router-dom";
-import { render } from "testing-library";
+import { renderWithRouter } from "testing-library";
 
 import { SideBar } from "./SideBar";
 
 describe("SideBar", () => {
 	it("should render empty", () => {
-		const { container, asFragment } = render(<SideBar />, { wrapper: MemoryRouter });
+		const { container, asFragment } = renderWithRouter(<SideBar />);
 
 		expect(container).toBeTruthy();
 		expect(asFragment()).toMatchSnapshot();
@@ -34,7 +33,7 @@ describe("SideBar", () => {
 			},
 		];
 
-		const { container, asFragment, getAllByRole } = render(<SideBar items={items} />, { wrapper: MemoryRouter });
+		const { container, asFragment, getAllByRole } = renderWithRouter(<SideBar items={items} />);
 
 		expect(container).toBeTruthy();
 		expect(getAllByRole("listitem").length).toEqual(3);

--- a/src/app/components/SideBar/SideBarItem/SideBarItem.test.tsx
+++ b/src/app/components/SideBar/SideBarItem/SideBarItem.test.tsx
@@ -1,6 +1,5 @@
 import React from "react";
-import { MemoryRouter } from "react-router-dom";
-import { act, fireEvent, render } from "testing-library";
+import { act, fireEvent, renderWithRouter } from "testing-library";
 
 import { SideBarItem } from "./SideBarItem";
 
@@ -14,14 +13,14 @@ describe("SideBarItem", () => {
 	};
 
 	it("should render", () => {
-		const { container, asFragment } = render(<SideBarItem {...item} />, { wrapper: MemoryRouter });
+		const { container, asFragment } = renderWithRouter(<SideBarItem {...item} />);
 
 		expect(container).toBeTruthy();
 		expect(asFragment()).toMatchSnapshot();
 	});
 
 	it("should render as active", () => {
-		const { container, asFragment } = render(<SideBarItem {...item} isActive={true} />, { wrapper: MemoryRouter });
+		const { container, asFragment } = renderWithRouter(<SideBarItem {...item} isActive={true} />);
 
 		expect(container).toBeTruthy();
 		expect(asFragment()).toMatchSnapshot();
@@ -30,9 +29,7 @@ describe("SideBarItem", () => {
 	it("should fire click event", () => {
 		const handleActiveItem = jest.fn();
 
-		const { getByTestId } = render(<SideBarItem {...item} handleActiveItem={handleActiveItem} />, {
-			wrapper: MemoryRouter,
-		});
+		const { getByTestId } = renderWithRouter(<SideBarItem {...item} handleActiveItem={handleActiveItem} />);
 		const menuItem = getByTestId("side-menu__item--plugin");
 
 		act(() => {

--- a/src/app/index.test.tsx
+++ b/src/app/index.test.tsx
@@ -1,18 +1,11 @@
-import { render, screen, waitFor } from "@testing-library/react";
-import { createMemoryHistory } from "history";
 import React from "react";
-import { Router } from "react-router-dom";
+import { renderWithRouter, screen, waitFor } from "testing-library";
 
 import { App } from "./";
 
 describe("App", () => {
-	const history = createMemoryHistory();
 	it("should render", async () => {
-		const { container, asFragment } = render(
-			<Router history={history}>
-				<App />
-			</Router>,
-		);
+		const { container, asFragment } = renderWithRouter(<App />);
 
 		await waitFor(async () => {
 			await expect(

--- a/src/domains/contact/pages/Contacts/Contacts.test.tsx
+++ b/src/domains/contact/pages/Contacts/Contacts.test.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/require-await */
 import React from "react";
-import { MemoryRouter as Router } from "react-router-dom";
-import { act, fireEvent, render, waitFor } from "testing-library";
+import { act, fireEvent, renderWithRouter, waitFor } from "testing-library";
 
 import { contacts } from "../../data";
 import { translations } from "../../i18n";
@@ -27,11 +26,7 @@ const assets = [
 
 describe("Contacts", () => {
 	it("should render", () => {
-		const { asFragment, getByTestId } = render(
-			<Router>
-				<Contacts contacts={[]} />
-			</Router>,
-		);
+		const { asFragment, getByTestId } = renderWithRouter(<Contacts contacts={[]} />);
 
 		expect(getByTestId("contacts")).toHaveTextContent(translations.CONTACTS_PAGE.TITLE);
 		expect(getByTestId("contacts")).toHaveTextContent(translations.CONTACTS_PAGE.SUBTITLE);
@@ -42,11 +37,7 @@ describe("Contacts", () => {
 	});
 
 	it("should render with contacts", () => {
-		const { asFragment, getByTestId } = render(
-			<Router>
-				<Contacts contacts={contacts} />
-			</Router>,
-		);
+		const { asFragment, getByTestId } = renderWithRouter(<Contacts contacts={contacts} />);
 
 		expect(getByTestId("contacts")).toHaveTextContent(translations.CONTACTS_PAGE.TITLE);
 		expect(getByTestId("contacts")).toHaveTextContent(translations.CONTACTS_PAGE.SUBTITLE);
@@ -61,10 +52,8 @@ describe("Contacts", () => {
 		["cancel", "contact-form__cancel-btn"],
 		["save", "contact-form__save-btn"],
 	])("should open & close add contact modal (%s)", async (buttonName, buttonId) => {
-		const { getAllByTestId, getByTestId, queryByTestId } = render(
-			<Router>
-				<Contacts contacts={[]} assets={assets} />
-			</Router>,
+		const { getAllByTestId, getByTestId, queryByTestId } = renderWithRouter(
+			<Contacts contacts={[]} assets={assets} />,
 		);
 
 		fireEvent.click(getByTestId("contacts__add-contact-btn"));

--- a/src/domains/contact/pages/Contacts/Contacts.test.tsx
+++ b/src/domains/contact/pages/Contacts/Contacts.test.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/require-await */
 import React from "react";
+import { MemoryRouter as Router } from "react-router-dom";
 import { act, fireEvent, render, waitFor } from "testing-library";
 
 import { contacts } from "../../data";
@@ -26,7 +27,11 @@ const assets = [
 
 describe("Contacts", () => {
 	it("should render", () => {
-		const { asFragment, getByTestId } = render(<Contacts contacts={[]} />);
+		const { asFragment, getByTestId } = render(
+			<Router>
+				<Contacts contacts={[]} />
+			</Router>,
+		);
 
 		expect(getByTestId("contacts")).toHaveTextContent(translations.CONTACTS_PAGE.TITLE);
 		expect(getByTestId("contacts")).toHaveTextContent(translations.CONTACTS_PAGE.SUBTITLE);
@@ -37,7 +42,11 @@ describe("Contacts", () => {
 	});
 
 	it("should render with contacts", () => {
-		const { asFragment, getByTestId } = render(<Contacts contacts={contacts} />);
+		const { asFragment, getByTestId } = render(
+			<Router>
+				<Contacts contacts={contacts} />
+			</Router>,
+		);
 
 		expect(getByTestId("contacts")).toHaveTextContent(translations.CONTACTS_PAGE.TITLE);
 		expect(getByTestId("contacts")).toHaveTextContent(translations.CONTACTS_PAGE.SUBTITLE);
@@ -52,7 +61,11 @@ describe("Contacts", () => {
 		["cancel", "contact-form__cancel-btn"],
 		["save", "contact-form__save-btn"],
 	])("should open & close add contact modal (%s)", async (buttonName, buttonId) => {
-		const { getAllByTestId, getByTestId, queryByTestId } = render(<Contacts contacts={[]} assets={assets} />);
+		const { getAllByTestId, getByTestId, queryByTestId } = render(
+			<Router>
+				<Contacts contacts={[]} assets={assets} />
+			</Router>,
+		);
 
 		fireEvent.click(getByTestId("contacts__add-contact-btn"));
 

--- a/src/domains/profile/pages/CreateProfile/CreateProfile.test.tsx
+++ b/src/domains/profile/pages/CreateProfile/CreateProfile.test.tsx
@@ -1,16 +1,13 @@
 import React from "react";
-import { MemoryRouter } from "react-router-dom";
-import { fireEvent, render } from "testing-library";
+import { fireEvent, renderWithRouter } from "testing-library";
 
 import { CreateProfile } from "./CreateProfile";
 
 describe("CreateProfile", () => {
 	it("should render", () => {
-		const { container, getByText, asFragment } = render(
-			<MemoryRouter initialEntries={["/", "profile/create"]}>
-				<CreateProfile />
-			</MemoryRouter>,
-		);
+		const { container, getByText, asFragment } = renderWithRouter(<CreateProfile />, {
+			routes: ["/", "/profile/create"],
+		});
 
 		expect(container).toBeTruthy();
 		fireEvent.click(getByText("Back"));

--- a/src/domains/profile/pages/MyRegistrations/components/HistoryModal/HistoryModal.test.tsx
+++ b/src/domains/profile/pages/MyRegistrations/components/HistoryModal/HistoryModal.test.tsx
@@ -1,6 +1,5 @@
 import React from "react";
-import { BrowserRouter as Router } from "react-router-dom";
-import { render } from "testing-library";
+import { renderWithRouter } from "testing-library";
 
 import { HistoryModal } from "./HistoryModal";
 
@@ -31,11 +30,7 @@ describe("HistoryModal", () => {
 	it("should render empty state", () => {
 		const handleClose = jest.fn();
 
-		const { asFragment } = render(
-			<Router>
-				<HistoryModal isOpen handleClose={() => handleClose()} />,
-			</Router>,
-		);
+		const { asFragment } = renderWithRouter(<HistoryModal isOpen handleClose={() => handleClose()} />);
 
 		expect(asFragment()).toMatchSnapshot();
 	});
@@ -43,10 +38,8 @@ describe("HistoryModal", () => {
 	it("should render properly", () => {
 		const handleClose = jest.fn();
 
-		const { asFragment } = render(
-			<Router>
-				<HistoryModal history={history} isOpen handleClose={() => handleClose()} />,
-			</Router>,
+		const { asFragment } = renderWithRouter(
+			<HistoryModal history={history} isOpen handleClose={() => handleClose()} />,
 		);
 
 		expect(asFragment()).toMatchSnapshot();

--- a/src/domains/profile/pages/MyRegistrations/components/HistoryModal/__snapshots__/HistoryModal.test.tsx.snap
+++ b/src/domains/profile/pages/MyRegistrations/components/HistoryModal/__snapshots__/HistoryModal.test.tsx.snap
@@ -206,7 +206,6 @@ exports[`HistoryModal should render empty state 1`] = `
       </div>
     </div>
   </div>
-  ,
 </DocumentFragment>
 `;
 
@@ -565,6 +564,5 @@ exports[`HistoryModal should render properly 1`] = `
       </div>
     </div>
   </div>
-  ,
 </DocumentFragment>
 `;

--- a/src/domains/profile/pages/MyRegistrations/components/RepositoryModal/RepositoryModal.test.tsx
+++ b/src/domains/profile/pages/MyRegistrations/components/RepositoryModal/RepositoryModal.test.tsx
@@ -1,6 +1,5 @@
 import React from "react";
-import { BrowserRouter as Router } from "react-router-dom";
-import { render } from "testing-library";
+import { renderWithRouter } from "testing-library";
 
 import { RepositoryModal } from "./RepositoryModal";
 
@@ -27,10 +26,8 @@ describe("RepositoryModal", () => {
 	it("should render empty state", () => {
 		const handleClose = jest.fn();
 
-		const { asFragment } = render(
-			<Router>
-				<RepositoryModal isOpen repositories={repositories} handleClose={() => handleClose()} />,
-			</Router>,
+		const { asFragment } = renderWithRouter(
+			<RepositoryModal isOpen repositories={repositories} handleClose={() => handleClose()} />,
 		);
 
 		expect(asFragment()).toMatchSnapshot();

--- a/src/domains/profile/pages/MyRegistrations/components/RepositoryModal/__snapshots__/RepositoryModal.test.tsx.snap
+++ b/src/domains/profile/pages/MyRegistrations/components/RepositoryModal/__snapshots__/RepositoryModal.test.tsx.snap
@@ -184,6 +184,5 @@ exports[`RepositoryModal should render empty state 1`] = `
       </div>
     </div>
   </div>
-  ,
 </DocumentFragment>
 `;

--- a/src/domains/profile/pages/MyRegistrations/components/RepositoryModal/components/RepositoryLink/RepositoryLink.test.tsx
+++ b/src/domains/profile/pages/MyRegistrations/components/RepositoryModal/components/RepositoryLink/RepositoryLink.test.tsx
@@ -1,15 +1,12 @@
 import React from "react";
-import { BrowserRouter as Router } from "react-router-dom";
-import { render } from "testing-library";
+import { renderWithRouter } from "testing-library";
 
 import { RepositoryLink } from "./RepositoryLink";
 
 describe("RepositoryLink", () => {
 	it("should render properly", () => {
-		const { container, asFragment, getByText } = render(
-			<Router>
-				<RepositoryLink provider="GitLab" url="http://github.com/robank" />,
-			</Router>,
+		const { container, asFragment, getByText } = renderWithRouter(
+			<RepositoryLink provider="GitLab" url="http://github.com/robank" />,
 		);
 
 		expect(asFragment()).toMatchSnapshot();

--- a/src/domains/profile/pages/MyRegistrations/components/RepositoryModal/components/RepositoryLink/__snapshots__/RepositoryLink.test.tsx.snap
+++ b/src/domains/profile/pages/MyRegistrations/components/RepositoryModal/components/RepositoryLink/__snapshots__/RepositoryLink.test.tsx.snap
@@ -36,6 +36,5 @@ exports[`RepositoryLink should render properly 1`] = `
       </a>
     </div>
   </div>
-  ,
 </DocumentFragment>
 `;

--- a/src/domains/profile/pages/Welcome/Welcome.test.tsx
+++ b/src/domains/profile/pages/Welcome/Welcome.test.tsx
@@ -4,24 +4,19 @@ import { Environment } from "@arkecosystem/platform-sdk-profiles";
 import { EnvironmentContext } from "app/contexts";
 // i18n
 import { httpClient } from "app/services";
-import { createMemoryHistory } from "history";
 import React from "react";
-import { Router } from "react-router-dom";
-import { fireEvent, render, screen, waitFor } from "testing-library";
+import { fireEvent, render, renderWithRouter, screen, waitFor } from "testing-library";
 
 import { Welcome } from "../Welcome";
 
 describe("Welcome", () => {
-	const history = createMemoryHistory();
 	it("should render", async () => {
 		const env: Environment = new Environment({ coins: { ARK }, httpClient, storage: "indexeddb" });
 
 		const { container, asFragment } = render(
-			<Router history={history}>
-				<EnvironmentContext.Provider value={{ env }}>
-					<Welcome />
-				</EnvironmentContext.Provider>
-			</Router>,
+			<EnvironmentContext.Provider value={{ env }}>
+				<Welcome />
+			</EnvironmentContext.Provider>,
 		);
 
 		await waitFor(async () => {
@@ -37,12 +32,10 @@ describe("Welcome", () => {
 	it("should change route to create profile", async () => {
 		const env: Environment = new Environment({ coins: { ARK }, httpClient, storage: "indexeddb" });
 
-		const { container, getByText, asFragment } = render(
-			<Router history={history}>
-				<EnvironmentContext.Provider value={{ env }}>
-					<Welcome />
-				</EnvironmentContext.Provider>
-			</Router>,
+		const { container, getByText, asFragment, history } = renderWithRouter(
+			<EnvironmentContext.Provider value={{ env }}>
+				<Welcome />
+			</EnvironmentContext.Provider>,
 		);
 
 		await waitFor(async () => {
@@ -63,12 +56,10 @@ describe("Welcome", () => {
 		env.profiles().create("caio");
 		const createdProfile = env.profiles().all()[0];
 
-		const { container, getByText, asFragment } = render(
-			<Router history={history}>
-				<EnvironmentContext.Provider value={{ env }}>
-					<Welcome />
-				</EnvironmentContext.Provider>
-			</Router>,
+		const { container, getByText, asFragment, history } = renderWithRouter(
+			<EnvironmentContext.Provider value={{ env }}>
+				<Welcome />
+			</EnvironmentContext.Provider>,
 		);
 
 		await waitFor(async () => {

--- a/src/domains/setting/pages/Settings/Settings.test.tsx
+++ b/src/domains/setting/pages/Settings/Settings.test.tsx
@@ -1,7 +1,6 @@
 import { translations as pluginTranslations } from "domains/plugin/i18n";
 import React from "react";
-import { MemoryRouter } from "react-router-dom";
-import { act, fireEvent, render } from "testing-library";
+import { act, fireEvent, renderWithRouter } from "testing-library";
 
 import { Settings } from "./Settings";
 
@@ -35,9 +34,8 @@ describe("Settings", () => {
 			},
 		};
 
-		const { container, asFragment } = render(
+		const { container, asFragment } = renderWithRouter(
 			<Settings settings={items} activeSettings={"General"} setActiveSettings={() => null} {...settingsProps} />,
-			{ wrapper: MemoryRouter },
 		);
 
 		expect(container).toBeTruthy();
@@ -73,9 +71,8 @@ describe("Settings", () => {
 			},
 		};
 
-		const { container, asFragment } = render(
+		const { container, asFragment } = renderWithRouter(
 			<Settings settings={items} activeSettings={"Peer"} setActiveSettings={() => null} {...settingsProps} />,
-			{ wrapper: MemoryRouter },
 		);
 
 		expect(container).toBeTruthy();
@@ -111,10 +108,8 @@ describe("Settings", () => {
 			},
 		};
 
-		const { container, asFragment } = render(
+		const { container, asFragment } = renderWithRouter(
 			<Settings settings={items} activeSettings={"Plugins"} setActiveSettings={() => null} {...settingsProps} />,
-
-			{ wrapper: MemoryRouter },
 		);
 
 		expect(container).toBeTruthy();
@@ -150,10 +145,8 @@ describe("Settings", () => {
 			},
 		};
 
-		const { container, asFragment, getByTestId, queryByText } = render(
+		const { container, asFragment, getByTestId, queryByText } = renderWithRouter(
 			<Settings settings={items} activeSettings={"Plugins"} setActiveSettings={() => null} {...settingsProps} />,
-
-			{ wrapper: MemoryRouter },
 		);
 
 		expect(container).toBeTruthy();
@@ -217,9 +210,8 @@ describe("Settings", () => {
 			},
 		};
 
-		const { container, asFragment } = render(
+		const { container, asFragment } = renderWithRouter(
 			<Settings settings={items} activeSettings={"Foo"} setActiveSettings={() => null} {...settingsProps} />,
-			{ wrapper: MemoryRouter },
 		);
 
 		expect(container).toBeTruthy();

--- a/src/domains/vote/pages/Votes/Votes.test.tsx
+++ b/src/domains/vote/pages/Votes/Votes.test.tsx
@@ -1,16 +1,13 @@
 import React from "react";
-import { BrowserRouter as Router } from "react-router-dom";
-import { act, fireEvent, render } from "testing-library";
+import { act, fireEvent, renderWithRouter } from "testing-library";
 
 import { addressListData, assets, delegateListData } from "../../data";
 import { Votes } from "./Votes";
 
 describe("Votes", () => {
 	it("should render", () => {
-		const { container, asFragment } = render(
-			<Router>
-				<Votes assets={assets} addressList={addressListData} delegateList={delegateListData} />,
-			</Router>,
+		const { container, asFragment } = renderWithRouter(
+			<Votes assets={assets} addressList={addressListData} delegateList={delegateListData} />,
 		);
 
 		expect(container).toBeTruthy();
@@ -18,10 +15,8 @@ describe("Votes", () => {
 	});
 
 	it("should select a cryptoasset", () => {
-		const { container, asFragment, getByTestId } = render(
-			<Router>
-				<Votes assets={assets} addressList={addressListData} delegateList={delegateListData} />,
-			</Router>,
+		const { container, asFragment, getByTestId } = renderWithRouter(
+			<Votes assets={assets} addressList={addressListData} delegateList={delegateListData} />,
 		);
 		const selectAssetInput = getByTestId("select-asset__input");
 
@@ -40,10 +35,8 @@ describe("Votes", () => {
 	});
 
 	it("should select address", () => {
-		const { asFragment, getByTestId, getAllByTestId } = render(
-			<Router>
-				<Votes assets={assets} addressList={addressListData} delegateList={delegateListData} />,
-			</Router>,
+		const { asFragment, getByTestId, getAllByTestId } = renderWithRouter(
+			<Votes assets={assets} addressList={addressListData} delegateList={delegateListData} />,
 		);
 		const selectAssetInput = getByTestId("select-asset__input");
 
@@ -68,10 +61,8 @@ describe("Votes", () => {
 	});
 
 	it("should select a delegate", () => {
-		const { asFragment, getByTestId, getAllByTestId } = render(
-			<Router>
-				<Votes assets={assets} addressList={addressListData} delegateList={delegateListData} />,
-			</Router>,
+		const { asFragment, getByTestId, getAllByTestId } = renderWithRouter(
+			<Votes assets={assets} addressList={addressListData} delegateList={delegateListData} />,
 		);
 		const selectAssetInput = getByTestId("select-asset__input");
 

--- a/src/domains/vote/pages/Votes/__snapshots__/Votes.test.tsx.snap
+++ b/src/domains/vote/pages/Votes/__snapshots__/Votes.test.tsx.snap
@@ -507,7 +507,6 @@ exports[`Votes should render 1`] = `
       </div>
     </div>
   </div>
-  ,
 </DocumentFragment>
 `;
 
@@ -1707,7 +1706,6 @@ exports[`Votes should select a cryptoasset 1`] = `
       </div>
     </div>
   </div>
-  ,
 </DocumentFragment>
 `;
 
@@ -3066,7 +3064,6 @@ exports[`Votes should select a delegate 1`] = `
       </div>
     </div>
   </div>
-  ,
 </DocumentFragment>
 `;
 
@@ -4342,6 +4339,5 @@ exports[`Votes should select address 1`] = `
       </div>
     </div>
   </div>
-  ,
 </DocumentFragment>
 `;

--- a/src/domains/wallet/pages/WalletDetails/WalletDetails.test.tsx
+++ b/src/domains/wallet/pages/WalletDetails/WalletDetails.test.tsx
@@ -1,6 +1,5 @@
 import React from "react";
-import { BrowserRouter as Router } from "react-router-dom";
-import { render } from "testing-library";
+import { renderWithRouter } from "testing-library";
 
 import { WalletDetails } from "./WalletDetails";
 
@@ -79,11 +78,7 @@ const wallets = [
 
 describe("WalletDetails", () => {
 	it("should render", () => {
-		const { asFragment } = render(
-			<Router>
-				<WalletDetails wallets={wallets} wallet={wallets[0]} />
-			</Router>,
-		);
+		const { asFragment } = renderWithRouter(<WalletDetails wallets={wallets} wallet={wallets[0]} />);
 		expect(asFragment()).toMatchSnapshot();
 	});
 });

--- a/src/utils/testing-library.tsx
+++ b/src/utils/testing-library.tsx
@@ -1,7 +1,9 @@
 import { render } from "@testing-library/react";
 import { i18n } from "app/i18n";
+import { createMemoryHistory } from "history";
 import React from "react";
 import { I18nextProvider } from "react-i18next";
+import { Router } from "react-router-dom";
 
 const WithProviders = ({ children }: { children: React.ReactNode }) => {
 	return <I18nextProvider i18n={i18n}>{children}</I18nextProvider>;
@@ -10,8 +12,20 @@ const WithProviders = ({ children }: { children: React.ReactNode }) => {
 const customRender = (component: React.ReactElement, options: any) =>
 	render(component, { wrapper: WithProviders, ...options });
 
-// re-export everything
+const renderWithRouter = (
+	component: React.ReactElement,
+	{ routes = ["/"], history = createMemoryHistory({ initialEntries: routes }) } = {},
+) => {
+	const RouterWrapper = ({ children }: { children: React.ReactNode }) => (
+		<Router history={history}>{children}</Router>
+	);
+
+	return {
+		...customRender(component, { wrapper: RouterWrapper }),
+		history,
+	};
+};
+
 export * from "@testing-library/react";
 
-// override render method
-export { customRender as render };
+export { customRender as render, renderWithRouter };


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Adds a helper method for tests that renders a component with a Router. Routes can be passed to the method and it will expose the history object.

```ts
import { renderWithRouter } from "testing-library";

const { history } = renderWithRouter(<MyComponent />, {
    routes: ["/", "/my/component/route"],
});
```
<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
