### PR TITLE
chore: add `hideViewAll` props to `FilterNetwork` component

### DIFF
--- a/src/app/components/FilterNetwork/FilterNetwork.stories.tsx
+++ b/src/app/components/FilterNetwork/FilterNetwork.stories.tsx
@@ -1,9 +1,11 @@
+import { boolean, withKnobs } from "@storybook/addon-knobs";
 import React from "react";
 
 import { FilterNetwork } from "./FilterNetwork";
 
 export default {
 	title: "App / Components / FilterNetwork",
+	decorators: [withKnobs],
 };
 
 export const Default = () => {
@@ -21,9 +23,12 @@ export const Default = () => {
 			isSelected: false,
 		},
 	];
+
 	return (
-		<div>
-			<FilterNetwork networks={networks} onViewAll={() => alert("View all networks")} />
-		</div>
+		<FilterNetwork
+			networks={networks}
+			onViewAll={() => alert("View all networks")}
+			hideViewAll={boolean("Hide View All", false)}
+		/>
 	);
 };

--- a/src/app/components/FilterNetwork/FilterNetwork.test.tsx
+++ b/src/app/components/FilterNetwork/FilterNetwork.test.tsx
@@ -53,4 +53,9 @@ describe("FilterNetwork", () => {
 
 		expect(onChange).not.toHaveBeenCalled();
 	});
+
+	it("should hide view all", () => {
+		const { container } = render(<FilterNetwork networks={networks} hideViewAll />);
+		expect(container).toMatchSnapshot();
+	});
 });

--- a/src/app/components/FilterNetwork/FilterNetwork.tsx
+++ b/src/app/components/FilterNetwork/FilterNetwork.tsx
@@ -1,8 +1,7 @@
+import { Badge } from "app/components/Badge";
+import { Circle } from "app/components/Circle";
+import { Icon } from "app/components/Icon";
 import React, { useState } from "react";
-
-import { Badge } from "../Badge";
-import { Circle } from "../Circle";
-import { Icon } from "../Icon";
 
 type Network = {
 	name: string;
@@ -13,6 +12,7 @@ type NetworkProps = {
 	networks?: any;
 	onChange?: any;
 	onViewAll?: any;
+	hideViewAll?: boolean;
 };
 
 const renderNetworks = (networks: any[], onClick: any) => (
@@ -24,17 +24,15 @@ const renderNetworks = (networks: any[], onClick: any) => (
 				data-testid={`network__option--${key}`}
 				onClick={() => onClick(option, key)}
 			>
-				{!option.isSelected && (
-					<Circle size="lg" className="relative border-theme-neutral-200 text-theme-neutral-300">
-						<Icon name={option.name} width={20} height={20} />
-						<Badge className="border-theme-neutral-200" />
-					</Circle>
-				)}
-
-				{option.isSelected && (
+				{option.isSelected ? (
 					<Circle size="lg" className="relative border-theme-success-500 text-theme-success-500">
 						<Icon name={option.name} width={20} height={20} />
 						<Badge className="bg-theme-success-500 text-theme-success-contrast" icon="Checkmark" />
+					</Circle>
+				) : (
+					<Circle size="lg" className="relative border-theme-neutral-200 text-theme-neutral-300">
+						<Icon name={option.name} width={20} height={20} />
+						<Badge className="border-theme-neutral-200" />
 					</Circle>
 				)}
 			</li>
@@ -42,35 +40,41 @@ const renderNetworks = (networks: any[], onClick: any) => (
 	</ul>
 );
 
-export const FilterNetwork = ({ networks, onChange, onViewAll }: NetworkProps) => {
+export const FilterNetwork = ({ networks, onChange, onViewAll, hideViewAll }: NetworkProps) => {
 	const [networkList, setNetworkList] = useState(networks.concat());
 
 	const onClick = (network: Network, index: number) => {
-		network.isSelected = !network.isSelected;
-
 		const list = networkList.concat();
+
+		network.isSelected = !network.isSelected;
 		list.splice(index, 1, network);
 		setNetworkList(list);
-		if (typeof onChange === "function") onChange(network, list);
+
+		if (typeof onChange === "function") {
+			onChange(network, list);
+		}
 	};
 
 	return (
 		<div>
 			{renderNetworks(networkList, onClick)}
-			<Circle
-				size="lg"
-				data-testid="network__viewall"
-				className="relative cursor-pointer border-theme-primary-100"
-				onClick={onViewAll}
-			>
-				<div className="text-sm font-semibold text-theme-primary-500">All</div>
-				<Badge
-					className="border-theme-primary-100 text-theme-primary-500"
-					icon="ChevronDown"
-					iconWidth={10}
-					iconHeight={10}
-				/>
-			</Circle>
+
+			{!hideViewAll && (
+				<Circle
+					size="lg"
+					data-testid="network__viewall"
+					className="relative cursor-pointer border-theme-primary-100"
+					onClick={onViewAll}
+				>
+					<div className="text-sm font-semibold text-theme-primary-500">All</div>
+					<Badge
+						className="border-theme-primary-100 text-theme-primary-500"
+						icon="ChevronDown"
+						iconWidth={10}
+						iconHeight={10}
+					/>
+				</Circle>
+			)}
 		</div>
 	);
 };
@@ -78,4 +82,5 @@ export const FilterNetwork = ({ networks, onChange, onViewAll }: NetworkProps) =
 FilterNetwork.defaultProps = {
 	isSelected: false,
 	networks: [],
+	hideViewAll: false,
 };

--- a/src/app/components/FilterNetwork/__snapshots__/FilterNetwork.test.tsx.snap
+++ b/src/app/components/FilterNetwork/__snapshots__/FilterNetwork.test.tsx.snap
@@ -1,5 +1,95 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`FilterNetwork should hide view all 1`] = `
+<div>
+  <div>
+    <ul
+      class="inline-block"
+      data-testid="network__option"
+    >
+      <li
+        class="inline-block mr-5 cursor-pointer"
+        data-testid="network__option--0"
+      >
+        <div
+          class="sc-AxiKw jQtkkF relative border-theme-neutral-200 text-theme-neutral-300"
+        >
+          <div
+            class="sc-AxjAm buCJuk"
+            height="20"
+            width="20"
+          >
+            <svg>
+              ark.svg
+            </svg>
+          </div>
+          <span
+            class="sc-AxirZ bKxtun flex border-2 rounded-full justify-center w-5 h-5 items-center align-middle bg-theme-background border-transparent border-theme-neutral-200"
+          >
+            <span />
+          </span>
+        </div>
+      </li>
+      <li
+        class="inline-block mr-5 cursor-pointer"
+        data-testid="network__option--1"
+      >
+        <div
+          class="sc-AxiKw jQtkkF relative border-theme-success-500 text-theme-success-500"
+        >
+          <div
+            class="sc-AxjAm buCJuk"
+            height="20"
+            width="20"
+          >
+            <svg>
+              eth.svg
+            </svg>
+          </div>
+          <span
+            class="sc-AxirZ bKxtun flex border-2 rounded-full justify-center w-5 h-5 items-center align-middle bg-theme-background border-transparent bg-theme-success-500 text-theme-success-contrast"
+          >
+            <div
+              class="sc-AxjAm HWmvM"
+              height="12"
+              width="12"
+            >
+              <svg>
+                checkmark.svg
+              </svg>
+            </div>
+            <span />
+          </span>
+        </div>
+      </li>
+      <li
+        class="inline-block mr-5 cursor-pointer"
+        data-testid="network__option--2"
+      >
+        <div
+          class="sc-AxiKw jQtkkF relative border-theme-neutral-200 text-theme-neutral-300"
+        >
+          <div
+            class="sc-AxjAm buCJuk"
+            height="20"
+            width="20"
+          >
+            <svg>
+              btc.svg
+            </svg>
+          </div>
+          <span
+            class="sc-AxirZ bKxtun flex border-2 rounded-full justify-center w-5 h-5 items-center align-middle bg-theme-background border-transparent border-theme-neutral-200"
+          >
+            <span />
+          </span>
+        </div>
+      </li>
+    </ul>
+  </div>
+</div>
+`;
+
 exports[`FilterNetwork should render 1`] = `
 <div>
   <div>


### PR DESCRIPTION
## Summary

The News page uses this component without showing the "all" option. See the image below:

![Screenshot from 2020-07-08 17-07-13](https://user-images.githubusercontent.com/1894191/86965251-9e3a2d00-c13d-11ea-9c04-b0bc8eb7a33c.png)

## Checklist

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged
