### PR TITLE
feat: add extra slot in `HeaderSearchBar`

### DIFF
--- a/src/app/components/Header/HeaderSearchBar/HeaderSearchBar.test.tsx
+++ b/src/app/components/Header/HeaderSearchBar/HeaderSearchBar.test.tsx
@@ -21,9 +21,7 @@ describe("HeaderSearchBar", () => {
 	});
 
 	it("should show extra slot", () => {
-		const { getByTestId } = render(
-			<HeaderSearchBar extra={<div data-testid="extra-slot" />} />,
-		);
+		const { getByTestId } = render(<HeaderSearchBar extra={<div data-testid="extra-slot" />} />);
 
 		fireEvent.click(getByTestId("header-search-bar__button"));
 

--- a/src/app/components/Header/HeaderSearchBar/HeaderSearchBar.test.tsx
+++ b/src/app/components/Header/HeaderSearchBar/HeaderSearchBar.test.tsx
@@ -20,6 +20,16 @@ describe("HeaderSearchBar", () => {
 		expect(getByTestId("header-search-bar__input")).toBeTruthy();
 	});
 
+	it("should show extra slot", () => {
+		const { getByTestId } = render(
+			<HeaderSearchBar extra={<div data-testid="extra-slot" />} />,
+		);
+
+		fireEvent.click(getByTestId("header-search-bar__button"));
+
+		expect(getByTestId("extra-slot")).toBeTruthy();
+	});
+
 	it("should show the with custom label slot", () => {
 		const { getByTestId } = render(
 			<HeaderSearchBar>

--- a/src/app/components/Header/HeaderSearchBar/HeaderSearchBar.tsx
+++ b/src/app/components/Header/HeaderSearchBar/HeaderSearchBar.tsx
@@ -9,13 +9,14 @@ type HeaderSearchBarProps = {
 	label?: string;
 	children?: React.ReactNode;
 	onSearch?: any;
+	extra?: React.ReactNode;
 };
 
 const SearchBarInputWrapper = styled.div`
 	min-width: 24rem;
 `;
 
-export const HeaderSearchBar = ({ placeholder, children, label, onSearch }: HeaderSearchBarProps) => {
+export const HeaderSearchBar = ({ placeholder, children, label, onSearch, extra }: HeaderSearchBarProps) => {
 	const [searchbarVisible, setSearchbarVisible] = useState(false);
 	const [query, setQuery] = useState("");
 
@@ -60,13 +61,20 @@ export const HeaderSearchBar = ({ placeholder, children, label, onSearch }: Head
 					ref={ref}
 					className="absolute flex items-center px-6 py-4 bg-white shadow-xl rounded-md -bottom-4 -right-6"
 				>
+					{extra && (
+						<div className="flex items-center">
+							<div className="ml-2">{extra}</div>
+							<div className="mx-8 h-10  border-l border-theme-neutral-200" />
+						</div>
+					)}
+
 					<button data-testid="header-search-bar__reset" onClick={resetQuery}>
 						<Icon className="text-theme-neutral-500" name="CrossSlim" width={12} height={12} />
 					</button>
 
-					<div className="flex-1 mx-4">
+					<div className="mx-4">
 						<Input
-							className="border-none shadow-none"
+							className="border-none shadow-none pt-2"
 							placeholder={placeholder}
 							value={query}
 							onChange={(e) => setQuery((e.target as HTMLInputElement).value)}

--- a/src/app/components/Header/HeaderSearchBar/HeaderSearchBar.tsx
+++ b/src/app/components/Header/HeaderSearchBar/HeaderSearchBar.tsx
@@ -64,7 +64,7 @@ export const HeaderSearchBar = ({ placeholder, children, label, onSearch, extra 
 					{extra && (
 						<div className="flex items-center">
 							<div className="ml-2">{extra}</div>
-							<div className="mx-8 h-10  border-l border-theme-neutral-200" />
+							<div className="h-10 mx-8 border-l  border-theme-neutral-200" />
 						</div>
 					)}
 
@@ -74,7 +74,7 @@ export const HeaderSearchBar = ({ placeholder, children, label, onSearch, extra 
 
 					<div className="mx-4">
 						<Input
-							className="border-none shadow-none pt-2"
+							className="pt-2 border-none shadow-none"
 							placeholder={placeholder}
 							value={query}
 							onChange={(e) => setQuery((e.target as HTMLInputElement).value)}

--- a/src/domains/plugin/pages/PluginManager/__snapshots__/PluginManager.test.tsx.snap
+++ b/src/domains/plugin/pages/PluginManager/__snapshots__/PluginManager.test.tsx.snap
@@ -26688,7 +26688,7 @@ exports[`PluginManager should search for plugin 1`] = `
                     class="mx-4"
                   >
                     <input
-                      class="sc-AxiKw cYyoys overflow-hidden w-full bg-theme-background appearance-none rounded border border-theme-neutral-300 text-theme-neutral-900 transition-colors duration-200 border-none shadow-none pt-2"
+                      class="sc-AxiKw cYyoys overflow-hidden w-full bg-theme-background appearance-none rounded border border-theme-neutral-300 text-theme-neutral-900 transition-colors duration-200 pt-2 border-none shadow-none"
                       data-testid="Input"
                       placeholder="Search..."
                       value="test"

--- a/src/domains/plugin/pages/PluginManager/__snapshots__/PluginManager.test.tsx.snap
+++ b/src/domains/plugin/pages/PluginManager/__snapshots__/PluginManager.test.tsx.snap
@@ -26685,10 +26685,10 @@ exports[`PluginManager should search for plugin 1`] = `
                     </div>
                   </button>
                   <div
-                    class="flex-1 mx-4"
+                    class="mx-4"
                   >
                     <input
-                      class="sc-AxiKw cYyoys overflow-hidden w-full bg-theme-background appearance-none rounded border border-theme-neutral-300 text-theme-neutral-900 transition-colors duration-200 border-none shadow-none"
+                      class="sc-AxiKw cYyoys overflow-hidden w-full bg-theme-background appearance-none rounded border border-theme-neutral-300 text-theme-neutral-900 transition-colors duration-200 border-none shadow-none pt-2"
                       data-testid="Input"
                       placeholder="Search..."
                       value="test"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Add support for extra slot to add additional menu items (e.g plugin filters):
Preview:
![2020-07-08-131801_475x124_scrot](https://user-images.githubusercontent.com/22020168/86907498-cf0a6a00-c11d-11ea-8b5d-b2f8b7554af2.png)


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
