### PR TITLE
chore: fix card handleclick error on `Card`

### DIFF
--- a/src/app/components/Card/Card.tsx
+++ b/src/app/components/Card/Card.tsx
@@ -14,7 +14,7 @@ const Wrapper = styled.div`
 `;
 
 export const Card = ({ handleClick, children, className }: CardProps) => (
-	<Wrapper className={className} onClick={() => handleClick()}>
+	<Wrapper className={className} onClick={() => handleClick?.()}>
 		{children}
 	</Wrapper>
 );


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Fix `handleClick is not a function` error on click event in Card component when `handleClick` callback is not provided.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
