### PR TITLE
refactor: remove white shadow from `shadow-xl`

### DIFF
--- a/src/app/components/SearchBar/SearchBarPluginFilters/__snapshots__/SearchBarPluginFilters.test.tsx.snap
+++ b/src/app/components/SearchBar/SearchBarPluginFilters/__snapshots__/SearchBarPluginFilters.test.tsx.snap
@@ -53,7 +53,7 @@ exports[`SearchBarPluginFilters should render categories 1`] = `
         </div>
       </span>
       <div
-        class="sc-AxiKw bvzlGg left-0 undefined"
+        class="sc-AxiKw icyLii left-0 undefined"
       >
         <div
           data-testid="dropdown__content"
@@ -576,7 +576,7 @@ exports[`SearchBarPluginFilters should render ratings 1`] = `
         </div>
       </span>
       <div
-        class="sc-AxiKw bvzlGg left-0 undefined"
+        class="sc-AxiKw icyLii left-0 undefined"
       >
         <div
           data-testid="dropdown__content"

--- a/src/app/components/SelectDropdown/__snapshots__/SelectDropdown.test.tsx.snap
+++ b/src/app/components/SelectDropdown/__snapshots__/SelectDropdown.test.tsx.snap
@@ -27,7 +27,7 @@ exports[`SelectDropdown should render 1`] = `
         />
         <ul
           aria-labelledby="downshift-0-label"
-          class="sc-fzoLsD ciCmXo"
+          class="sc-fzoLsD jbAlKS"
           id="downshift-0-menu"
           role="listbox"
           tabindex="-1"
@@ -79,7 +79,7 @@ exports[`SelectDropdown should render disabled 1`] = `
         />
         <ul
           aria-labelledby="downshift-2-label"
-          class="sc-fzoLsD ciCmXo"
+          class="sc-fzoLsD jbAlKS"
           id="downshift-2-menu"
           role="listbox"
           tabindex="-1"
@@ -131,7 +131,7 @@ exports[`SelectDropdown should render invalid 1`] = `
         />
         <ul
           aria-labelledby="downshift-1-label"
-          class="sc-fzoLsD ciCmXo"
+          class="sc-fzoLsD jbAlKS"
           id="downshift-1-menu"
           role="listbox"
           tabindex="-1"
@@ -182,7 +182,7 @@ exports[`SelectDropdown should render with empty options 1`] = `
         />
         <ul
           aria-labelledby="downshift-5-label"
-          class="sc-fzoLsD ciCmXo"
+          class="sc-fzoLsD jbAlKS"
           id="downshift-5-menu"
           role="listbox"
           tabindex="-1"
@@ -235,7 +235,7 @@ exports[`SelectDropdown should render with initial default value 1`] = `
         </button>
         <ul
           aria-labelledby="downshift-3-label"
-          class="sc-fzoLsD ciCmXo"
+          class="sc-fzoLsD jbAlKS"
           id="downshift-3-menu"
           role="listbox"
           tabindex="-1"
@@ -286,7 +286,7 @@ exports[`SelectDropdown should render with options values as numbers 1`] = `
         />
         <ul
           aria-labelledby="downshift-6-label"
-          class="sc-fzoLsD ciCmXo"
+          class="sc-fzoLsD jbAlKS"
           id="downshift-6-menu"
           role="listbox"
           tabindex="-1"
@@ -337,7 +337,7 @@ exports[`SelectDropdown should render with wrong default value 1`] = `
         />
         <ul
           aria-labelledby="downshift-4-label"
-          class="sc-fzoLsD ciCmXo"
+          class="sc-fzoLsD jbAlKS"
           id="downshift-4-menu"
           role="listbox"
           tabindex="-1"

--- a/src/domains/exchange/components/ExchangeCard/__snapshots__/ExchangeCard.test.tsx.snap
+++ b/src/domains/exchange/components/ExchangeCard/__snapshots__/ExchangeCard.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`ExchangeCard should render Add Exchange card 1`] = `
 <div>
   <div
-    class="sc-AxiKw gsaGVU col-span-2 border-theme-primary-100"
+    class="sc-AxiKw zaMrG col-span-2 border-theme-primary-100"
     data-testid="Exchange__add-exchange-card"
   >
     <div
@@ -27,7 +27,7 @@ exports[`ExchangeCard should render Add Exchange card 1`] = `
 exports[`ExchangeCard should render Blank Exchange card 1`] = `
 <div>
   <div
-    class="sc-AxiKw gsaGVU border-theme-primary-100"
+    class="sc-AxiKw zaMrG border-theme-primary-100"
     data-testid="Exchange__blank-card"
   >
     <div
@@ -45,7 +45,7 @@ exports[`ExchangeCard should render Blank Exchange card 1`] = `
 exports[`ExchangeCard should render Exchange card 1`] = `
 <div>
   <div
-    class="sc-AxiKw gsaGVU border-theme-primary-100 hover:border-theme-background"
+    class="sc-AxiKw zaMrG border-theme-primary-100 hover:border-theme-background"
     data-testid="Exchange__exchange-card-test-exchange"
   >
     <div

--- a/src/domains/exchange/pages/Exchange/__snapshots__/Exchange.test.tsx.snap
+++ b/src/domains/exchange/pages/Exchange/__snapshots__/Exchange.test.tsx.snap
@@ -51,7 +51,7 @@ exports[`Exchange should not render filler exchange cards 1`] = `
                   style="height: 155px;"
                 >
                   <div
-                    class="sc-AxgMl hGLWbv border-theme-primary-100 hover:border-theme-background"
+                    class="sc-AxgMl kYFwyN border-theme-primary-100 hover:border-theme-background"
                     data-testid="Exchange__exchange-card-changenow-plugin"
                   >
                     <div
@@ -105,7 +105,7 @@ exports[`Exchange should not render filler exchange cards 1`] = `
                   style="height: 155px;"
                 >
                   <div
-                    class="sc-AxgMl hGLWbv border-theme-primary-100 hover:border-theme-background"
+                    class="sc-AxgMl kYFwyN border-theme-primary-100 hover:border-theme-background"
                     data-testid="Exchange__exchange-card-binance"
                   >
                     <div
@@ -159,7 +159,7 @@ exports[`Exchange should not render filler exchange cards 1`] = `
                   style="height: 155px;"
                 >
                   <div
-                    class="sc-AxgMl hGLWbv border-theme-primary-100 hover:border-theme-background"
+                    class="sc-AxgMl kYFwyN border-theme-primary-100 hover:border-theme-background"
                     data-testid="Exchange__exchange-card-atomars"
                   >
                     <div
@@ -213,7 +213,7 @@ exports[`Exchange should not render filler exchange cards 1`] = `
                   style="height: 155px;"
                 >
                   <div
-                    class="sc-AxgMl hGLWbv col-span-2 border-theme-primary-100"
+                    class="sc-AxgMl kYFwyN col-span-2 border-theme-primary-100"
                     data-testid="Exchange__add-exchange-card"
                   >
                     <div
@@ -316,7 +316,7 @@ exports[`Exchange should open & close add exchange modal 1`] = `
                   style="height: 155px;"
                 >
                   <div
-                    class="sc-AxgMl hGLWbv border-theme-primary-100 hover:border-theme-background"
+                    class="sc-AxgMl kYFwyN border-theme-primary-100 hover:border-theme-background"
                     data-testid="Exchange__exchange-card-changenow-plugin"
                   >
                     <div
@@ -370,7 +370,7 @@ exports[`Exchange should open & close add exchange modal 1`] = `
                   style="height: 155px;"
                 >
                   <div
-                    class="sc-AxgMl hGLWbv border-theme-primary-100 hover:border-theme-background"
+                    class="sc-AxgMl kYFwyN border-theme-primary-100 hover:border-theme-background"
                     data-testid="Exchange__exchange-card-binance"
                   >
                     <div
@@ -424,7 +424,7 @@ exports[`Exchange should open & close add exchange modal 1`] = `
                   style="height: 155px;"
                 >
                   <div
-                    class="sc-AxgMl hGLWbv border-theme-primary-100 hover:border-theme-background"
+                    class="sc-AxgMl kYFwyN border-theme-primary-100 hover:border-theme-background"
                     data-testid="Exchange__exchange-card-atomars"
                   >
                     <div
@@ -478,7 +478,7 @@ exports[`Exchange should open & close add exchange modal 1`] = `
                   style="height: 155px;"
                 >
                   <div
-                    class="sc-AxgMl hGLWbv col-span-2 border-theme-primary-100"
+                    class="sc-AxgMl kYFwyN col-span-2 border-theme-primary-100"
                     data-testid="Exchange__add-exchange-card"
                   >
                     <div
@@ -581,7 +581,7 @@ exports[`Exchange should open & close add exchange modal when no existing exchan
             </div>
           </div>
           <div
-            class="sc-AxgMl hGLWbv col-span-2 border-theme-primary-100"
+            class="sc-AxgMl kYFwyN col-span-2 border-theme-primary-100"
             data-testid="Exchange__add-exchange-card"
           >
             <div
@@ -666,7 +666,7 @@ exports[`Exchange should render 1`] = `
             </div>
           </div>
           <div
-            class="sc-AxgMl hGLWbv col-span-2 border-theme-primary-100"
+            class="sc-AxgMl kYFwyN col-span-2 border-theme-primary-100"
             data-testid="Exchange__add-exchange-card"
           >
             <div
@@ -751,7 +751,7 @@ exports[`Exchange should render with exchanges 1`] = `
                   style="height: 155px;"
                 >
                   <div
-                    class="sc-AxgMl hGLWbv border-theme-primary-100 hover:border-theme-background"
+                    class="sc-AxgMl kYFwyN border-theme-primary-100 hover:border-theme-background"
                     data-testid="Exchange__exchange-card-changenow-plugin"
                   >
                     <div
@@ -805,7 +805,7 @@ exports[`Exchange should render with exchanges 1`] = `
                   style="height: 155px;"
                 >
                   <div
-                    class="sc-AxgMl hGLWbv border-theme-primary-100 hover:border-theme-background"
+                    class="sc-AxgMl kYFwyN border-theme-primary-100 hover:border-theme-background"
                     data-testid="Exchange__exchange-card-binance"
                   >
                     <div
@@ -859,7 +859,7 @@ exports[`Exchange should render with exchanges 1`] = `
                   style="height: 155px;"
                 >
                   <div
-                    class="sc-AxgMl hGLWbv border-theme-primary-100 hover:border-theme-background"
+                    class="sc-AxgMl kYFwyN border-theme-primary-100 hover:border-theme-background"
                     data-testid="Exchange__exchange-card-atomars"
                   >
                     <div
@@ -913,7 +913,7 @@ exports[`Exchange should render with exchanges 1`] = `
                   style="height: 155px;"
                 >
                   <div
-                    class="sc-AxgMl hGLWbv border-theme-primary-100 hover:border-theme-background"
+                    class="sc-AxgMl kYFwyN border-theme-primary-100 hover:border-theme-background"
                     data-testid="Exchange__exchange-card-okex"
                   >
                     <div
@@ -967,7 +967,7 @@ exports[`Exchange should render with exchanges 1`] = `
                   style="height: 155px;"
                 >
                   <div
-                    class="sc-AxgMl hGLWbv col-span-2 border-theme-primary-100"
+                    class="sc-AxgMl kYFwyN col-span-2 border-theme-primary-100"
                     data-testid="Exchange__add-exchange-card"
                   >
                     <div
@@ -991,7 +991,7 @@ exports[`Exchange should render with exchanges 1`] = `
                   style="height: 155px;"
                 >
                   <div
-                    class="sc-AxgMl hGLWbv border-theme-primary-100"
+                    class="sc-AxgMl kYFwyN border-theme-primary-100"
                     data-testid="Exchange__blank-card"
                   >
                     <div
@@ -1009,7 +1009,7 @@ exports[`Exchange should render with exchanges 1`] = `
                   style="height: 155px;"
                 >
                   <div
-                    class="sc-AxgMl hGLWbv border-theme-primary-100"
+                    class="sc-AxgMl kYFwyN border-theme-primary-100"
                     data-testid="Exchange__blank-card"
                   >
                     <div
@@ -1027,7 +1027,7 @@ exports[`Exchange should render with exchanges 1`] = `
                   style="height: 155px;"
                 >
                   <div
-                    class="sc-AxgMl hGLWbv border-theme-primary-100"
+                    class="sc-AxgMl kYFwyN border-theme-primary-100"
                     data-testid="Exchange__blank-card"
                   >
                     <div
@@ -1124,7 +1124,7 @@ exports[`Exchange should select exchange 1`] = `
                   style="height: 155px;"
                 >
                   <div
-                    class="sc-AxgMl hGLWbv bg-theme-success-100 border-theme-success-300 hover:border-theme-success-100"
+                    class="sc-AxgMl kYFwyN bg-theme-success-100 border-theme-success-300 hover:border-theme-success-100"
                     data-testid="Exchange__exchange-card-changenow-plugin"
                   >
                     <div
@@ -1178,7 +1178,7 @@ exports[`Exchange should select exchange 1`] = `
                   style="height: 155px;"
                 >
                   <div
-                    class="sc-AxgMl hGLWbv border-theme-primary-100 hover:border-theme-background"
+                    class="sc-AxgMl kYFwyN border-theme-primary-100 hover:border-theme-background"
                     data-testid="Exchange__exchange-card-binance"
                   >
                     <div
@@ -1232,7 +1232,7 @@ exports[`Exchange should select exchange 1`] = `
                   style="height: 155px;"
                 >
                   <div
-                    class="sc-AxgMl hGLWbv border-theme-primary-100 hover:border-theme-background"
+                    class="sc-AxgMl kYFwyN border-theme-primary-100 hover:border-theme-background"
                     data-testid="Exchange__exchange-card-atomars"
                   >
                     <div
@@ -1286,7 +1286,7 @@ exports[`Exchange should select exchange 1`] = `
                   style="height: 155px;"
                 >
                   <div
-                    class="sc-AxgMl hGLWbv col-span-2 border-theme-primary-100"
+                    class="sc-AxgMl kYFwyN col-span-2 border-theme-primary-100"
                     data-testid="Exchange__add-exchange-card"
                   >
                     <div

--- a/src/domains/help/components/ContactUs/__snapshots__/ContactUs.test.tsx.snap
+++ b/src/domains/help/components/ContactUs/__snapshots__/ContactUs.test.tsx.snap
@@ -207,7 +207,7 @@ exports[`ContactUs should render a modal 1`] = `
                   </button>
                   <ul
                     aria-labelledby="downshift-0-label"
-                    class="sc-fznKkj hupalw"
+                    class="sc-fznKkj dRrIJa"
                     id="downshift-0-menu"
                     role="listbox"
                     tabindex="-1"

--- a/src/domains/plugin/components/PluginCard/__snapshots__/PluginCard.test.tsx.snap
+++ b/src/domains/plugin/components/PluginCard/__snapshots__/PluginCard.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`PluginCard should render 1`] = `
 <DocumentFragment>
   <div
-    class="sc-AxiKw gweSCl border-theme-primary-100 hover:border-theme-background"
+    class="sc-AxiKw hRFoeL border-theme-primary-100 hover:border-theme-background"
     data-testid="PluginCard--ark-explorer"
   >
     <div
@@ -74,7 +74,7 @@ exports[`PluginCard should render 1`] = `
 exports[`PluginCard should render grant icon 1`] = `
 <DocumentFragment>
   <div
-    class="sc-AxiKw gweSCl border-theme-primary-100 hover:border-theme-background"
+    class="sc-AxiKw hRFoeL border-theme-primary-100 hover:border-theme-background"
     data-testid="PluginCard--ark-explorer"
   >
     <div
@@ -155,7 +155,7 @@ exports[`PluginCard should render grant icon 1`] = `
 exports[`PluginCard should render official icon 1`] = `
 <DocumentFragment>
   <div
-    class="sc-AxiKw gweSCl border-theme-primary-100 hover:border-theme-background"
+    class="sc-AxiKw hRFoeL border-theme-primary-100 hover:border-theme-background"
     data-testid="PluginCard--ark-explorer"
   >
     <div
@@ -236,7 +236,7 @@ exports[`PluginCard should render official icon 1`] = `
 exports[`PluginCard should trigger delete 1`] = `
 <DocumentFragment>
   <div
-    class="sc-AxiKw gweSCl border-theme-primary-100 hover:border-theme-background"
+    class="sc-AxiKw hRFoeL border-theme-primary-100 hover:border-theme-background"
     data-testid="PluginCard--ark-explorer"
   >
     <div

--- a/src/domains/plugin/components/PluginGrid/__snapshots__/PluginGrid.test.tsx.snap
+++ b/src/domains/plugin/components/PluginGrid/__snapshots__/PluginGrid.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`PluginGrid should render 1`] = `
       class="grid grid-cols-4 gap-5 undefined"
     >
       <div
-        class="sc-AxheI jEitmk border-theme-primary-100 hover:border-theme-background"
+        class="sc-AxheI dgnzGu border-theme-primary-100 hover:border-theme-background"
         data-testid="PluginCard--ark-explorer"
       >
         <div
@@ -85,7 +85,7 @@ exports[`PluginGrid should render 1`] = `
         </div>
       </div>
       <div
-        class="sc-AxheI jEitmk border-theme-primary-100 hover:border-theme-background"
+        class="sc-AxheI dgnzGu border-theme-primary-100 hover:border-theme-background"
         data-testid="PluginCard--ark-avatars"
       >
         <div
@@ -280,7 +280,7 @@ exports[`PluginGrid should render without pagination 1`] = `
       class="grid grid-cols-4 gap-5 undefined"
     >
       <div
-        class="sc-AxheI jEitmk border-theme-primary-100 hover:border-theme-background"
+        class="sc-AxheI dgnzGu border-theme-primary-100 hover:border-theme-background"
         data-testid="PluginCard--ark-explorer"
       >
         <div
@@ -356,7 +356,7 @@ exports[`PluginGrid should render without pagination 1`] = `
         </div>
       </div>
       <div
-        class="sc-AxheI jEitmk border-theme-primary-100 hover:border-theme-background"
+        class="sc-AxheI dgnzGu border-theme-primary-100 hover:border-theme-background"
         data-testid="PluginCard--ark-avatars"
       >
         <div
@@ -467,7 +467,7 @@ exports[`PluginGrid should split by page 1`] = `
       class="grid grid-cols-4 gap-5 undefined"
     >
       <div
-        class="sc-AxheI jEitmk border-theme-primary-100 hover:border-theme-background"
+        class="sc-AxheI dgnzGu border-theme-primary-100 hover:border-theme-background"
         data-testid="PluginCard--ark-avatars"
       >
         <div
@@ -665,7 +665,7 @@ exports[`PluginGrid should trigger delete 1`] = `
       class="grid grid-cols-4 gap-5 undefined"
     >
       <div
-        class="sc-AxheI jEitmk border-theme-primary-100 hover:border-theme-background"
+        class="sc-AxheI dgnzGu border-theme-primary-100 hover:border-theme-background"
         data-testid="PluginCard--ark-explorer"
       >
         <div
@@ -741,7 +741,7 @@ exports[`PluginGrid should trigger delete 1`] = `
         </div>
       </div>
       <div
-        class="sc-AxheI jEitmk border-theme-primary-100 hover:border-theme-background"
+        class="sc-AxheI dgnzGu border-theme-primary-100 hover:border-theme-background"
         data-testid="PluginCard--ark-avatars"
       >
         <div
@@ -936,7 +936,7 @@ exports[`PluginGrid should trigger select 1`] = `
       class="grid grid-cols-4 gap-5 undefined"
     >
       <div
-        class="sc-AxheI jEitmk border-theme-primary-100 hover:border-theme-background"
+        class="sc-AxheI dgnzGu border-theme-primary-100 hover:border-theme-background"
         data-testid="PluginCard--ark-explorer"
       >
         <div
@@ -1012,7 +1012,7 @@ exports[`PluginGrid should trigger select 1`] = `
         </div>
       </div>
       <div
-        class="sc-AxheI jEitmk border-theme-primary-100 hover:border-theme-background"
+        class="sc-AxheI dgnzGu border-theme-primary-100 hover:border-theme-background"
         data-testid="PluginCard--ark-avatars"
       >
         <div

--- a/src/domains/plugin/pages/PluginManager/__snapshots__/PluginManager.test.tsx.snap
+++ b/src/domains/plugin/pages/PluginManager/__snapshots__/PluginManager.test.tsx.snap
@@ -10719,7 +10719,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                 class="grid grid-cols-4 gap-5 undefined"
               >
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-0"
                 >
                   <div
@@ -10795,7 +10795,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-0"
                 >
                   <div
@@ -10893,7 +10893,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-1"
                 >
                   <div
@@ -10969,7 +10969,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-1"
                 >
                   <div
@@ -11067,7 +11067,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-2"
                 >
                   <div
@@ -11143,7 +11143,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-2"
                 >
                   <div
@@ -11241,7 +11241,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-3"
                 >
                   <div
@@ -11317,7 +11317,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-3"
                 >
                   <div
@@ -11440,7 +11440,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                 class="grid grid-cols-4 gap-5 undefined"
               >
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-0"
                 >
                   <div
@@ -11516,7 +11516,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-0"
                 >
                   <div
@@ -11614,7 +11614,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-1"
                 >
                   <div
@@ -11690,7 +11690,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-1"
                 >
                   <div
@@ -11788,7 +11788,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-2"
                 >
                   <div
@@ -11864,7 +11864,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-2"
                 >
                   <div
@@ -11962,7 +11962,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-3"
                 >
                   <div
@@ -12038,7 +12038,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-3"
                 >
                   <div
@@ -12153,7 +12153,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                 class="grid grid-cols-4 gap-5 undefined"
               >
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-0"
                 >
                   <div
@@ -12229,7 +12229,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-0"
                 >
                   <div
@@ -12327,7 +12327,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-1"
                 >
                   <div
@@ -12403,7 +12403,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-1"
                 >
                   <div
@@ -12501,7 +12501,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-2"
                 >
                   <div
@@ -12577,7 +12577,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-2"
                 >
                   <div
@@ -12675,7 +12675,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-3"
                 >
                   <div
@@ -12751,7 +12751,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-3"
                 >
                   <div
@@ -19640,7 +19640,7 @@ exports[`PluginManager should open & close featured modal 1`] = `
                 class="grid grid-cols-4 gap-5 undefined"
               >
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-0"
                 >
                   <div
@@ -19716,7 +19716,7 @@ exports[`PluginManager should open & close featured modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-0"
                 >
                   <div
@@ -19814,7 +19814,7 @@ exports[`PluginManager should open & close featured modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-1"
                 >
                   <div
@@ -19890,7 +19890,7 @@ exports[`PluginManager should open & close featured modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-1"
                 >
                   <div
@@ -19988,7 +19988,7 @@ exports[`PluginManager should open & close featured modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-2"
                 >
                   <div
@@ -20064,7 +20064,7 @@ exports[`PluginManager should open & close featured modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-2"
                 >
                   <div
@@ -20162,7 +20162,7 @@ exports[`PluginManager should open & close featured modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-3"
                 >
                   <div
@@ -20238,7 +20238,7 @@ exports[`PluginManager should open & close featured modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-3"
                 >
                   <div
@@ -20361,7 +20361,7 @@ exports[`PluginManager should open & close featured modal 1`] = `
                 class="grid grid-cols-4 gap-5 undefined"
               >
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-0"
                 >
                   <div
@@ -20437,7 +20437,7 @@ exports[`PluginManager should open & close featured modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-0"
                 >
                   <div
@@ -20535,7 +20535,7 @@ exports[`PluginManager should open & close featured modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-1"
                 >
                   <div
@@ -20611,7 +20611,7 @@ exports[`PluginManager should open & close featured modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-1"
                 >
                   <div
@@ -20709,7 +20709,7 @@ exports[`PluginManager should open & close featured modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-2"
                 >
                   <div
@@ -20785,7 +20785,7 @@ exports[`PluginManager should open & close featured modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-2"
                 >
                   <div
@@ -20883,7 +20883,7 @@ exports[`PluginManager should open & close featured modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-3"
                 >
                   <div
@@ -20959,7 +20959,7 @@ exports[`PluginManager should open & close featured modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-3"
                 >
                   <div
@@ -21074,7 +21074,7 @@ exports[`PluginManager should open & close featured modal 1`] = `
                 class="grid grid-cols-4 gap-5 undefined"
               >
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-0"
                 >
                   <div
@@ -21150,7 +21150,7 @@ exports[`PluginManager should open & close featured modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-0"
                 >
                   <div
@@ -21248,7 +21248,7 @@ exports[`PluginManager should open & close featured modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-1"
                 >
                   <div
@@ -21324,7 +21324,7 @@ exports[`PluginManager should open & close featured modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-1"
                 >
                   <div
@@ -21422,7 +21422,7 @@ exports[`PluginManager should open & close featured modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-2"
                 >
                   <div
@@ -21498,7 +21498,7 @@ exports[`PluginManager should open & close featured modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-2"
                 >
                   <div
@@ -21596,7 +21596,7 @@ exports[`PluginManager should open & close featured modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-3"
                 >
                   <div
@@ -21672,7 +21672,7 @@ exports[`PluginManager should open & close featured modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-3"
                 >
                   <div
@@ -22078,7 +22078,7 @@ exports[`PluginManager should open & close top rated modal 1`] = `
                 class="grid grid-cols-4 gap-5 undefined"
               >
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-0"
                 >
                   <div
@@ -22154,7 +22154,7 @@ exports[`PluginManager should open & close top rated modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-0"
                 >
                   <div
@@ -22252,7 +22252,7 @@ exports[`PluginManager should open & close top rated modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-1"
                 >
                   <div
@@ -22328,7 +22328,7 @@ exports[`PluginManager should open & close top rated modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-1"
                 >
                   <div
@@ -22426,7 +22426,7 @@ exports[`PluginManager should open & close top rated modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-2"
                 >
                   <div
@@ -22502,7 +22502,7 @@ exports[`PluginManager should open & close top rated modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-2"
                 >
                   <div
@@ -22600,7 +22600,7 @@ exports[`PluginManager should open & close top rated modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-3"
                 >
                   <div
@@ -22676,7 +22676,7 @@ exports[`PluginManager should open & close top rated modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-3"
                 >
                   <div
@@ -22799,7 +22799,7 @@ exports[`PluginManager should open & close top rated modal 1`] = `
                 class="grid grid-cols-4 gap-5 undefined"
               >
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-0"
                 >
                   <div
@@ -22875,7 +22875,7 @@ exports[`PluginManager should open & close top rated modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-0"
                 >
                   <div
@@ -22973,7 +22973,7 @@ exports[`PluginManager should open & close top rated modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-1"
                 >
                   <div
@@ -23049,7 +23049,7 @@ exports[`PluginManager should open & close top rated modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-1"
                 >
                   <div
@@ -23147,7 +23147,7 @@ exports[`PluginManager should open & close top rated modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-2"
                 >
                   <div
@@ -23223,7 +23223,7 @@ exports[`PluginManager should open & close top rated modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-2"
                 >
                   <div
@@ -23321,7 +23321,7 @@ exports[`PluginManager should open & close top rated modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-3"
                 >
                   <div
@@ -23397,7 +23397,7 @@ exports[`PluginManager should open & close top rated modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-3"
                 >
                   <div
@@ -23512,7 +23512,7 @@ exports[`PluginManager should open & close top rated modal 1`] = `
                 class="grid grid-cols-4 gap-5 undefined"
               >
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-0"
                 >
                   <div
@@ -23588,7 +23588,7 @@ exports[`PluginManager should open & close top rated modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-0"
                 >
                   <div
@@ -23686,7 +23686,7 @@ exports[`PluginManager should open & close top rated modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-1"
                 >
                   <div
@@ -23762,7 +23762,7 @@ exports[`PluginManager should open & close top rated modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-1"
                 >
                   <div
@@ -23860,7 +23860,7 @@ exports[`PluginManager should open & close top rated modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-2"
                 >
                   <div
@@ -23936,7 +23936,7 @@ exports[`PluginManager should open & close top rated modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-2"
                 >
                   <div
@@ -24034,7 +24034,7 @@ exports[`PluginManager should open & close top rated modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-3"
                 >
                   <div
@@ -24110,7 +24110,7 @@ exports[`PluginManager should open & close top rated modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-3"
                 >
                   <div
@@ -24516,7 +24516,7 @@ exports[`PluginManager should render 1`] = `
                 class="grid grid-cols-4 gap-5 undefined"
               >
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-0"
                 >
                   <div
@@ -24592,7 +24592,7 @@ exports[`PluginManager should render 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-0"
                 >
                   <div
@@ -24690,7 +24690,7 @@ exports[`PluginManager should render 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-1"
                 >
                   <div
@@ -24766,7 +24766,7 @@ exports[`PluginManager should render 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-1"
                 >
                   <div
@@ -24864,7 +24864,7 @@ exports[`PluginManager should render 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-2"
                 >
                   <div
@@ -24940,7 +24940,7 @@ exports[`PluginManager should render 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-2"
                 >
                   <div
@@ -25038,7 +25038,7 @@ exports[`PluginManager should render 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-3"
                 >
                   <div
@@ -25114,7 +25114,7 @@ exports[`PluginManager should render 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-3"
                 >
                   <div
@@ -25237,7 +25237,7 @@ exports[`PluginManager should render 1`] = `
                 class="grid grid-cols-4 gap-5 undefined"
               >
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-0"
                 >
                   <div
@@ -25313,7 +25313,7 @@ exports[`PluginManager should render 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-0"
                 >
                   <div
@@ -25411,7 +25411,7 @@ exports[`PluginManager should render 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-1"
                 >
                   <div
@@ -25487,7 +25487,7 @@ exports[`PluginManager should render 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-1"
                 >
                   <div
@@ -25585,7 +25585,7 @@ exports[`PluginManager should render 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-2"
                 >
                   <div
@@ -25661,7 +25661,7 @@ exports[`PluginManager should render 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-2"
                 >
                   <div
@@ -25759,7 +25759,7 @@ exports[`PluginManager should render 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-3"
                 >
                   <div
@@ -25835,7 +25835,7 @@ exports[`PluginManager should render 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-3"
                 >
                   <div
@@ -25950,7 +25950,7 @@ exports[`PluginManager should render 1`] = `
                 class="grid grid-cols-4 gap-5 undefined"
               >
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-0"
                 >
                   <div
@@ -26026,7 +26026,7 @@ exports[`PluginManager should render 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-0"
                 >
                   <div
@@ -26124,7 +26124,7 @@ exports[`PluginManager should render 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-1"
                 >
                   <div
@@ -26200,7 +26200,7 @@ exports[`PluginManager should render 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-1"
                 >
                   <div
@@ -26298,7 +26298,7 @@ exports[`PluginManager should render 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-2"
                 >
                   <div
@@ -26374,7 +26374,7 @@ exports[`PluginManager should render 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-2"
                 >
                   <div
@@ -26472,7 +26472,7 @@ exports[`PluginManager should render 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-3"
                 >
                   <div
@@ -26548,7 +26548,7 @@ exports[`PluginManager should render 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-3"
                 >
                   <div
@@ -26972,7 +26972,7 @@ exports[`PluginManager should search for plugin 1`] = `
                 class="grid grid-cols-4 gap-5 undefined"
               >
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-0"
                 >
                   <div
@@ -27048,7 +27048,7 @@ exports[`PluginManager should search for plugin 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-0"
                 >
                   <div
@@ -27146,7 +27146,7 @@ exports[`PluginManager should search for plugin 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-1"
                 >
                   <div
@@ -27222,7 +27222,7 @@ exports[`PluginManager should search for plugin 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-1"
                 >
                   <div
@@ -27320,7 +27320,7 @@ exports[`PluginManager should search for plugin 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-2"
                 >
                   <div
@@ -27396,7 +27396,7 @@ exports[`PluginManager should search for plugin 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-2"
                 >
                   <div
@@ -27494,7 +27494,7 @@ exports[`PluginManager should search for plugin 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-3"
                 >
                   <div
@@ -27570,7 +27570,7 @@ exports[`PluginManager should search for plugin 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-3"
                 >
                   <div
@@ -27693,7 +27693,7 @@ exports[`PluginManager should search for plugin 1`] = `
                 class="grid grid-cols-4 gap-5 undefined"
               >
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-0"
                 >
                   <div
@@ -27769,7 +27769,7 @@ exports[`PluginManager should search for plugin 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-0"
                 >
                   <div
@@ -27867,7 +27867,7 @@ exports[`PluginManager should search for plugin 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-1"
                 >
                   <div
@@ -27943,7 +27943,7 @@ exports[`PluginManager should search for plugin 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-1"
                 >
                   <div
@@ -28041,7 +28041,7 @@ exports[`PluginManager should search for plugin 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-2"
                 >
                   <div
@@ -28117,7 +28117,7 @@ exports[`PluginManager should search for plugin 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-2"
                 >
                   <div
@@ -28215,7 +28215,7 @@ exports[`PluginManager should search for plugin 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-3"
                 >
                   <div
@@ -28291,7 +28291,7 @@ exports[`PluginManager should search for plugin 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-3"
                 >
                   <div
@@ -28406,7 +28406,7 @@ exports[`PluginManager should search for plugin 1`] = `
                 class="grid grid-cols-4 gap-5 undefined"
               >
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-0"
                 >
                   <div
@@ -28482,7 +28482,7 @@ exports[`PluginManager should search for plugin 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-0"
                 >
                   <div
@@ -28580,7 +28580,7 @@ exports[`PluginManager should search for plugin 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-1"
                 >
                   <div
@@ -28656,7 +28656,7 @@ exports[`PluginManager should search for plugin 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-1"
                 >
                   <div
@@ -28754,7 +28754,7 @@ exports[`PluginManager should search for plugin 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-2"
                 >
                   <div
@@ -28830,7 +28830,7 @@ exports[`PluginManager should search for plugin 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-2"
                 >
                   <div
@@ -28928,7 +28928,7 @@ exports[`PluginManager should search for plugin 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-3"
                 >
                   <div
@@ -29004,7 +29004,7 @@ exports[`PluginManager should search for plugin 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-3"
                 >
                   <div
@@ -29390,7 +29390,7 @@ exports[`PluginManager should select plugin on game grid 1`] = `
             class="grid grid-cols-4 gap-5 mt-6"
           >
             <div
-              class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+              class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
               data-testid="PluginCard--ark-explorer-0"
             >
               <div
@@ -29466,7 +29466,7 @@ exports[`PluginManager should select plugin on game grid 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+              class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
               data-testid="PluginCard--ark-avatars-0"
             >
               <div
@@ -29564,7 +29564,7 @@ exports[`PluginManager should select plugin on game grid 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+              class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
               data-testid="PluginCard--ark-explorer-1"
             >
               <div
@@ -29640,7 +29640,7 @@ exports[`PluginManager should select plugin on game grid 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+              class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
               data-testid="PluginCard--ark-avatars-1"
             >
               <div
@@ -29738,7 +29738,7 @@ exports[`PluginManager should select plugin on game grid 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+              class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
               data-testid="PluginCard--ark-explorer-2"
             >
               <div
@@ -29814,7 +29814,7 @@ exports[`PluginManager should select plugin on game grid 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+              class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
               data-testid="PluginCard--ark-avatars-2"
             >
               <div
@@ -29912,7 +29912,7 @@ exports[`PluginManager should select plugin on game grid 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+              class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
               data-testid="PluginCard--ark-explorer-3"
             >
               <div
@@ -29988,7 +29988,7 @@ exports[`PluginManager should select plugin on game grid 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+              class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
               data-testid="PluginCard--ark-avatars-3"
             >
               <div
@@ -30086,7 +30086,7 @@ exports[`PluginManager should select plugin on game grid 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+              class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
               data-testid="PluginCard--ark-explorer-4"
             >
               <div
@@ -30162,7 +30162,7 @@ exports[`PluginManager should select plugin on game grid 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+              class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
               data-testid="PluginCard--ark-avatars-4"
             >
               <div
@@ -30260,7 +30260,7 @@ exports[`PluginManager should select plugin on game grid 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+              class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
               data-testid="PluginCard--ark-explorer-5"
             >
               <div
@@ -30336,7 +30336,7 @@ exports[`PluginManager should select plugin on game grid 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+              class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
               data-testid="PluginCard--ark-avatars-5"
             >
               <div
@@ -30434,7 +30434,7 @@ exports[`PluginManager should select plugin on game grid 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+              class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
               data-testid="PluginCard--ark-explorer-6"
             >
               <div
@@ -30510,7 +30510,7 @@ exports[`PluginManager should select plugin on game grid 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+              class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
               data-testid="PluginCard--ark-avatars-6"
             >
               <div
@@ -30608,7 +30608,7 @@ exports[`PluginManager should select plugin on game grid 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+              class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
               data-testid="PluginCard--ark-explorer-7"
             >
               <div
@@ -30684,7 +30684,7 @@ exports[`PluginManager should select plugin on game grid 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+              class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
               data-testid="PluginCard--ark-avatars-7"
             >
               <div
@@ -30782,7 +30782,7 @@ exports[`PluginManager should select plugin on game grid 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+              class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
               data-testid="PluginCard--ark-explorer-8"
             >
               <div
@@ -30858,7 +30858,7 @@ exports[`PluginManager should select plugin on game grid 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+              class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
               data-testid="PluginCard--ark-avatars-8"
             >
               <div
@@ -30956,7 +30956,7 @@ exports[`PluginManager should select plugin on game grid 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+              class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
               data-testid="PluginCard--ark-explorer-9"
             >
               <div
@@ -31032,7 +31032,7 @@ exports[`PluginManager should select plugin on game grid 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+              class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
               data-testid="PluginCard--ark-avatars-9"
             >
               <div
@@ -31520,7 +31520,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                 class="grid grid-cols-4 gap-5 undefined"
               >
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-0"
                 >
                   <div
@@ -31596,7 +31596,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-0"
                 >
                   <div
@@ -31694,7 +31694,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-1"
                 >
                   <div
@@ -31770,7 +31770,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-1"
                 >
                   <div
@@ -31868,7 +31868,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-2"
                 >
                   <div
@@ -31944,7 +31944,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-2"
                 >
                   <div
@@ -32042,7 +32042,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-3"
                 >
                   <div
@@ -32118,7 +32118,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-3"
                 >
                   <div
@@ -32241,7 +32241,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                 class="grid grid-cols-4 gap-5 undefined"
               >
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-0"
                 >
                   <div
@@ -32317,7 +32317,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-0"
                 >
                   <div
@@ -32415,7 +32415,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-1"
                 >
                   <div
@@ -32491,7 +32491,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-1"
                 >
                   <div
@@ -32589,7 +32589,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-2"
                 >
                   <div
@@ -32665,7 +32665,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-2"
                 >
                   <div
@@ -32763,7 +32763,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-3"
                 >
                   <div
@@ -32839,7 +32839,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-3"
                 >
                   <div
@@ -32954,7 +32954,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                 class="grid grid-cols-4 gap-5 undefined"
               >
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-0"
                 >
                   <div
@@ -33030,7 +33030,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-0"
                 >
                   <div
@@ -33128,7 +33128,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-1"
                 >
                   <div
@@ -33204,7 +33204,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-1"
                 >
                   <div
@@ -33302,7 +33302,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-2"
                 >
                   <div
@@ -33378,7 +33378,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-2"
                 >
                   <div
@@ -33476,7 +33476,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-3"
                 >
                   <div
@@ -33552,7 +33552,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-3"
                 >
                   <div
@@ -33938,7 +33938,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
             class="grid grid-cols-4 gap-5 mt-6"
           >
             <div
-              class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+              class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
               data-testid="PluginCard--ark-explorer-0"
             >
               <div
@@ -34014,7 +34014,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+              class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
               data-testid="PluginCard--ark-avatars-0"
             >
               <div
@@ -34112,7 +34112,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+              class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
               data-testid="PluginCard--ark-explorer-1"
             >
               <div
@@ -34188,7 +34188,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+              class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
               data-testid="PluginCard--ark-avatars-1"
             >
               <div
@@ -34286,7 +34286,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+              class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
               data-testid="PluginCard--ark-explorer-2"
             >
               <div
@@ -34362,7 +34362,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+              class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
               data-testid="PluginCard--ark-avatars-2"
             >
               <div
@@ -34460,7 +34460,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+              class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
               data-testid="PluginCard--ark-explorer-3"
             >
               <div
@@ -34536,7 +34536,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+              class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
               data-testid="PluginCard--ark-avatars-3"
             >
               <div
@@ -34634,7 +34634,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+              class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
               data-testid="PluginCard--ark-explorer-4"
             >
               <div
@@ -34710,7 +34710,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+              class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
               data-testid="PluginCard--ark-avatars-4"
             >
               <div
@@ -34808,7 +34808,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+              class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
               data-testid="PluginCard--ark-explorer-5"
             >
               <div
@@ -34884,7 +34884,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+              class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
               data-testid="PluginCard--ark-avatars-5"
             >
               <div
@@ -34982,7 +34982,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+              class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
               data-testid="PluginCard--ark-explorer-6"
             >
               <div
@@ -35058,7 +35058,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+              class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
               data-testid="PluginCard--ark-avatars-6"
             >
               <div
@@ -35156,7 +35156,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+              class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
               data-testid="PluginCard--ark-explorer-7"
             >
               <div
@@ -35232,7 +35232,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+              class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
               data-testid="PluginCard--ark-avatars-7"
             >
               <div
@@ -35330,7 +35330,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+              class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
               data-testid="PluginCard--ark-explorer-8"
             >
               <div
@@ -35406,7 +35406,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+              class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
               data-testid="PluginCard--ark-avatars-8"
             >
               <div
@@ -35504,7 +35504,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+              class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
               data-testid="PluginCard--ark-explorer-9"
             >
               <div
@@ -35580,7 +35580,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+              class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
               data-testid="PluginCard--ark-avatars-9"
             >
               <div
@@ -36068,7 +36068,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                 class="grid grid-cols-4 gap-5 undefined"
               >
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-0"
                 >
                   <div
@@ -36144,7 +36144,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-0"
                 >
                   <div
@@ -36242,7 +36242,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-1"
                 >
                   <div
@@ -36318,7 +36318,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-1"
                 >
                   <div
@@ -36416,7 +36416,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-2"
                 >
                   <div
@@ -36492,7 +36492,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-2"
                 >
                   <div
@@ -36590,7 +36590,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-3"
                 >
                   <div
@@ -36666,7 +36666,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-3"
                 >
                   <div
@@ -36789,7 +36789,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                 class="grid grid-cols-4 gap-5 undefined"
               >
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-0"
                 >
                   <div
@@ -36865,7 +36865,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-0"
                 >
                   <div
@@ -36963,7 +36963,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-1"
                 >
                   <div
@@ -37039,7 +37039,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-1"
                 >
                   <div
@@ -37137,7 +37137,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-2"
                 >
                   <div
@@ -37213,7 +37213,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-2"
                 >
                   <div
@@ -37311,7 +37311,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-3"
                 >
                   <div
@@ -37387,7 +37387,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-3"
                 >
                   <div
@@ -37502,7 +37502,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                 class="grid grid-cols-4 gap-5 undefined"
               >
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-0"
                 >
                   <div
@@ -37578,7 +37578,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-0"
                 >
                   <div
@@ -37676,7 +37676,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-1"
                 >
                   <div
@@ -37752,7 +37752,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-1"
                 >
                   <div
@@ -37850,7 +37850,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-2"
                 >
                   <div
@@ -37926,7 +37926,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-2"
                 >
                   <div
@@ -38024,7 +38024,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-3"
                 >
                   <div
@@ -38100,7 +38100,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag jVNBI border-theme-primary-100 hover:border-theme-background"
+                  class="sc-fzoLag iZiyTC border-theme-primary-100 hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-3"
                 >
                   <div

--- a/src/domains/profile/pages/CreateProfile/__snapshots__/CreateProfile.test.tsx.snap
+++ b/src/domains/profile/pages/CreateProfile/__snapshots__/CreateProfile.test.tsx.snap
@@ -213,7 +213,7 @@ exports[`CreateProfile should render 1`] = `
                       </button>
                       <ul
                         aria-labelledby="downshift-0-label"
-                        class="sc-fznKkj hupalw"
+                        class="sc-fznKkj dRrIJa"
                         id="downshift-0-menu"
                         role="listbox"
                         tabindex="-1"
@@ -274,7 +274,7 @@ exports[`CreateProfile should render 1`] = `
                       </button>
                       <ul
                         aria-labelledby="downshift-1-label"
-                        class="sc-fznKkj hupalw"
+                        class="sc-fznKkj dRrIJa"
                         id="downshift-1-menu"
                         role="listbox"
                         tabindex="-1"

--- a/src/domains/setting/pages/Settings/__snapshots__/Settings.test.tsx.snap
+++ b/src/domains/setting/pages/Settings/__snapshots__/Settings.test.tsx.snap
@@ -294,7 +294,7 @@ exports[`Settings should open & close modals in the plugin settings 1`] = `
                       </button>
                       <ul
                         aria-labelledby="downshift-25-label"
-                        class="sc-fznZeY ftMtbA"
+                        class="sc-fznZeY FsNrS"
                         id="downshift-25-menu"
                         role="listbox"
                         tabindex="-1"
@@ -614,7 +614,7 @@ exports[`Settings should render 1`] = `
                       </button>
                       <ul
                         aria-labelledby="downshift-0-label"
-                        class="sc-fznZeY ftMtbA"
+                        class="sc-fznZeY FsNrS"
                         id="downshift-0-menu"
                         role="listbox"
                         tabindex="-1"
@@ -675,7 +675,7 @@ exports[`Settings should render 1`] = `
                       </button>
                       <ul
                         aria-labelledby="downshift-1-label"
-                        class="sc-fznZeY ftMtbA"
+                        class="sc-fznZeY FsNrS"
                         id="downshift-1-menu"
                         role="listbox"
                         tabindex="-1"
@@ -740,7 +740,7 @@ exports[`Settings should render 1`] = `
                       </button>
                       <ul
                         aria-labelledby="downshift-2-label"
-                        class="sc-fznZeY ftMtbA"
+                        class="sc-fznZeY FsNrS"
                         id="downshift-2-menu"
                         role="listbox"
                         tabindex="-1"
@@ -801,7 +801,7 @@ exports[`Settings should render 1`] = `
                       </button>
                       <ul
                         aria-labelledby="downshift-3-label"
-                        class="sc-fznZeY ftMtbA"
+                        class="sc-fznZeY FsNrS"
                         id="downshift-3-menu"
                         role="listbox"
                         tabindex="-1"
@@ -862,7 +862,7 @@ exports[`Settings should render 1`] = `
                       </button>
                       <ul
                         aria-labelledby="downshift-4-label"
-                        class="sc-fznZeY ftMtbA"
+                        class="sc-fznZeY FsNrS"
                         id="downshift-4-menu"
                         role="listbox"
                         tabindex="-1"
@@ -1063,7 +1063,7 @@ exports[`Settings should render 1`] = `
                         </button>
                         <ul
                           aria-labelledby="downshift-5-label"
-                          class="sc-fznZeY ftMtbA"
+                          class="sc-fznZeY FsNrS"
                           id="downshift-5-menu"
                           role="listbox"
                           tabindex="-1"
@@ -2161,7 +2161,7 @@ exports[`Settings should render plugin settings 1`] = `
                       </button>
                       <ul
                         aria-labelledby="downshift-18-label"
-                        class="sc-fznZeY ftMtbA"
+                        class="sc-fznZeY FsNrS"
                         id="downshift-18-menu"
                         role="listbox"
                         tabindex="-1"

--- a/src/domains/transaction/components/LinkCollection/__snapshots__/LinkCollection.test.tsx.snap
+++ b/src/domains/transaction/components/LinkCollection/__snapshots__/LinkCollection.test.tsx.snap
@@ -85,7 +85,7 @@ exports[`LinkCollection should add and remove links 1`] = `
                     </button>
                     <ul
                       aria-labelledby="downshift-1-label"
-                      class="sc-fznyAO hCfgtZ"
+                      class="sc-fznyAO hzJaLD"
                       id="downshift-1-menu"
                       role="listbox"
                       tabindex="-1"
@@ -377,7 +377,7 @@ exports[`LinkCollection should select a specific link type 1`] = `
                     />
                     <ul
                       aria-labelledby="downshift-8-label"
-                      class="sc-fznyAO hCfgtZ"
+                      class="sc-fznyAO hzJaLD"
                       id="downshift-8-menu"
                       role="listbox"
                       tabindex="-1"

--- a/src/domains/transaction/pages/Registration/__snapshots__/Registration.test.tsx.snap
+++ b/src/domains/transaction/pages/Registration/__snapshots__/Registration.test.tsx.snap
@@ -294,7 +294,7 @@ exports[`Registration should render 1st step 1`] = `
                             />
                             <ul
                               aria-labelledby="downshift-1-label"
-                              class="sc-fznZeY ftMtbA"
+                              class="sc-fznZeY FsNrS"
                               id="downshift-1-menu"
                               role="listbox"
                               tabindex="-1"
@@ -2100,7 +2100,7 @@ exports[`Registration should select registration type 1`] = `
                             </button>
                             <ul
                               aria-labelledby="downshift-26-label"
-                              class="sc-fznZeY ftMtbA"
+                              class="sc-fznZeY FsNrS"
                               id="downshift-26-menu"
                               role="listbox"
                               tabindex="-1"
@@ -2449,7 +2449,7 @@ exports[`Registration should should go back 1`] = `
                             />
                             <ul
                               aria-labelledby="downshift-6-label"
-                              class="sc-fznZeY ftMtbA"
+                              class="sc-fznZeY FsNrS"
                               id="downshift-6-menu"
                               role="listbox"
                               tabindex="-1"

--- a/src/tailwind.config.js
+++ b/src/tailwind.config.js
@@ -172,7 +172,7 @@ module.exports = {
 				default: "0 1px 3px 0 var(--theme-color-neutral-200), 0 1px 2px 0 var(--theme-color-neutral-100)",
 				md: "0 4px 6px -1px var(--theme-color-neutral-200), 0 2px 4px -1px var(--theme-color-neutral-100)",
 				lg: "0 10px 15px -3px var(--theme-color-neutral-200), 0 4px 6px -2px var(--theme-color-neutral-100)",
-				xl: "0 15px 20px -3px var(--theme-color-neutral-200), 0 15px 15px -7px var(--theme-color-neutral-300)",
+				xl: "0 15px 15px -7px var(--theme-color-neutral-300)",
 				outline: "0 0 0 3px rgba(var(--theme-color-primary-rgb), 0.4)",
 			},
 			listStyleType: {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Remove white shadow from `shadow-xl` in `tailwind.config`
Fixes issues when a shadowed element is on top of darker background.

Example:

![2020-07-09-112454_658x533_scrot](https://user-images.githubusercontent.com/22020168/87022293-f5440e80-c1de-11ea-9696-0d1fe2627782.png)


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
