### PR TITLE
refactor: fix paddings in plugin navigation

### DIFF
--- a/src/app/components/Breadcrumbs/__snapshots__/Breadcrumbs.test.tsx.snap
+++ b/src/app/components/Breadcrumbs/__snapshots__/Breadcrumbs.test.tsx.snap
@@ -61,7 +61,7 @@ exports[`Breadcrumbs should render with custom classes 1`] = `
       </a>
       <span>
         <div
-          class="sc-AxjAm jsQKzL border-1 border-theme-neutral-500"
+          class="sc-AxjAm gHUxAL border-1 border-theme-neutral-500"
           type="vertical"
         />
       </span>

--- a/src/app/components/Divider/Divider.styles.ts
+++ b/src/app/components/Divider/Divider.styles.ts
@@ -5,19 +5,9 @@ const baseStyle = [tw`border-t border-solid`];
 const getType = (type: string): any => {
 	switch (type) {
 		case "horizontal":
-			return [
-				tw`flex clear-both w-full min-w-full`,
-				css`
-					margin: 24px 0;
-				`,
-			];
+			return tw`flex clear-both w-full min-w-full my-6`;
 		case "vertical":
-			return [
-				tw`relative inline-block align-middle border-t-0 border-l border-solid`,
-				css`
-					margin: 0 8px;
-				`,
-			];
+			return tw`relative inline-block align-middle border-t-0 border-l border-solid mx-2`;
 	}
 };
 

--- a/src/app/components/Divider/__snapshots__/Divider.test.tsx.snap
+++ b/src/app/components/Divider/__snapshots__/Divider.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Divider should render 1`] = `
 <DocumentFragment>
   <div
-    class="sc-AxjAm eOYkvJ border-theme-neutral-300"
+    class="sc-AxjAm dnkyDE border-theme-neutral-300"
     type="horizontal"
   />
 </DocumentFragment>
@@ -12,7 +12,7 @@ exports[`Divider should render 1`] = `
 exports[`Divider should render a dashed 1`] = `
 <div>
   <div
-    class="sc-AxjAm hqlXXr border-theme-neutral-300"
+    class="sc-AxjAm iUsVaG border-theme-neutral-300"
     type="horizontal"
   />
 </div>
@@ -21,7 +21,7 @@ exports[`Divider should render a dashed 1`] = `
 exports[`Divider should render horizontal type 1`] = `
 <div>
   <div
-    class="sc-AxjAm eOYkvJ border-theme-neutral-300"
+    class="sc-AxjAm dnkyDE border-theme-neutral-300"
     type="horizontal"
   />
 </div>
@@ -30,7 +30,7 @@ exports[`Divider should render horizontal type 1`] = `
 exports[`Divider should render vertical type 1`] = `
 <div>
   <div
-    class="sc-AxjAm jsQKzL border-theme-neutral-300"
+    class="sc-AxjAm gHUxAL border-theme-neutral-300"
     type="vertical"
   />
 </div>
@@ -39,7 +39,7 @@ exports[`Divider should render vertical type 1`] = `
 exports[`Divider should render vertical type and large 1`] = `
 <div>
   <div
-    class="sc-AxjAm hlvmjM border-theme-neutral-300"
+    class="sc-AxjAm kDIOvA border-theme-neutral-300"
     type="vertical"
   />
 </div>
@@ -48,7 +48,7 @@ exports[`Divider should render vertical type and large 1`] = `
 exports[`Divider should render vertical type and small 1`] = `
 <div>
   <div
-    class="sc-AxjAm iCCswl border-theme-neutral-300"
+    class="sc-AxjAm cExLXd border-theme-neutral-300"
     type="vertical"
   />
 </div>

--- a/src/domains/news/components/NewsCard/__snapshots__/NewsCard.test.tsx.snap
+++ b/src/domains/news/components/NewsCard/__snapshots__/NewsCard.test.tsx.snap
@@ -46,7 +46,7 @@ exports[`NewsCard should render 1`] = `
                 Travis Walker, Co-Founder
               </p>
               <div
-                class="sc-AxhCb wsXLc border-theme-neutral-300"
+                class="sc-AxhCb hvZPgQ border-theme-neutral-300"
                 type="vertical"
               />
               <p
@@ -75,7 +75,7 @@ exports[`NewsCard should render 1`] = `
         </div>
       </div>
       <div
-        class="sc-AxhCb jCsMVC border-theme-neutral-300"
+        class="sc-AxhCb bmdmIf border-theme-neutral-300"
         type="horizontal"
       />
       <p
@@ -135,7 +135,7 @@ exports[`NewsCard should render with cover image 1`] = `
                 Travis Walker, Co-Founder
               </p>
               <div
-                class="sc-AxhCb wsXLc border-theme-neutral-300"
+                class="sc-AxhCb hvZPgQ border-theme-neutral-300"
                 type="vertical"
               />
               <p
@@ -164,7 +164,7 @@ exports[`NewsCard should render with cover image 1`] = `
         </div>
       </div>
       <div
-        class="sc-AxhCb jCsMVC border-theme-neutral-300"
+        class="sc-AxhCb bmdmIf border-theme-neutral-300"
         type="horizontal"
       />
       <p

--- a/src/domains/news/components/NewsOptions/__snapshots__/NewsOptions.test.tsx.snap
+++ b/src/domains/news/components/NewsOptions/__snapshots__/NewsOptions.test.tsx.snap
@@ -39,7 +39,7 @@ exports[`NewsOptions should render 1`] = `
         </div>
       </div>
       <div
-        class="sc-AxirZ bTLcec border-theme-neutral-300"
+        class="sc-AxirZ jJscrd border-theme-neutral-300"
         type="horizontal"
       />
       <div
@@ -139,7 +139,7 @@ exports[`NewsOptions should render 1`] = `
         </div>
       </div>
       <div
-        class="sc-AxirZ bTLcec border-theme-neutral-300"
+        class="sc-AxirZ jJscrd border-theme-neutral-300"
         type="horizontal"
       />
       <div

--- a/src/domains/plugin/components/PluginManagerNavigationBar/PluginManagerNavigationBar.tsx
+++ b/src/domains/plugin/components/PluginManagerNavigationBar/PluginManagerNavigationBar.tsx
@@ -33,12 +33,11 @@ export const PluginManagerNavigationBar = ({
 						{menu &&
 							menu.map((menuItem: any, index: number) => (
 								<li key={index} className="flex">
-									<a
-										href="/"
+									<button
 										data-testid={`PluginManagerNavigationBar__${menuItem.name}`}
 										onClick={() => onChange(menuItem.name)}
 										title={menuItem.title}
-										className={`PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer ${
+										className={`PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer ${
 											selected === menuItem.name ? "active" : ""
 										}`}
 									>
@@ -46,26 +45,31 @@ export const PluginManagerNavigationBar = ({
 										{menuItem.count && (
 											<span className="ml-1 text-theme-neutral-400">{menuItem.count}</span>
 										)}
-										<div className="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300" />
-									</a>
+									</button>
+
+									{index < menu.length - 1 && (
+										<div className="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300" />
+									)}
 								</li>
 							))}
 					</ul>
 				</div>
+
 				<div className="flex h-24">
-					<a
-						href="/"
+					<button
 						data-testid={`PluginManagerNavigationBar__my-plugins`}
 						onClick={() => onChange("my-plugins")}
 						title="My Plugins"
-						className={`PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer ${
+						className={`PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer ${
 							selected === "my-plugins" ? "active" : ""
 						}`}
 					>
 						<span>MyPlugin</span>
 						<span className="ml-1 text-theme-neutral-400">8</span>
-					</a>
+					</button>
+
 					<div className="w-px h-10 mx-8 my-auto border-r border-theme-neutral-300" />
+
 					<PluginManagerControls
 						onSelectGridView={onSelectGridView}
 						onSelectListView={onSelectListView}

--- a/src/domains/plugin/components/PluginManagerNavigationBar/PluginManagerNavigationBar.tsx
+++ b/src/domains/plugin/components/PluginManagerNavigationBar/PluginManagerNavigationBar.tsx
@@ -48,7 +48,7 @@ export const PluginManagerNavigationBar = ({
 									</button>
 
 									{index < menu.length - 1 && (
-										<div className="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300" />
+										<div className="w-px h-4 mx-6 my-auto border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300" />
 									)}
 								</li>
 							))}

--- a/src/domains/plugin/components/PluginManagerNavigationBar/__snapshots__/PluginManagerNavigationBar.test.tsx.snap
+++ b/src/domains/plugin/components/PluginManagerNavigationBar/__snapshots__/PluginManagerNavigationBar.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`PluginManagerNavigationBar should render 1`] = `
               </span>
             </button>
             <div
-              class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+              class="w-px h-4 mx-6 my-auto border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
             />
           </li>
           <li
@@ -47,7 +47,7 @@ exports[`PluginManagerNavigationBar should render 1`] = `
               </span>
             </button>
             <div
-              class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+              class="w-px h-4 mx-6 my-auto border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
             />
           </li>
           <li
@@ -68,7 +68,7 @@ exports[`PluginManagerNavigationBar should render 1`] = `
               </span>
             </button>
             <div
-              class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+              class="w-px h-4 mx-6 my-auto border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
             />
           </li>
           <li
@@ -89,7 +89,7 @@ exports[`PluginManagerNavigationBar should render 1`] = `
               </span>
             </button>
             <div
-              class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+              class="w-px h-4 mx-6 my-auto border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
             />
           </li>
           <li
@@ -207,7 +207,7 @@ exports[`PluginManagerNavigationBar should update selected 1`] = `
               </span>
             </button>
             <div
-              class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+              class="w-px h-4 mx-6 my-auto border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
             />
           </li>
           <li
@@ -228,7 +228,7 @@ exports[`PluginManagerNavigationBar should update selected 1`] = `
               </span>
             </button>
             <div
-              class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+              class="w-px h-4 mx-6 my-auto border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
             />
           </li>
           <li
@@ -249,7 +249,7 @@ exports[`PluginManagerNavigationBar should update selected 1`] = `
               </span>
             </button>
             <div
-              class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+              class="w-px h-4 mx-6 my-auto border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
             />
           </li>
           <li
@@ -270,7 +270,7 @@ exports[`PluginManagerNavigationBar should update selected 1`] = `
               </span>
             </button>
             <div
-              class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+              class="w-px h-4 mx-6 my-auto border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
             />
           </li>
           <li

--- a/src/domains/plugin/components/PluginManagerNavigationBar/__snapshots__/PluginManagerNavigationBar.test.tsx.snap
+++ b/src/domains/plugin/components/PluginManagerNavigationBar/__snapshots__/PluginManagerNavigationBar.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`PluginManagerNavigationBar should render 1`] = `
 <DocumentFragment>
   <nav
-    class="sc-AxirZ jSCgBq sticky md:top-24 top-20 bg-theme-neutral-100"
+    class="sc-AxirZ hgOUPI sticky md:top-24 top-20 bg-theme-neutral-100"
     data-testid="PluginManagerNavigationBar"
   >
     <div
@@ -16,27 +16,25 @@ exports[`PluginManagerNavigationBar should render 1`] = `
           <li
             class="flex"
           >
-            <a
-              class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer active"
+            <button
+              class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer active"
               data-testid="PluginManagerNavigationBar__home"
-              href="/"
               title="Home"
             >
               <span>
                 Home
               </span>
-              <div
-                class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-              />
-            </a>
+            </button>
+            <div
+              class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+            />
           </li>
           <li
             class="flex"
           >
-            <a
-              class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+            <button
+              class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
               data-testid="PluginManagerNavigationBar__game"
-              href="/"
               title="Game"
             >
               <span>
@@ -47,18 +45,17 @@ exports[`PluginManagerNavigationBar should render 1`] = `
               >
                 48
               </span>
-              <div
-                class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-              />
-            </a>
+            </button>
+            <div
+              class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+            />
           </li>
           <li
             class="flex"
           >
-            <a
-              class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+            <button
+              class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
               data-testid="PluginManagerNavigationBar__utility"
-              href="/"
               title="Utility"
             >
               <span>
@@ -69,18 +66,17 @@ exports[`PluginManagerNavigationBar should render 1`] = `
               >
                 264
               </span>
-              <div
-                class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-              />
-            </a>
+            </button>
+            <div
+              class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+            />
           </li>
           <li
             class="flex"
           >
-            <a
-              class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+            <button
+              class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
               data-testid="PluginManagerNavigationBar__themes"
-              href="/"
               title="Themes"
             >
               <span>
@@ -91,18 +87,17 @@ exports[`PluginManagerNavigationBar should render 1`] = `
               >
                 96
               </span>
-              <div
-                class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-              />
-            </a>
+            </button>
+            <div
+              class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+            />
           </li>
           <li
             class="flex"
           >
-            <a
-              class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+            <button
+              class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
               data-testid="PluginManagerNavigationBar__other"
-              href="/"
               title="Other"
             >
               <span>
@@ -113,20 +108,16 @@ exports[`PluginManagerNavigationBar should render 1`] = `
               >
                 27
               </span>
-              <div
-                class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-              />
-            </a>
+            </button>
           </li>
         </ul>
       </div>
       <div
         class="flex h-24"
       >
-        <a
-          class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+        <button
+          class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
           data-testid="PluginManagerNavigationBar__my-plugins"
-          href="/"
           title="My Plugins"
         >
           <span>
@@ -137,7 +128,7 @@ exports[`PluginManagerNavigationBar should render 1`] = `
           >
             8
           </span>
-        </a>
+        </button>
         <div
           class="w-px h-10 mx-8 my-auto border-r border-theme-neutral-300"
         />
@@ -193,7 +184,7 @@ exports[`PluginManagerNavigationBar should render 1`] = `
 exports[`PluginManagerNavigationBar should update selected 1`] = `
 <DocumentFragment>
   <nav
-    class="sc-AxirZ jSCgBq sticky md:top-24 top-20 bg-theme-neutral-100"
+    class="sc-AxirZ hgOUPI sticky md:top-24 top-20 bg-theme-neutral-100"
     data-testid="PluginManagerNavigationBar"
   >
     <div
@@ -206,27 +197,25 @@ exports[`PluginManagerNavigationBar should update selected 1`] = `
           <li
             class="flex"
           >
-            <a
-              class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer active"
+            <button
+              class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer active"
               data-testid="PluginManagerNavigationBar__home"
-              href="/"
               title="Home"
             >
               <span>
                 Home
               </span>
-              <div
-                class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-              />
-            </a>
+            </button>
+            <div
+              class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+            />
           </li>
           <li
             class="flex"
           >
-            <a
-              class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+            <button
+              class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
               data-testid="PluginManagerNavigationBar__game"
-              href="/"
               title="Game"
             >
               <span>
@@ -237,18 +226,17 @@ exports[`PluginManagerNavigationBar should update selected 1`] = `
               >
                 48
               </span>
-              <div
-                class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-              />
-            </a>
+            </button>
+            <div
+              class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+            />
           </li>
           <li
             class="flex"
           >
-            <a
-              class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+            <button
+              class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
               data-testid="PluginManagerNavigationBar__utility"
-              href="/"
               title="Utility"
             >
               <span>
@@ -259,18 +247,17 @@ exports[`PluginManagerNavigationBar should update selected 1`] = `
               >
                 264
               </span>
-              <div
-                class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-              />
-            </a>
+            </button>
+            <div
+              class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+            />
           </li>
           <li
             class="flex"
           >
-            <a
-              class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+            <button
+              class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
               data-testid="PluginManagerNavigationBar__themes"
-              href="/"
               title="Themes"
             >
               <span>
@@ -281,18 +268,17 @@ exports[`PluginManagerNavigationBar should update selected 1`] = `
               >
                 96
               </span>
-              <div
-                class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-              />
-            </a>
+            </button>
+            <div
+              class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+            />
           </li>
           <li
             class="flex"
           >
-            <a
-              class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+            <button
+              class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
               data-testid="PluginManagerNavigationBar__other"
-              href="/"
               title="Other"
             >
               <span>
@@ -303,20 +289,16 @@ exports[`PluginManagerNavigationBar should update selected 1`] = `
               >
                 27
               </span>
-              <div
-                class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-              />
-            </a>
+            </button>
           </li>
         </ul>
       </div>
       <div
         class="flex h-24"
       >
-        <a
-          class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+        <button
+          class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
           data-testid="PluginManagerNavigationBar__my-plugins"
-          href="/"
           title="My Plugins"
         >
           <span>
@@ -327,7 +309,7 @@ exports[`PluginManagerNavigationBar should update selected 1`] = `
           >
             8
           </span>
-        </a>
+        </button>
         <div
           class="w-px h-10 mx-8 my-auto border-r border-theme-neutral-300"
         />

--- a/src/domains/plugin/components/PluginManagerNavigationBar/styles.ts
+++ b/src/domains/plugin/components/PluginManagerNavigationBar/styles.ts
@@ -10,12 +10,6 @@ export const defaultStyle = `
 
 	}
 
-	li:last-child {
-	   .PluginManagerNavigationBar__menu-divider {
-		   display: none;
-	   }
-    }
-
 	li:first-child {
 	   a {
 		   padding-left: 0;

--- a/src/domains/plugin/pages/PluginManager/__snapshots__/PluginManager.test.tsx.snap
+++ b/src/domains/plugin/pages/PluginManager/__snapshots__/PluginManager.test.tsx.snap
@@ -109,7 +109,7 @@ exports[`PluginManager should cancel install plugin 1`] = `
                 </span>
               </button>
               <div
-                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+                class="w-px h-4 mx-6 my-auto border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
               />
             </li>
             <li
@@ -130,7 +130,7 @@ exports[`PluginManager should cancel install plugin 1`] = `
                 </span>
               </button>
               <div
-                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+                class="w-px h-4 mx-6 my-auto border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
               />
             </li>
             <li
@@ -151,7 +151,7 @@ exports[`PluginManager should cancel install plugin 1`] = `
                 </span>
               </button>
               <div
-                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+                class="w-px h-4 mx-6 my-auto border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
               />
             </li>
             <li
@@ -172,7 +172,7 @@ exports[`PluginManager should cancel install plugin 1`] = `
                 </span>
               </button>
               <div
-                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+                class="w-px h-4 mx-6 my-auto border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
               />
             </li>
             <li
@@ -199,7 +199,7 @@ exports[`PluginManager should cancel install plugin 1`] = `
           class="flex h-24"
         >
           <button
-            class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+            class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
             data-testid="PluginManagerNavigationBar__my-plugins"
             title="My Plugins"
           >
@@ -4356,7 +4356,7 @@ exports[`PluginManager should close install plugin modal 1`] = `
                 </span>
               </button>
               <div
-                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+                class="w-px h-4 mx-6 my-auto border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
               />
             </li>
             <li
@@ -4377,7 +4377,7 @@ exports[`PluginManager should close install plugin modal 1`] = `
                 </span>
               </button>
               <div
-                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+                class="w-px h-4 mx-6 my-auto border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
               />
             </li>
             <li
@@ -4398,7 +4398,7 @@ exports[`PluginManager should close install plugin modal 1`] = `
                 </span>
               </button>
               <div
-                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+                class="w-px h-4 mx-6 my-auto border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
               />
             </li>
             <li
@@ -4419,7 +4419,7 @@ exports[`PluginManager should close install plugin modal 1`] = `
                 </span>
               </button>
               <div
-                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+                class="w-px h-4 mx-6 my-auto border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
               />
             </li>
             <li
@@ -4446,7 +4446,7 @@ exports[`PluginManager should close install plugin modal 1`] = `
           class="flex h-24"
         >
           <button
-            class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+            class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
             data-testid="PluginManagerNavigationBar__my-plugins"
             title="My Plugins"
           >
@@ -8603,7 +8603,7 @@ exports[`PluginManager should delete plugin on game 1`] = `
                 </span>
               </button>
               <div
-                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+                class="w-px h-4 mx-6 my-auto border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
               />
             </li>
             <li
@@ -8624,7 +8624,7 @@ exports[`PluginManager should delete plugin on game 1`] = `
                 </span>
               </button>
               <div
-                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+                class="w-px h-4 mx-6 my-auto border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
               />
             </li>
             <li
@@ -8645,7 +8645,7 @@ exports[`PluginManager should delete plugin on game 1`] = `
                 </span>
               </button>
               <div
-                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+                class="w-px h-4 mx-6 my-auto border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
               />
             </li>
             <li
@@ -8666,7 +8666,7 @@ exports[`PluginManager should delete plugin on game 1`] = `
                 </span>
               </button>
               <div
-                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+                class="w-px h-4 mx-6 my-auto border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
               />
             </li>
             <li
@@ -8693,7 +8693,7 @@ exports[`PluginManager should delete plugin on game 1`] = `
           class="flex h-24"
         >
           <button
-            class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+            class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
             data-testid="PluginManagerNavigationBar__my-plugins"
             title="My Plugins"
           >
@@ -10529,7 +10529,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                 </span>
               </button>
               <div
-                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+                class="w-px h-4 mx-6 my-auto border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
               />
             </li>
             <li
@@ -10550,7 +10550,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                 </span>
               </button>
               <div
-                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+                class="w-px h-4 mx-6 my-auto border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
               />
             </li>
             <li
@@ -10571,7 +10571,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                 </span>
               </button>
               <div
-                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+                class="w-px h-4 mx-6 my-auto border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
               />
             </li>
             <li
@@ -10592,7 +10592,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                 </span>
               </button>
               <div
-                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+                class="w-px h-4 mx-6 my-auto border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
               />
             </li>
             <li
@@ -10619,7 +10619,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
           class="flex h-24"
         >
           <button
-            class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+            class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
             data-testid="PluginManagerNavigationBar__my-plugins"
             title="My Plugins"
           >
@@ -13122,7 +13122,7 @@ exports[`PluginManager should download & install plugin on game 1`] = `
                 </span>
               </button>
               <div
-                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+                class="w-px h-4 mx-6 my-auto border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
               />
             </li>
             <li
@@ -13143,7 +13143,7 @@ exports[`PluginManager should download & install plugin on game 1`] = `
                 </span>
               </button>
               <div
-                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+                class="w-px h-4 mx-6 my-auto border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
               />
             </li>
             <li
@@ -13164,7 +13164,7 @@ exports[`PluginManager should download & install plugin on game 1`] = `
                 </span>
               </button>
               <div
-                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+                class="w-px h-4 mx-6 my-auto border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
               />
             </li>
             <li
@@ -13185,7 +13185,7 @@ exports[`PluginManager should download & install plugin on game 1`] = `
                 </span>
               </button>
               <div
-                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+                class="w-px h-4 mx-6 my-auto border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
               />
             </li>
             <li
@@ -13212,7 +13212,7 @@ exports[`PluginManager should download & install plugin on game 1`] = `
           class="flex h-24"
         >
           <button
-            class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+            class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
             data-testid="PluginManagerNavigationBar__my-plugins"
             title="My Plugins"
           >
@@ -15203,7 +15203,7 @@ exports[`PluginManager should download & install plugin on home 1`] = `
                 </span>
               </button>
               <div
-                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+                class="w-px h-4 mx-6 my-auto border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
               />
             </li>
             <li
@@ -15224,7 +15224,7 @@ exports[`PluginManager should download & install plugin on home 1`] = `
                 </span>
               </button>
               <div
-                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+                class="w-px h-4 mx-6 my-auto border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
               />
             </li>
             <li
@@ -15245,7 +15245,7 @@ exports[`PluginManager should download & install plugin on home 1`] = `
                 </span>
               </button>
               <div
-                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+                class="w-px h-4 mx-6 my-auto border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
               />
             </li>
             <li
@@ -15266,7 +15266,7 @@ exports[`PluginManager should download & install plugin on home 1`] = `
                 </span>
               </button>
               <div
-                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+                class="w-px h-4 mx-6 my-auto border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
               />
             </li>
             <li
@@ -15293,7 +15293,7 @@ exports[`PluginManager should download & install plugin on home 1`] = `
           class="flex h-24"
         >
           <button
-            class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+            class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
             data-testid="PluginManagerNavigationBar__my-plugins"
             title="My Plugins"
           >
@@ -19450,7 +19450,7 @@ exports[`PluginManager should open & close featured modal 1`] = `
                 </span>
               </button>
               <div
-                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+                class="w-px h-4 mx-6 my-auto border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
               />
             </li>
             <li
@@ -19471,7 +19471,7 @@ exports[`PluginManager should open & close featured modal 1`] = `
                 </span>
               </button>
               <div
-                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+                class="w-px h-4 mx-6 my-auto border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
               />
             </li>
             <li
@@ -19492,7 +19492,7 @@ exports[`PluginManager should open & close featured modal 1`] = `
                 </span>
               </button>
               <div
-                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+                class="w-px h-4 mx-6 my-auto border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
               />
             </li>
             <li
@@ -19513,7 +19513,7 @@ exports[`PluginManager should open & close featured modal 1`] = `
                 </span>
               </button>
               <div
-                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+                class="w-px h-4 mx-6 my-auto border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
               />
             </li>
             <li
@@ -19540,7 +19540,7 @@ exports[`PluginManager should open & close featured modal 1`] = `
           class="flex h-24"
         >
           <button
-            class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+            class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
             data-testid="PluginManagerNavigationBar__my-plugins"
             title="My Plugins"
           >
@@ -21888,7 +21888,7 @@ exports[`PluginManager should open & close top rated modal 1`] = `
                 </span>
               </button>
               <div
-                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+                class="w-px h-4 mx-6 my-auto border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
               />
             </li>
             <li
@@ -21909,7 +21909,7 @@ exports[`PluginManager should open & close top rated modal 1`] = `
                 </span>
               </button>
               <div
-                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+                class="w-px h-4 mx-6 my-auto border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
               />
             </li>
             <li
@@ -21930,7 +21930,7 @@ exports[`PluginManager should open & close top rated modal 1`] = `
                 </span>
               </button>
               <div
-                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+                class="w-px h-4 mx-6 my-auto border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
               />
             </li>
             <li
@@ -21951,7 +21951,7 @@ exports[`PluginManager should open & close top rated modal 1`] = `
                 </span>
               </button>
               <div
-                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+                class="w-px h-4 mx-6 my-auto border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
               />
             </li>
             <li
@@ -21978,7 +21978,7 @@ exports[`PluginManager should open & close top rated modal 1`] = `
           class="flex h-24"
         >
           <button
-            class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+            class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
             data-testid="PluginManagerNavigationBar__my-plugins"
             title="My Plugins"
           >
@@ -24326,7 +24326,7 @@ exports[`PluginManager should render 1`] = `
                 </span>
               </button>
               <div
-                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+                class="w-px h-4 mx-6 my-auto border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
               />
             </li>
             <li
@@ -24347,7 +24347,7 @@ exports[`PluginManager should render 1`] = `
                 </span>
               </button>
               <div
-                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+                class="w-px h-4 mx-6 my-auto border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
               />
             </li>
             <li
@@ -24368,7 +24368,7 @@ exports[`PluginManager should render 1`] = `
                 </span>
               </button>
               <div
-                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+                class="w-px h-4 mx-6 my-auto border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
               />
             </li>
             <li
@@ -24389,7 +24389,7 @@ exports[`PluginManager should render 1`] = `
                 </span>
               </button>
               <div
-                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+                class="w-px h-4 mx-6 my-auto border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
               />
             </li>
             <li
@@ -24416,7 +24416,7 @@ exports[`PluginManager should render 1`] = `
           class="flex h-24"
         >
           <button
-            class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+            class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
             data-testid="PluginManagerNavigationBar__my-plugins"
             title="My Plugins"
           >
@@ -26782,7 +26782,7 @@ exports[`PluginManager should search for plugin 1`] = `
                 </span>
               </button>
               <div
-                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+                class="w-px h-4 mx-6 my-auto border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
               />
             </li>
             <li
@@ -26803,7 +26803,7 @@ exports[`PluginManager should search for plugin 1`] = `
                 </span>
               </button>
               <div
-                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+                class="w-px h-4 mx-6 my-auto border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
               />
             </li>
             <li
@@ -26824,7 +26824,7 @@ exports[`PluginManager should search for plugin 1`] = `
                 </span>
               </button>
               <div
-                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+                class="w-px h-4 mx-6 my-auto border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
               />
             </li>
             <li
@@ -26845,7 +26845,7 @@ exports[`PluginManager should search for plugin 1`] = `
                 </span>
               </button>
               <div
-                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+                class="w-px h-4 mx-6 my-auto border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
               />
             </li>
             <li
@@ -26872,7 +26872,7 @@ exports[`PluginManager should search for plugin 1`] = `
           class="flex h-24"
         >
           <button
-            class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+            class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
             data-testid="PluginManagerNavigationBar__my-plugins"
             title="My Plugins"
           >
@@ -29220,7 +29220,7 @@ exports[`PluginManager should select plugin on game grid 1`] = `
                 </span>
               </button>
               <div
-                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+                class="w-px h-4 mx-6 my-auto border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
               />
             </li>
             <li
@@ -29241,7 +29241,7 @@ exports[`PluginManager should select plugin on game grid 1`] = `
                 </span>
               </button>
               <div
-                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+                class="w-px h-4 mx-6 my-auto border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
               />
             </li>
             <li
@@ -29262,7 +29262,7 @@ exports[`PluginManager should select plugin on game grid 1`] = `
                 </span>
               </button>
               <div
-                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+                class="w-px h-4 mx-6 my-auto border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
               />
             </li>
             <li
@@ -29283,7 +29283,7 @@ exports[`PluginManager should select plugin on game grid 1`] = `
                 </span>
               </button>
               <div
-                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+                class="w-px h-4 mx-6 my-auto border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
               />
             </li>
             <li
@@ -29310,7 +29310,7 @@ exports[`PluginManager should select plugin on game grid 1`] = `
           class="flex h-24"
         >
           <button
-            class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+            class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
             data-testid="PluginManagerNavigationBar__my-plugins"
             title="My Plugins"
           >
@@ -31330,7 +31330,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                 </span>
               </button>
               <div
-                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+                class="w-px h-4 mx-6 my-auto border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
               />
             </li>
             <li
@@ -31351,7 +31351,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                 </span>
               </button>
               <div
-                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+                class="w-px h-4 mx-6 my-auto border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
               />
             </li>
             <li
@@ -31372,7 +31372,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                 </span>
               </button>
               <div
-                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+                class="w-px h-4 mx-6 my-auto border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
               />
             </li>
             <li
@@ -31393,7 +31393,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                 </span>
               </button>
               <div
-                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+                class="w-px h-4 mx-6 my-auto border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
               />
             </li>
             <li
@@ -31420,7 +31420,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
           class="flex h-24"
         >
           <button
-            class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+            class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
             data-testid="PluginManagerNavigationBar__my-plugins"
             title="My Plugins"
           >
@@ -33768,7 +33768,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
                 </span>
               </button>
               <div
-                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+                class="w-px h-4 mx-6 my-auto border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
               />
             </li>
             <li
@@ -33789,7 +33789,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
                 </span>
               </button>
               <div
-                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+                class="w-px h-4 mx-6 my-auto border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
               />
             </li>
             <li
@@ -33810,7 +33810,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
                 </span>
               </button>
               <div
-                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+                class="w-px h-4 mx-6 my-auto border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
               />
             </li>
             <li
@@ -33831,7 +33831,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
                 </span>
               </button>
               <div
-                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+                class="w-px h-4 mx-6 my-auto border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
               />
             </li>
             <li
@@ -33858,7 +33858,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
           class="flex h-24"
         >
           <button
-            class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+            class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
             data-testid="PluginManagerNavigationBar__my-plugins"
             title="My Plugins"
           >
@@ -35878,7 +35878,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                 </span>
               </button>
               <div
-                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+                class="w-px h-4 mx-6 my-auto border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
               />
             </li>
             <li
@@ -35899,7 +35899,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                 </span>
               </button>
               <div
-                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+                class="w-px h-4 mx-6 my-auto border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
               />
             </li>
             <li
@@ -35920,7 +35920,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                 </span>
               </button>
               <div
-                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+                class="w-px h-4 mx-6 my-auto border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
               />
             </li>
             <li
@@ -35941,7 +35941,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                 </span>
               </button>
               <div
-                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+                class="w-px h-4 mx-6 my-auto border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
               />
             </li>
             <li
@@ -35968,7 +35968,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
           class="flex h-24"
         >
           <button
-            class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+            class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
             data-testid="PluginManagerNavigationBar__my-plugins"
             title="My Plugins"
           >

--- a/src/domains/plugin/pages/PluginManager/__snapshots__/PluginManager.test.tsx.snap
+++ b/src/domains/plugin/pages/PluginManager/__snapshots__/PluginManager.test.tsx.snap
@@ -86,7 +86,7 @@ exports[`PluginManager should cancel install plugin 1`] = `
       </div>
     </div>
     <nav
-      class="sc-fzoXzr dkyLjt sticky md:top-24 top-20 bg-theme-neutral-100"
+      class="sc-fzoXzr gJHSCD sticky md:top-24 top-20 bg-theme-neutral-100"
       data-testid="PluginManagerNavigationBar"
     >
       <div
@@ -99,27 +99,25 @@ exports[`PluginManager should cancel install plugin 1`] = `
             <li
               class="flex"
             >
-              <a
-                class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer active"
+              <button
+                class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer active"
                 data-testid="PluginManagerNavigationBar__home"
-                href="/"
                 title="Home"
               >
                 <span>
                   Home
                 </span>
-                <div
-                  class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-                />
-              </a>
+              </button>
+              <div
+                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+              />
             </li>
             <li
               class="flex"
             >
-              <a
-                class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+              <button
+                class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
                 data-testid="PluginManagerNavigationBar__game"
-                href="/"
                 title="Game"
               >
                 <span>
@@ -130,18 +128,17 @@ exports[`PluginManager should cancel install plugin 1`] = `
                 >
                   48
                 </span>
-                <div
-                  class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-                />
-              </a>
+              </button>
+              <div
+                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+              />
             </li>
             <li
               class="flex"
             >
-              <a
-                class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+              <button
+                class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
                 data-testid="PluginManagerNavigationBar__utility"
-                href="/"
                 title="Utility"
               >
                 <span>
@@ -152,18 +149,17 @@ exports[`PluginManager should cancel install plugin 1`] = `
                 >
                   264
                 </span>
-                <div
-                  class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-                />
-              </a>
+              </button>
+              <div
+                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+              />
             </li>
             <li
               class="flex"
             >
-              <a
-                class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+              <button
+                class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
                 data-testid="PluginManagerNavigationBar__themes"
-                href="/"
                 title="Themes"
               >
                 <span>
@@ -174,18 +170,17 @@ exports[`PluginManager should cancel install plugin 1`] = `
                 >
                   96
                 </span>
-                <div
-                  class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-                />
-              </a>
+              </button>
+              <div
+                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+              />
             </li>
             <li
               class="flex"
             >
-              <a
-                class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+              <button
+                class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
                 data-testid="PluginManagerNavigationBar__other"
-                href="/"
                 title="Other"
               >
                 <span>
@@ -196,20 +191,16 @@ exports[`PluginManager should cancel install plugin 1`] = `
                 >
                   27
                 </span>
-                <div
-                  class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-                />
-              </a>
+              </button>
             </li>
           </ul>
         </div>
         <div
           class="flex h-24"
         >
-          <a
+          <button
             class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
             data-testid="PluginManagerNavigationBar__my-plugins"
-            href="/"
             title="My Plugins"
           >
             <span>
@@ -220,7 +211,7 @@ exports[`PluginManager should cancel install plugin 1`] = `
             >
               8
             </span>
-          </a>
+          </button>
           <div
             class="w-px h-10 mx-8 my-auto border-r border-theme-neutral-300"
           />
@@ -4342,7 +4333,7 @@ exports[`PluginManager should close install plugin modal 1`] = `
       </div>
     </div>
     <nav
-      class="sc-fzoXzr dkyLjt sticky md:top-24 top-20 bg-theme-neutral-100"
+      class="sc-fzoXzr gJHSCD sticky md:top-24 top-20 bg-theme-neutral-100"
       data-testid="PluginManagerNavigationBar"
     >
       <div
@@ -4355,27 +4346,25 @@ exports[`PluginManager should close install plugin modal 1`] = `
             <li
               class="flex"
             >
-              <a
-                class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer active"
+              <button
+                class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer active"
                 data-testid="PluginManagerNavigationBar__home"
-                href="/"
                 title="Home"
               >
                 <span>
                   Home
                 </span>
-                <div
-                  class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-                />
-              </a>
+              </button>
+              <div
+                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+              />
             </li>
             <li
               class="flex"
             >
-              <a
-                class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+              <button
+                class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
                 data-testid="PluginManagerNavigationBar__game"
-                href="/"
                 title="Game"
               >
                 <span>
@@ -4386,18 +4375,17 @@ exports[`PluginManager should close install plugin modal 1`] = `
                 >
                   48
                 </span>
-                <div
-                  class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-                />
-              </a>
+              </button>
+              <div
+                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+              />
             </li>
             <li
               class="flex"
             >
-              <a
-                class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+              <button
+                class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
                 data-testid="PluginManagerNavigationBar__utility"
-                href="/"
                 title="Utility"
               >
                 <span>
@@ -4408,18 +4396,17 @@ exports[`PluginManager should close install plugin modal 1`] = `
                 >
                   264
                 </span>
-                <div
-                  class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-                />
-              </a>
+              </button>
+              <div
+                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+              />
             </li>
             <li
               class="flex"
             >
-              <a
-                class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+              <button
+                class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
                 data-testid="PluginManagerNavigationBar__themes"
-                href="/"
                 title="Themes"
               >
                 <span>
@@ -4430,18 +4417,17 @@ exports[`PluginManager should close install plugin modal 1`] = `
                 >
                   96
                 </span>
-                <div
-                  class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-                />
-              </a>
+              </button>
+              <div
+                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+              />
             </li>
             <li
               class="flex"
             >
-              <a
-                class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+              <button
+                class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
                 data-testid="PluginManagerNavigationBar__other"
-                href="/"
                 title="Other"
               >
                 <span>
@@ -4452,20 +4438,16 @@ exports[`PluginManager should close install plugin modal 1`] = `
                 >
                   27
                 </span>
-                <div
-                  class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-                />
-              </a>
+              </button>
             </li>
           </ul>
         </div>
         <div
           class="flex h-24"
         >
-          <a
+          <button
             class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
             data-testid="PluginManagerNavigationBar__my-plugins"
-            href="/"
             title="My Plugins"
           >
             <span>
@@ -4476,7 +4458,7 @@ exports[`PluginManager should close install plugin modal 1`] = `
             >
               8
             </span>
-          </a>
+          </button>
           <div
             class="w-px h-10 mx-8 my-auto border-r border-theme-neutral-300"
           />
@@ -8598,7 +8580,7 @@ exports[`PluginManager should delete plugin on game 1`] = `
       </div>
     </div>
     <nav
-      class="sc-fzoXzr dkyLjt sticky md:top-24 top-20 bg-theme-neutral-100"
+      class="sc-fzoXzr gJHSCD sticky md:top-24 top-20 bg-theme-neutral-100"
       data-testid="PluginManagerNavigationBar"
     >
       <div
@@ -8611,27 +8593,25 @@ exports[`PluginManager should delete plugin on game 1`] = `
             <li
               class="flex"
             >
-              <a
-                class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+              <button
+                class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
                 data-testid="PluginManagerNavigationBar__home"
-                href="/"
                 title="Home"
               >
                 <span>
                   Home
                 </span>
-                <div
-                  class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-                />
-              </a>
+              </button>
+              <div
+                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+              />
             </li>
             <li
               class="flex"
             >
-              <a
-                class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer active"
+              <button
+                class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer active"
                 data-testid="PluginManagerNavigationBar__game"
-                href="/"
                 title="Game"
               >
                 <span>
@@ -8642,18 +8622,17 @@ exports[`PluginManager should delete plugin on game 1`] = `
                 >
                   48
                 </span>
-                <div
-                  class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-                />
-              </a>
+              </button>
+              <div
+                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+              />
             </li>
             <li
               class="flex"
             >
-              <a
-                class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+              <button
+                class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
                 data-testid="PluginManagerNavigationBar__utility"
-                href="/"
                 title="Utility"
               >
                 <span>
@@ -8664,18 +8643,17 @@ exports[`PluginManager should delete plugin on game 1`] = `
                 >
                   264
                 </span>
-                <div
-                  class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-                />
-              </a>
+              </button>
+              <div
+                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+              />
             </li>
             <li
               class="flex"
             >
-              <a
-                class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+              <button
+                class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
                 data-testid="PluginManagerNavigationBar__themes"
-                href="/"
                 title="Themes"
               >
                 <span>
@@ -8686,18 +8664,17 @@ exports[`PluginManager should delete plugin on game 1`] = `
                 >
                   96
                 </span>
-                <div
-                  class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-                />
-              </a>
+              </button>
+              <div
+                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+              />
             </li>
             <li
               class="flex"
             >
-              <a
-                class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+              <button
+                class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
                 data-testid="PluginManagerNavigationBar__other"
-                href="/"
                 title="Other"
               >
                 <span>
@@ -8708,20 +8685,16 @@ exports[`PluginManager should delete plugin on game 1`] = `
                 >
                   27
                 </span>
-                <div
-                  class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-                />
-              </a>
+              </button>
             </li>
           </ul>
         </div>
         <div
           class="flex h-24"
         >
-          <a
+          <button
             class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
             data-testid="PluginManagerNavigationBar__my-plugins"
-            href="/"
             title="My Plugins"
           >
             <span>
@@ -8732,7 +8705,7 @@ exports[`PluginManager should delete plugin on game 1`] = `
             >
               8
             </span>
-          </a>
+          </button>
           <div
             class="w-px h-10 mx-8 my-auto border-r border-theme-neutral-300"
           />
@@ -10533,7 +10506,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
       </div>
     </div>
     <nav
-      class="sc-fzoXzr dkyLjt sticky md:top-24 top-20 bg-theme-neutral-100"
+      class="sc-fzoXzr gJHSCD sticky md:top-24 top-20 bg-theme-neutral-100"
       data-testid="PluginManagerNavigationBar"
     >
       <div
@@ -10546,27 +10519,25 @@ exports[`PluginManager should delete plugin on home 1`] = `
             <li
               class="flex"
             >
-              <a
-                class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer active"
+              <button
+                class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer active"
                 data-testid="PluginManagerNavigationBar__home"
-                href="/"
                 title="Home"
               >
                 <span>
                   Home
                 </span>
-                <div
-                  class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-                />
-              </a>
+              </button>
+              <div
+                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+              />
             </li>
             <li
               class="flex"
             >
-              <a
-                class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+              <button
+                class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
                 data-testid="PluginManagerNavigationBar__game"
-                href="/"
                 title="Game"
               >
                 <span>
@@ -10577,18 +10548,17 @@ exports[`PluginManager should delete plugin on home 1`] = `
                 >
                   48
                 </span>
-                <div
-                  class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-                />
-              </a>
+              </button>
+              <div
+                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+              />
             </li>
             <li
               class="flex"
             >
-              <a
-                class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+              <button
+                class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
                 data-testid="PluginManagerNavigationBar__utility"
-                href="/"
                 title="Utility"
               >
                 <span>
@@ -10599,18 +10569,17 @@ exports[`PluginManager should delete plugin on home 1`] = `
                 >
                   264
                 </span>
-                <div
-                  class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-                />
-              </a>
+              </button>
+              <div
+                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+              />
             </li>
             <li
               class="flex"
             >
-              <a
-                class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+              <button
+                class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
                 data-testid="PluginManagerNavigationBar__themes"
-                href="/"
                 title="Themes"
               >
                 <span>
@@ -10621,18 +10590,17 @@ exports[`PluginManager should delete plugin on home 1`] = `
                 >
                   96
                 </span>
-                <div
-                  class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-                />
-              </a>
+              </button>
+              <div
+                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+              />
             </li>
             <li
               class="flex"
             >
-              <a
-                class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+              <button
+                class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
                 data-testid="PluginManagerNavigationBar__other"
-                href="/"
                 title="Other"
               >
                 <span>
@@ -10643,20 +10611,16 @@ exports[`PluginManager should delete plugin on home 1`] = `
                 >
                   27
                 </span>
-                <div
-                  class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-                />
-              </a>
+              </button>
             </li>
           </ul>
         </div>
         <div
           class="flex h-24"
         >
-          <a
+          <button
             class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
             data-testid="PluginManagerNavigationBar__my-plugins"
-            href="/"
             title="My Plugins"
           >
             <span>
@@ -10667,7 +10631,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
             >
               8
             </span>
-          </a>
+          </button>
           <div
             class="w-px h-10 mx-8 my-auto border-r border-theme-neutral-300"
           />
@@ -13135,7 +13099,7 @@ exports[`PluginManager should download & install plugin on game 1`] = `
       </div>
     </div>
     <nav
-      class="sc-fzoXzr dkyLjt sticky md:top-24 top-20 bg-theme-neutral-100"
+      class="sc-fzoXzr gJHSCD sticky md:top-24 top-20 bg-theme-neutral-100"
       data-testid="PluginManagerNavigationBar"
     >
       <div
@@ -13148,27 +13112,25 @@ exports[`PluginManager should download & install plugin on game 1`] = `
             <li
               class="flex"
             >
-              <a
-                class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+              <button
+                class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
                 data-testid="PluginManagerNavigationBar__home"
-                href="/"
                 title="Home"
               >
                 <span>
                   Home
                 </span>
-                <div
-                  class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-                />
-              </a>
+              </button>
+              <div
+                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+              />
             </li>
             <li
               class="flex"
             >
-              <a
-                class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer active"
+              <button
+                class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer active"
                 data-testid="PluginManagerNavigationBar__game"
-                href="/"
                 title="Game"
               >
                 <span>
@@ -13179,18 +13141,17 @@ exports[`PluginManager should download & install plugin on game 1`] = `
                 >
                   48
                 </span>
-                <div
-                  class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-                />
-              </a>
+              </button>
+              <div
+                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+              />
             </li>
             <li
               class="flex"
             >
-              <a
-                class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+              <button
+                class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
                 data-testid="PluginManagerNavigationBar__utility"
-                href="/"
                 title="Utility"
               >
                 <span>
@@ -13201,18 +13162,17 @@ exports[`PluginManager should download & install plugin on game 1`] = `
                 >
                   264
                 </span>
-                <div
-                  class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-                />
-              </a>
+              </button>
+              <div
+                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+              />
             </li>
             <li
               class="flex"
             >
-              <a
-                class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+              <button
+                class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
                 data-testid="PluginManagerNavigationBar__themes"
-                href="/"
                 title="Themes"
               >
                 <span>
@@ -13223,18 +13183,17 @@ exports[`PluginManager should download & install plugin on game 1`] = `
                 >
                   96
                 </span>
-                <div
-                  class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-                />
-              </a>
+              </button>
+              <div
+                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+              />
             </li>
             <li
               class="flex"
             >
-              <a
-                class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+              <button
+                class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
                 data-testid="PluginManagerNavigationBar__other"
-                href="/"
                 title="Other"
               >
                 <span>
@@ -13245,20 +13204,16 @@ exports[`PluginManager should download & install plugin on game 1`] = `
                 >
                   27
                 </span>
-                <div
-                  class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-                />
-              </a>
+              </button>
             </li>
           </ul>
         </div>
         <div
           class="flex h-24"
         >
-          <a
+          <button
             class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
             data-testid="PluginManagerNavigationBar__my-plugins"
-            href="/"
             title="My Plugins"
           >
             <span>
@@ -13269,7 +13224,7 @@ exports[`PluginManager should download & install plugin on game 1`] = `
             >
               8
             </span>
-          </a>
+          </button>
           <div
             class="w-px h-10 mx-8 my-auto border-r border-theme-neutral-300"
           />
@@ -15225,7 +15180,7 @@ exports[`PluginManager should download & install plugin on home 1`] = `
       </div>
     </div>
     <nav
-      class="sc-fzoXzr dkyLjt sticky md:top-24 top-20 bg-theme-neutral-100"
+      class="sc-fzoXzr gJHSCD sticky md:top-24 top-20 bg-theme-neutral-100"
       data-testid="PluginManagerNavigationBar"
     >
       <div
@@ -15238,27 +15193,25 @@ exports[`PluginManager should download & install plugin on home 1`] = `
             <li
               class="flex"
             >
-              <a
-                class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer active"
+              <button
+                class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer active"
                 data-testid="PluginManagerNavigationBar__home"
-                href="/"
                 title="Home"
               >
                 <span>
                   Home
                 </span>
-                <div
-                  class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-                />
-              </a>
+              </button>
+              <div
+                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+              />
             </li>
             <li
               class="flex"
             >
-              <a
-                class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+              <button
+                class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
                 data-testid="PluginManagerNavigationBar__game"
-                href="/"
                 title="Game"
               >
                 <span>
@@ -15269,18 +15222,17 @@ exports[`PluginManager should download & install plugin on home 1`] = `
                 >
                   48
                 </span>
-                <div
-                  class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-                />
-              </a>
+              </button>
+              <div
+                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+              />
             </li>
             <li
               class="flex"
             >
-              <a
-                class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+              <button
+                class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
                 data-testid="PluginManagerNavigationBar__utility"
-                href="/"
                 title="Utility"
               >
                 <span>
@@ -15291,18 +15243,17 @@ exports[`PluginManager should download & install plugin on home 1`] = `
                 >
                   264
                 </span>
-                <div
-                  class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-                />
-              </a>
+              </button>
+              <div
+                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+              />
             </li>
             <li
               class="flex"
             >
-              <a
-                class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+              <button
+                class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
                 data-testid="PluginManagerNavigationBar__themes"
-                href="/"
                 title="Themes"
               >
                 <span>
@@ -15313,18 +15264,17 @@ exports[`PluginManager should download & install plugin on home 1`] = `
                 >
                   96
                 </span>
-                <div
-                  class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-                />
-              </a>
+              </button>
+              <div
+                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+              />
             </li>
             <li
               class="flex"
             >
-              <a
-                class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+              <button
+                class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
                 data-testid="PluginManagerNavigationBar__other"
-                href="/"
                 title="Other"
               >
                 <span>
@@ -15335,20 +15285,16 @@ exports[`PluginManager should download & install plugin on home 1`] = `
                 >
                   27
                 </span>
-                <div
-                  class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-                />
-              </a>
+              </button>
             </li>
           </ul>
         </div>
         <div
           class="flex h-24"
         >
-          <a
+          <button
             class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
             data-testid="PluginManagerNavigationBar__my-plugins"
-            href="/"
             title="My Plugins"
           >
             <span>
@@ -15359,7 +15305,7 @@ exports[`PluginManager should download & install plugin on home 1`] = `
             >
               8
             </span>
-          </a>
+          </button>
           <div
             class="w-px h-10 mx-8 my-auto border-r border-theme-neutral-300"
           />
@@ -19481,7 +19427,7 @@ exports[`PluginManager should open & close featured modal 1`] = `
       </div>
     </div>
     <nav
-      class="sc-fzoXzr dkyLjt sticky md:top-24 top-20 bg-theme-neutral-100"
+      class="sc-fzoXzr gJHSCD sticky md:top-24 top-20 bg-theme-neutral-100"
       data-testid="PluginManagerNavigationBar"
     >
       <div
@@ -19494,27 +19440,25 @@ exports[`PluginManager should open & close featured modal 1`] = `
             <li
               class="flex"
             >
-              <a
-                class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer active"
+              <button
+                class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer active"
                 data-testid="PluginManagerNavigationBar__home"
-                href="/"
                 title="Home"
               >
                 <span>
                   Home
                 </span>
-                <div
-                  class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-                />
-              </a>
+              </button>
+              <div
+                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+              />
             </li>
             <li
               class="flex"
             >
-              <a
-                class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+              <button
+                class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
                 data-testid="PluginManagerNavigationBar__game"
-                href="/"
                 title="Game"
               >
                 <span>
@@ -19525,18 +19469,17 @@ exports[`PluginManager should open & close featured modal 1`] = `
                 >
                   48
                 </span>
-                <div
-                  class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-                />
-              </a>
+              </button>
+              <div
+                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+              />
             </li>
             <li
               class="flex"
             >
-              <a
-                class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+              <button
+                class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
                 data-testid="PluginManagerNavigationBar__utility"
-                href="/"
                 title="Utility"
               >
                 <span>
@@ -19547,18 +19490,17 @@ exports[`PluginManager should open & close featured modal 1`] = `
                 >
                   264
                 </span>
-                <div
-                  class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-                />
-              </a>
+              </button>
+              <div
+                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+              />
             </li>
             <li
               class="flex"
             >
-              <a
-                class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+              <button
+                class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
                 data-testid="PluginManagerNavigationBar__themes"
-                href="/"
                 title="Themes"
               >
                 <span>
@@ -19569,18 +19511,17 @@ exports[`PluginManager should open & close featured modal 1`] = `
                 >
                   96
                 </span>
-                <div
-                  class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-                />
-              </a>
+              </button>
+              <div
+                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+              />
             </li>
             <li
               class="flex"
             >
-              <a
-                class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+              <button
+                class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
                 data-testid="PluginManagerNavigationBar__other"
-                href="/"
                 title="Other"
               >
                 <span>
@@ -19591,20 +19532,16 @@ exports[`PluginManager should open & close featured modal 1`] = `
                 >
                   27
                 </span>
-                <div
-                  class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-                />
-              </a>
+              </button>
             </li>
           </ul>
         </div>
         <div
           class="flex h-24"
         >
-          <a
+          <button
             class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
             data-testid="PluginManagerNavigationBar__my-plugins"
-            href="/"
             title="My Plugins"
           >
             <span>
@@ -19615,7 +19552,7 @@ exports[`PluginManager should open & close featured modal 1`] = `
             >
               8
             </span>
-          </a>
+          </button>
           <div
             class="w-px h-10 mx-8 my-auto border-r border-theme-neutral-300"
           />
@@ -21928,7 +21865,7 @@ exports[`PluginManager should open & close top rated modal 1`] = `
       </div>
     </div>
     <nav
-      class="sc-fzoXzr dkyLjt sticky md:top-24 top-20 bg-theme-neutral-100"
+      class="sc-fzoXzr gJHSCD sticky md:top-24 top-20 bg-theme-neutral-100"
       data-testid="PluginManagerNavigationBar"
     >
       <div
@@ -21941,27 +21878,25 @@ exports[`PluginManager should open & close top rated modal 1`] = `
             <li
               class="flex"
             >
-              <a
-                class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer active"
+              <button
+                class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer active"
                 data-testid="PluginManagerNavigationBar__home"
-                href="/"
                 title="Home"
               >
                 <span>
                   Home
                 </span>
-                <div
-                  class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-                />
-              </a>
+              </button>
+              <div
+                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+              />
             </li>
             <li
               class="flex"
             >
-              <a
-                class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+              <button
+                class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
                 data-testid="PluginManagerNavigationBar__game"
-                href="/"
                 title="Game"
               >
                 <span>
@@ -21972,18 +21907,17 @@ exports[`PluginManager should open & close top rated modal 1`] = `
                 >
                   48
                 </span>
-                <div
-                  class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-                />
-              </a>
+              </button>
+              <div
+                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+              />
             </li>
             <li
               class="flex"
             >
-              <a
-                class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+              <button
+                class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
                 data-testid="PluginManagerNavigationBar__utility"
-                href="/"
                 title="Utility"
               >
                 <span>
@@ -21994,18 +21928,17 @@ exports[`PluginManager should open & close top rated modal 1`] = `
                 >
                   264
                 </span>
-                <div
-                  class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-                />
-              </a>
+              </button>
+              <div
+                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+              />
             </li>
             <li
               class="flex"
             >
-              <a
-                class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+              <button
+                class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
                 data-testid="PluginManagerNavigationBar__themes"
-                href="/"
                 title="Themes"
               >
                 <span>
@@ -22016,18 +21949,17 @@ exports[`PluginManager should open & close top rated modal 1`] = `
                 >
                   96
                 </span>
-                <div
-                  class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-                />
-              </a>
+              </button>
+              <div
+                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+              />
             </li>
             <li
               class="flex"
             >
-              <a
-                class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+              <button
+                class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
                 data-testid="PluginManagerNavigationBar__other"
-                href="/"
                 title="Other"
               >
                 <span>
@@ -22038,20 +21970,16 @@ exports[`PluginManager should open & close top rated modal 1`] = `
                 >
                   27
                 </span>
-                <div
-                  class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-                />
-              </a>
+              </button>
             </li>
           </ul>
         </div>
         <div
           class="flex h-24"
         >
-          <a
+          <button
             class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
             data-testid="PluginManagerNavigationBar__my-plugins"
-            href="/"
             title="My Plugins"
           >
             <span>
@@ -22062,7 +21990,7 @@ exports[`PluginManager should open & close top rated modal 1`] = `
             >
               8
             </span>
-          </a>
+          </button>
           <div
             class="w-px h-10 mx-8 my-auto border-r border-theme-neutral-300"
           />
@@ -24375,7 +24303,7 @@ exports[`PluginManager should render 1`] = `
       </div>
     </div>
     <nav
-      class="sc-fzoXzr dkyLjt sticky md:top-24 top-20 bg-theme-neutral-100"
+      class="sc-fzoXzr gJHSCD sticky md:top-24 top-20 bg-theme-neutral-100"
       data-testid="PluginManagerNavigationBar"
     >
       <div
@@ -24388,27 +24316,25 @@ exports[`PluginManager should render 1`] = `
             <li
               class="flex"
             >
-              <a
-                class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer active"
+              <button
+                class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer active"
                 data-testid="PluginManagerNavigationBar__home"
-                href="/"
                 title="Home"
               >
                 <span>
                   Home
                 </span>
-                <div
-                  class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-                />
-              </a>
+              </button>
+              <div
+                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+              />
             </li>
             <li
               class="flex"
             >
-              <a
-                class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+              <button
+                class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
                 data-testid="PluginManagerNavigationBar__game"
-                href="/"
                 title="Game"
               >
                 <span>
@@ -24419,18 +24345,17 @@ exports[`PluginManager should render 1`] = `
                 >
                   48
                 </span>
-                <div
-                  class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-                />
-              </a>
+              </button>
+              <div
+                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+              />
             </li>
             <li
               class="flex"
             >
-              <a
-                class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+              <button
+                class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
                 data-testid="PluginManagerNavigationBar__utility"
-                href="/"
                 title="Utility"
               >
                 <span>
@@ -24441,18 +24366,17 @@ exports[`PluginManager should render 1`] = `
                 >
                   264
                 </span>
-                <div
-                  class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-                />
-              </a>
+              </button>
+              <div
+                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+              />
             </li>
             <li
               class="flex"
             >
-              <a
-                class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+              <button
+                class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
                 data-testid="PluginManagerNavigationBar__themes"
-                href="/"
                 title="Themes"
               >
                 <span>
@@ -24463,18 +24387,17 @@ exports[`PluginManager should render 1`] = `
                 >
                   96
                 </span>
-                <div
-                  class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-                />
-              </a>
+              </button>
+              <div
+                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+              />
             </li>
             <li
               class="flex"
             >
-              <a
-                class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+              <button
+                class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
                 data-testid="PluginManagerNavigationBar__other"
-                href="/"
                 title="Other"
               >
                 <span>
@@ -24485,20 +24408,16 @@ exports[`PluginManager should render 1`] = `
                 >
                   27
                 </span>
-                <div
-                  class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-                />
-              </a>
+              </button>
             </li>
           </ul>
         </div>
         <div
           class="flex h-24"
         >
-          <a
+          <button
             class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
             data-testid="PluginManagerNavigationBar__my-plugins"
-            href="/"
             title="My Plugins"
           >
             <span>
@@ -24509,7 +24428,7 @@ exports[`PluginManager should render 1`] = `
             >
               8
             </span>
-          </a>
+          </button>
           <div
             class="w-px h-10 mx-8 my-auto border-r border-theme-neutral-300"
           />
@@ -26840,7 +26759,7 @@ exports[`PluginManager should search for plugin 1`] = `
       </div>
     </div>
     <nav
-      class="sc-fzoXzr dkyLjt sticky md:top-24 top-20 bg-theme-neutral-100"
+      class="sc-fzoXzr gJHSCD sticky md:top-24 top-20 bg-theme-neutral-100"
       data-testid="PluginManagerNavigationBar"
     >
       <div
@@ -26853,27 +26772,25 @@ exports[`PluginManager should search for plugin 1`] = `
             <li
               class="flex"
             >
-              <a
-                class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer active"
+              <button
+                class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer active"
                 data-testid="PluginManagerNavigationBar__home"
-                href="/"
                 title="Home"
               >
                 <span>
                   Home
                 </span>
-                <div
-                  class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-                />
-              </a>
+              </button>
+              <div
+                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+              />
             </li>
             <li
               class="flex"
             >
-              <a
-                class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+              <button
+                class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
                 data-testid="PluginManagerNavigationBar__game"
-                href="/"
                 title="Game"
               >
                 <span>
@@ -26884,18 +26801,17 @@ exports[`PluginManager should search for plugin 1`] = `
                 >
                   48
                 </span>
-                <div
-                  class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-                />
-              </a>
+              </button>
+              <div
+                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+              />
             </li>
             <li
               class="flex"
             >
-              <a
-                class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+              <button
+                class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
                 data-testid="PluginManagerNavigationBar__utility"
-                href="/"
                 title="Utility"
               >
                 <span>
@@ -26906,18 +26822,17 @@ exports[`PluginManager should search for plugin 1`] = `
                 >
                   264
                 </span>
-                <div
-                  class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-                />
-              </a>
+              </button>
+              <div
+                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+              />
             </li>
             <li
               class="flex"
             >
-              <a
-                class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+              <button
+                class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
                 data-testid="PluginManagerNavigationBar__themes"
-                href="/"
                 title="Themes"
               >
                 <span>
@@ -26928,18 +26843,17 @@ exports[`PluginManager should search for plugin 1`] = `
                 >
                   96
                 </span>
-                <div
-                  class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-                />
-              </a>
+              </button>
+              <div
+                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+              />
             </li>
             <li
               class="flex"
             >
-              <a
-                class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+              <button
+                class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
                 data-testid="PluginManagerNavigationBar__other"
-                href="/"
                 title="Other"
               >
                 <span>
@@ -26950,20 +26864,16 @@ exports[`PluginManager should search for plugin 1`] = `
                 >
                   27
                 </span>
-                <div
-                  class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-                />
-              </a>
+              </button>
             </li>
           </ul>
         </div>
         <div
           class="flex h-24"
         >
-          <a
+          <button
             class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
             data-testid="PluginManagerNavigationBar__my-plugins"
-            href="/"
             title="My Plugins"
           >
             <span>
@@ -26974,7 +26884,7 @@ exports[`PluginManager should search for plugin 1`] = `
             >
               8
             </span>
-          </a>
+          </button>
           <div
             class="w-px h-10 mx-8 my-auto border-r border-theme-neutral-300"
           />
@@ -29287,7 +29197,7 @@ exports[`PluginManager should select plugin on game grid 1`] = `
       </div>
     </div>
     <nav
-      class="sc-fzoXzr dkyLjt sticky md:top-24 top-20 bg-theme-neutral-100"
+      class="sc-fzoXzr gJHSCD sticky md:top-24 top-20 bg-theme-neutral-100"
       data-testid="PluginManagerNavigationBar"
     >
       <div
@@ -29300,27 +29210,25 @@ exports[`PluginManager should select plugin on game grid 1`] = `
             <li
               class="flex"
             >
-              <a
-                class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+              <button
+                class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
                 data-testid="PluginManagerNavigationBar__home"
-                href="/"
                 title="Home"
               >
                 <span>
                   Home
                 </span>
-                <div
-                  class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-                />
-              </a>
+              </button>
+              <div
+                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+              />
             </li>
             <li
               class="flex"
             >
-              <a
-                class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer active"
+              <button
+                class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer active"
                 data-testid="PluginManagerNavigationBar__game"
-                href="/"
                 title="Game"
               >
                 <span>
@@ -29331,18 +29239,17 @@ exports[`PluginManager should select plugin on game grid 1`] = `
                 >
                   48
                 </span>
-                <div
-                  class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-                />
-              </a>
+              </button>
+              <div
+                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+              />
             </li>
             <li
               class="flex"
             >
-              <a
-                class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+              <button
+                class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
                 data-testid="PluginManagerNavigationBar__utility"
-                href="/"
                 title="Utility"
               >
                 <span>
@@ -29353,18 +29260,17 @@ exports[`PluginManager should select plugin on game grid 1`] = `
                 >
                   264
                 </span>
-                <div
-                  class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-                />
-              </a>
+              </button>
+              <div
+                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+              />
             </li>
             <li
               class="flex"
             >
-              <a
-                class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+              <button
+                class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
                 data-testid="PluginManagerNavigationBar__themes"
-                href="/"
                 title="Themes"
               >
                 <span>
@@ -29375,18 +29281,17 @@ exports[`PluginManager should select plugin on game grid 1`] = `
                 >
                   96
                 </span>
-                <div
-                  class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-                />
-              </a>
+              </button>
+              <div
+                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+              />
             </li>
             <li
               class="flex"
             >
-              <a
-                class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+              <button
+                class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
                 data-testid="PluginManagerNavigationBar__other"
-                href="/"
                 title="Other"
               >
                 <span>
@@ -29397,20 +29302,16 @@ exports[`PluginManager should select plugin on game grid 1`] = `
                 >
                   27
                 </span>
-                <div
-                  class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-                />
-              </a>
+              </button>
             </li>
           </ul>
         </div>
         <div
           class="flex h-24"
         >
-          <a
+          <button
             class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
             data-testid="PluginManagerNavigationBar__my-plugins"
-            href="/"
             title="My Plugins"
           >
             <span>
@@ -29421,7 +29322,7 @@ exports[`PluginManager should select plugin on game grid 1`] = `
             >
               8
             </span>
-          </a>
+          </button>
           <div
             class="w-px h-10 mx-8 my-auto border-r border-theme-neutral-300"
           />
@@ -31406,7 +31307,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
       </div>
     </div>
     <nav
-      class="sc-fzoXzr dkyLjt sticky md:top-24 top-20 bg-theme-neutral-100"
+      class="sc-fzoXzr gJHSCD sticky md:top-24 top-20 bg-theme-neutral-100"
       data-testid="PluginManagerNavigationBar"
     >
       <div
@@ -31419,27 +31320,25 @@ exports[`PluginManager should select plugin on home grids 1`] = `
             <li
               class="flex"
             >
-              <a
-                class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer active"
+              <button
+                class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer active"
                 data-testid="PluginManagerNavigationBar__home"
-                href="/"
                 title="Home"
               >
                 <span>
                   Home
                 </span>
-                <div
-                  class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-                />
-              </a>
+              </button>
+              <div
+                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+              />
             </li>
             <li
               class="flex"
             >
-              <a
-                class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+              <button
+                class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
                 data-testid="PluginManagerNavigationBar__game"
-                href="/"
                 title="Game"
               >
                 <span>
@@ -31450,18 +31349,17 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                 >
                   48
                 </span>
-                <div
-                  class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-                />
-              </a>
+              </button>
+              <div
+                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+              />
             </li>
             <li
               class="flex"
             >
-              <a
-                class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+              <button
+                class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
                 data-testid="PluginManagerNavigationBar__utility"
-                href="/"
                 title="Utility"
               >
                 <span>
@@ -31472,18 +31370,17 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                 >
                   264
                 </span>
-                <div
-                  class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-                />
-              </a>
+              </button>
+              <div
+                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+              />
             </li>
             <li
               class="flex"
             >
-              <a
-                class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+              <button
+                class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
                 data-testid="PluginManagerNavigationBar__themes"
-                href="/"
                 title="Themes"
               >
                 <span>
@@ -31494,18 +31391,17 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                 >
                   96
                 </span>
-                <div
-                  class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-                />
-              </a>
+              </button>
+              <div
+                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+              />
             </li>
             <li
               class="flex"
             >
-              <a
-                class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+              <button
+                class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
                 data-testid="PluginManagerNavigationBar__other"
-                href="/"
                 title="Other"
               >
                 <span>
@@ -31516,20 +31412,16 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                 >
                   27
                 </span>
-                <div
-                  class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-                />
-              </a>
+              </button>
             </li>
           </ul>
         </div>
         <div
           class="flex h-24"
         >
-          <a
+          <button
             class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
             data-testid="PluginManagerNavigationBar__my-plugins"
-            href="/"
             title="My Plugins"
           >
             <span>
@@ -31540,7 +31432,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
             >
               8
             </span>
-          </a>
+          </button>
           <div
             class="w-px h-10 mx-8 my-auto border-r border-theme-neutral-300"
           />
@@ -33853,7 +33745,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
       </div>
     </div>
     <nav
-      class="sc-fzoXzr dkyLjt sticky md:top-24 top-20 bg-theme-neutral-100"
+      class="sc-fzoXzr gJHSCD sticky md:top-24 top-20 bg-theme-neutral-100"
       data-testid="PluginManagerNavigationBar"
     >
       <div
@@ -33866,27 +33758,25 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
             <li
               class="flex"
             >
-              <a
-                class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+              <button
+                class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
                 data-testid="PluginManagerNavigationBar__home"
-                href="/"
                 title="Home"
               >
                 <span>
                   Home
                 </span>
-                <div
-                  class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-                />
-              </a>
+              </button>
+              <div
+                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+              />
             </li>
             <li
               class="flex"
             >
-              <a
-                class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer active"
+              <button
+                class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer active"
                 data-testid="PluginManagerNavigationBar__game"
-                href="/"
                 title="Game"
               >
                 <span>
@@ -33897,18 +33787,17 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
                 >
                   48
                 </span>
-                <div
-                  class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-                />
-              </a>
+              </button>
+              <div
+                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+              />
             </li>
             <li
               class="flex"
             >
-              <a
-                class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+              <button
+                class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
                 data-testid="PluginManagerNavigationBar__utility"
-                href="/"
                 title="Utility"
               >
                 <span>
@@ -33919,18 +33808,17 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
                 >
                   264
                 </span>
-                <div
-                  class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-                />
-              </a>
+              </button>
+              <div
+                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+              />
             </li>
             <li
               class="flex"
             >
-              <a
-                class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+              <button
+                class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
                 data-testid="PluginManagerNavigationBar__themes"
-                href="/"
                 title="Themes"
               >
                 <span>
@@ -33941,18 +33829,17 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
                 >
                   96
                 </span>
-                <div
-                  class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-                />
-              </a>
+              </button>
+              <div
+                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+              />
             </li>
             <li
               class="flex"
             >
-              <a
-                class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+              <button
+                class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
                 data-testid="PluginManagerNavigationBar__other"
-                href="/"
                 title="Other"
               >
                 <span>
@@ -33963,20 +33850,16 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
                 >
                   27
                 </span>
-                <div
-                  class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-                />
-              </a>
+              </button>
             </li>
           </ul>
         </div>
         <div
           class="flex h-24"
         >
-          <a
+          <button
             class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
             data-testid="PluginManagerNavigationBar__my-plugins"
-            href="/"
             title="My Plugins"
           >
             <span>
@@ -33987,7 +33870,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
             >
               8
             </span>
-          </a>
+          </button>
           <div
             class="w-px h-10 mx-8 my-auto border-r border-theme-neutral-300"
           />
@@ -35972,7 +35855,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
       </div>
     </div>
     <nav
-      class="sc-fzoXzr dkyLjt sticky md:top-24 top-20 bg-theme-neutral-100"
+      class="sc-fzoXzr gJHSCD sticky md:top-24 top-20 bg-theme-neutral-100"
       data-testid="PluginManagerNavigationBar"
     >
       <div
@@ -35985,27 +35868,25 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
             <li
               class="flex"
             >
-              <a
-                class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer active"
+              <button
+                class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer active"
                 data-testid="PluginManagerNavigationBar__home"
-                href="/"
                 title="Home"
               >
                 <span>
                   Home
                 </span>
-                <div
-                  class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-                />
-              </a>
+              </button>
+              <div
+                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+              />
             </li>
             <li
               class="flex"
             >
-              <a
-                class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+              <button
+                class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
                 data-testid="PluginManagerNavigationBar__game"
-                href="/"
                 title="Game"
               >
                 <span>
@@ -36016,18 +35897,17 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                 >
                   48
                 </span>
-                <div
-                  class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-                />
-              </a>
+              </button>
+              <div
+                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+              />
             </li>
             <li
               class="flex"
             >
-              <a
-                class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+              <button
+                class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
                 data-testid="PluginManagerNavigationBar__utility"
-                href="/"
                 title="Utility"
               >
                 <span>
@@ -36038,18 +35918,17 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                 >
                   264
                 </span>
-                <div
-                  class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-                />
-              </a>
+              </button>
+              <div
+                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+              />
             </li>
             <li
               class="flex"
             >
-              <a
-                class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+              <button
+                class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
                 data-testid="PluginManagerNavigationBar__themes"
-                href="/"
                 title="Themes"
               >
                 <span>
@@ -36060,18 +35939,17 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                 >
                   96
                 </span>
-                <div
-                  class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-                />
-              </a>
+              </button>
+              <div
+                class="w-px h-4 my-auto mx-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
+              />
             </li>
             <li
               class="flex"
             >
-              <a
-                class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
+              <button
+                class="PluginManagerNavigationBar__item flex items-center font-bold text-md text-theme-neutral-600 cursor-pointer "
                 data-testid="PluginManagerNavigationBar__other"
-                href="/"
                 title="Other"
               >
                 <span>
@@ -36082,20 +35960,16 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                 >
                   27
                 </span>
-                <div
-                  class="w-px h-4 pl-6 border-r PluginManagerNavigationBar__menu-divider border-theme-neutral-300"
-                />
-              </a>
+              </button>
             </li>
           </ul>
         </div>
         <div
           class="flex h-24"
         >
-          <a
+          <button
             class="PluginManagerNavigationBar__item flex items-center pl-6 font-bold text-md text-theme-neutral-600 cursor-pointer "
             data-testid="PluginManagerNavigationBar__my-plugins"
-            href="/"
             title="My Plugins"
           >
             <span>
@@ -36106,7 +35980,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
             >
               8
             </span>
-          </a>
+          </button>
           <div
             class="w-px h-10 mx-8 my-auto border-r border-theme-neutral-300"
           />

--- a/src/domains/profile/pages/CreateProfile/__snapshots__/CreateProfile.test.tsx.snap
+++ b/src/domains/profile/pages/CreateProfile/__snapshots__/CreateProfile.test.tsx.snap
@@ -63,7 +63,7 @@ exports[`CreateProfile should render 1`] = `
           </button>
         </div>
         <div
-          class="sc-AxirZ cLgKLC border-theme-neutral-300"
+          class="sc-AxirZ jjvtQn border-theme-neutral-300"
           type="horizontal"
         />
         <form
@@ -360,7 +360,7 @@ exports[`CreateProfile should render 1`] = `
               </ul>
             </div>
             <div
-              class="sc-AxirZ bTLcec border-theme-neutral-300"
+              class="sc-AxirZ jJscrd border-theme-neutral-300"
               type="horizontal"
             />
           </div>

--- a/src/domains/profile/pages/Welcome/__snapshots__/Welcome.test.tsx.snap
+++ b/src/domains/profile/pages/Welcome/__snapshots__/Welcome.test.tsx.snap
@@ -301,7 +301,7 @@ exports[`Welcome should render with profiles 1`] = `
           </div>
         </div>
         <div
-          class="sc-AxirZ cLgKLC border-theme-neutral-300"
+          class="sc-AxirZ jjvtQn border-theme-neutral-300"
           type="horizontal"
         />
         <p

--- a/src/domains/setting/pages/Settings/__snapshots__/Settings.test.tsx.snap
+++ b/src/domains/setting/pages/Settings/__snapshots__/Settings.test.tsx.snap
@@ -320,7 +320,7 @@ exports[`Settings should open & close modals in the plugin settings 1`] = `
           </li>
         </ul>
         <div
-          class="sc-fzoyAV iPIqIV border-theme-neutral-300"
+          class="sc-fzoyAV exnPWc border-theme-neutral-300"
           type="horizontal"
         />
         <div
@@ -1846,7 +1846,7 @@ exports[`Settings should render peer settings 1`] = `
           class="pt-2 pb-4"
         >
           <div
-            class="sc-fzoyAV iPIqIV border-theme-neutral-300"
+            class="sc-fzoyAV exnPWc border-theme-neutral-300"
             type="horizontal"
           />
         </div>
@@ -2187,7 +2187,7 @@ exports[`Settings should render plugin settings 1`] = `
           </li>
         </ul>
         <div
-          class="sc-fzoyAV iPIqIV border-theme-neutral-300"
+          class="sc-fzoyAV exnPWc border-theme-neutral-300"
           type="horizontal"
         />
         <div

--- a/src/domains/transaction/components/SendTransactionForm/__snapshots__/SendTransactionForm.test.tsx.snap
+++ b/src/domains/transaction/components/SendTransactionForm/__snapshots__/SendTransactionForm.test.tsx.snap
@@ -249,7 +249,7 @@ exports[`SendTransactionForm should emit goBack button click 1`] = `
               </div>
             </button>
             <div
-              class="sc-fznKkj jozjVI border-theme-neutral-300"
+              class="sc-fznKkj kZHPHw border-theme-neutral-300"
               type="vertical"
             />
             <button
@@ -340,7 +340,7 @@ exports[`SendTransactionForm should emit goBack button click 1`] = `
               </div>
             </button>
             <div
-              class="sc-fznKkj jozjVI border-theme-neutral-300"
+              class="sc-fznKkj kZHPHw border-theme-neutral-300"
               type="vertical"
             />
             <button
@@ -814,7 +814,7 @@ exports[`SendTransactionForm should not call onBack callback if not provided 1`]
               </div>
             </button>
             <div
-              class="sc-fznKkj jozjVI border-theme-neutral-300"
+              class="sc-fznKkj kZHPHw border-theme-neutral-300"
               type="vertical"
             />
             <button
@@ -905,7 +905,7 @@ exports[`SendTransactionForm should not call onBack callback if not provided 1`]
               </div>
             </button>
             <div
-              class="sc-fznKkj jozjVI border-theme-neutral-300"
+              class="sc-fznKkj kZHPHw border-theme-neutral-300"
               type="vertical"
             />
             <button
@@ -1379,7 +1379,7 @@ exports[`SendTransactionForm should not call onSubmit callback if not provided 1
               </div>
             </button>
             <div
-              class="sc-fznKkj jozjVI border-theme-neutral-300"
+              class="sc-fznKkj kZHPHw border-theme-neutral-300"
               type="vertical"
             />
             <button
@@ -1470,7 +1470,7 @@ exports[`SendTransactionForm should not call onSubmit callback if not provided 1
               </div>
             </button>
             <div
-              class="sc-fznKkj jozjVI border-theme-neutral-300"
+              class="sc-fznKkj kZHPHw border-theme-neutral-300"
               type="vertical"
             />
             <button
@@ -1836,7 +1836,7 @@ exports[`SendTransactionForm should render 1`] = `
               </div>
             </button>
             <div
-              class="sc-fznKkj jozjVI border-theme-neutral-300"
+              class="sc-fznKkj kZHPHw border-theme-neutral-300"
               type="vertical"
             />
             <button
@@ -1927,7 +1927,7 @@ exports[`SendTransactionForm should render 1`] = `
               </div>
             </button>
             <div
-              class="sc-fznKkj jozjVI border-theme-neutral-300"
+              class="sc-fznKkj kZHPHw border-theme-neutral-300"
               type="vertical"
             />
             <button
@@ -2407,7 +2407,7 @@ exports[`SendTransactionForm should select recipient 1`] = `
               </div>
             </button>
             <div
-              class="sc-fznKkj jozjVI border-theme-neutral-300"
+              class="sc-fznKkj kZHPHw border-theme-neutral-300"
               type="vertical"
             />
             <button
@@ -2504,7 +2504,7 @@ exports[`SendTransactionForm should select recipient 1`] = `
               </div>
             </button>
             <div
-              class="sc-fznKkj jozjVI border-theme-neutral-300"
+              class="sc-fznKkj kZHPHw border-theme-neutral-300"
               type="vertical"
             />
             <button
@@ -3004,7 +3004,7 @@ exports[`SendTransactionForm should select sender 1`] = `
               </div>
             </button>
             <div
-              class="sc-fznKkj jozjVI border-theme-neutral-300"
+              class="sc-fznKkj kZHPHw border-theme-neutral-300"
               type="vertical"
             />
             <button
@@ -3115,7 +3115,7 @@ exports[`SendTransactionForm should select sender 1`] = `
               </div>
             </button>
             <div
-              class="sc-fznKkj jozjVI border-theme-neutral-300"
+              class="sc-fznKkj kZHPHw border-theme-neutral-300"
               type="vertical"
             />
             <button
@@ -3481,7 +3481,7 @@ exports[`SendTransactionForm should set available amount 1`] = `
               </div>
             </button>
             <div
-              class="sc-fznKkj jozjVI border-theme-neutral-300"
+              class="sc-fznKkj kZHPHw border-theme-neutral-300"
               type="vertical"
             />
             <button
@@ -3572,7 +3572,7 @@ exports[`SendTransactionForm should set available amount 1`] = `
               </div>
             </button>
             <div
-              class="sc-fznKkj jozjVI border-theme-neutral-300"
+              class="sc-fznKkj kZHPHw border-theme-neutral-300"
               type="vertical"
             />
             <button
@@ -4046,7 +4046,7 @@ exports[`SendTransactionForm should submit form 1`] = `
               </div>
             </button>
             <div
-              class="sc-fznKkj jozjVI border-theme-neutral-300"
+              class="sc-fznKkj kZHPHw border-theme-neutral-300"
               type="vertical"
             />
             <button
@@ -4137,7 +4137,7 @@ exports[`SendTransactionForm should submit form 1`] = `
               </div>
             </button>
             <div
-              class="sc-fznKkj jozjVI border-theme-neutral-300"
+              class="sc-fznKkj kZHPHw border-theme-neutral-300"
               type="vertical"
             />
             <button

--- a/src/domains/transaction/pages/TransactionSend/__snapshots__/TransactionSend.test.tsx.snap
+++ b/src/domains/transaction/pages/TransactionSend/__snapshots__/TransactionSend.test.tsx.snap
@@ -194,7 +194,7 @@ exports[`Transaction Send should render 1`] = `
                           </div>
                         </button>
                         <div
-                          class="sc-fzoyAV futolF border-theme-neutral-300"
+                          class="sc-fzoyAV staLB border-theme-neutral-300"
                           type="vertical"
                         />
                         <button
@@ -303,7 +303,7 @@ exports[`Transaction Send should render 1`] = `
                           </div>
                         </button>
                         <div
-                          class="sc-fzoyAV futolF border-theme-neutral-300"
+                          class="sc-fzoyAV staLB border-theme-neutral-300"
                           type="vertical"
                         />
                         <button
@@ -702,7 +702,7 @@ exports[`Transaction Send should render 1st step 1`] = `
                   </div>
                 </button>
                 <div
-                  class="sc-fzoyAV futolF border-theme-neutral-300"
+                  class="sc-fzoyAV staLB border-theme-neutral-300"
                   type="vertical"
                 />
                 <button
@@ -811,7 +811,7 @@ exports[`Transaction Send should render 1st step 1`] = `
                   </div>
                 </button>
                 <div
-                  class="sc-fzoyAV futolF border-theme-neutral-300"
+                  class="sc-fzoyAV staLB border-theme-neutral-300"
                   type="vertical"
                 />
                 <button

--- a/src/domains/wallet/components/ReceiveFunds/__snapshots__/ReceiveFunds.test.tsx.snap
+++ b/src/domains/wallet/components/ReceiveFunds/__snapshots__/ReceiveFunds.test.tsx.snap
@@ -83,7 +83,7 @@ exports[`ReceiveFunds should render with a wallet name 1`] = `
               </div>
             </div>
             <div
-              class="sc-AxirZ bTLcec border-theme-neutral-300"
+              class="sc-AxirZ jJscrd border-theme-neutral-300"
               type="horizontal"
             />
           </div>
@@ -139,7 +139,7 @@ exports[`ReceiveFunds should render with a wallet name 1`] = `
             </div>
           </div>
           <div
-            class="sc-AxirZ bTLcec border-theme-neutral-300"
+            class="sc-AxirZ jJscrd border-theme-neutral-300"
             type="horizontal"
           />
         </div>
@@ -268,7 +268,7 @@ exports[`ReceiveFunds should render without a wallet name 1`] = `
             </div>
           </div>
           <div
-            class="sc-AxirZ bTLcec border-theme-neutral-300"
+            class="sc-AxirZ jJscrd border-theme-neutral-300"
             type="horizontal"
           />
         </div>

--- a/src/domains/wallet/pages/CreateWallet/__snapshots__/CreateWallet.test.tsx.snap
+++ b/src/domains/wallet/pages/CreateWallet/__snapshots__/CreateWallet.test.tsx.snap
@@ -618,7 +618,7 @@ exports[`CreateWallet should render 2nd step 1`] = `
       </div>
     </div>
     <div
-      class="sc-AxgMl fujBvH border-theme-neutral-300"
+      class="sc-AxgMl fHSugy border-theme-neutral-300"
       type="horizontal"
     />
     <div
@@ -674,7 +674,7 @@ exports[`CreateWallet should render 2nd step 1`] = `
       </div>
     </div>
     <div
-      class="sc-AxgMl fujBvH border-theme-neutral-300"
+      class="sc-AxgMl fHSugy border-theme-neutral-300"
       type="horizontal"
     />
   </section>
@@ -741,7 +741,7 @@ exports[`CreateWallet should render 4th step 1`] = `
       </li>
       <li>
         <div
-          class="sc-AxgMl fujBvH border-theme-neutral-300"
+          class="sc-AxgMl fHSugy border-theme-neutral-300"
           type="horizontal"
         />
       </li>
@@ -766,7 +766,7 @@ exports[`CreateWallet should render 4th step 1`] = `
       </li>
     </ul>
     <div
-      class="sc-AxgMl fujBvH border-theme-neutral-300"
+      class="sc-AxgMl fHSugy border-theme-neutral-300"
       type="horizontal"
     />
     <fieldset


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Fixes the paddings of the plugin navigationbar items to match the designs. Also replaces the anchor tags with buttons so they can be activated without changing url in the storybook.

![image](https://user-images.githubusercontent.com/6547002/87001072-e77a9300-c1b6-11ea-81bc-220ba71daadc.png)

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
