### PR TITLE
fix: use neutral variable in `shadow-xl`

### DIFF
--- a/src/app/components/SearchBar/SearchBarPluginFilters/__snapshots__/SearchBarPluginFilters.test.tsx.snap
+++ b/src/app/components/SearchBar/SearchBarPluginFilters/__snapshots__/SearchBarPluginFilters.test.tsx.snap
@@ -53,7 +53,7 @@ exports[`SearchBarPluginFilters should render categories 1`] = `
         </div>
       </span>
       <div
-        class="sc-AxiKw eYIdSd right-0 undefined"
+        class="sc-AxiKw dLsSkj right-0 undefined"
       >
         <div
           data-testid="dropdown__content"
@@ -622,7 +622,7 @@ exports[`SearchBarPluginFilters should render ratings 1`] = `
         </div>
       </span>
       <div
-        class="sc-AxiKw eYIdSd right-0 undefined"
+        class="sc-AxiKw dLsSkj right-0 undefined"
       >
         <div
           data-testid="dropdown__content"
@@ -1245,7 +1245,7 @@ exports[`SearchBarPluginFilters should render with null initialValues 1`] = `
         </div>
       </span>
       <div
-        class="sc-AxiKw eYIdSd right-0 undefined"
+        class="sc-AxiKw dLsSkj right-0 undefined"
       >
         <div
           data-testid="dropdown__content"
@@ -1744,7 +1744,7 @@ exports[`SearchBarPluginFilters should render with selected values 1`] = `
         </div>
       </span>
       <div
-        class="sc-AxiKw eYIdSd right-0 undefined"
+        class="sc-AxiKw dLsSkj right-0 undefined"
       >
         <div
           data-testid="dropdown__content"

--- a/src/app/components/SelectDropdown/__snapshots__/SelectDropdown.test.tsx.snap
+++ b/src/app/components/SelectDropdown/__snapshots__/SelectDropdown.test.tsx.snap
@@ -27,7 +27,7 @@ exports[`SelectDropdown should render 1`] = `
         />
         <ul
           aria-labelledby="downshift-0-label"
-          class="sc-fzoLsD jPSZMC"
+          class="sc-fzoLsD jhmsZA"
           id="downshift-0-menu"
           role="listbox"
           tabindex="-1"
@@ -79,7 +79,7 @@ exports[`SelectDropdown should render disabled 1`] = `
         />
         <ul
           aria-labelledby="downshift-2-label"
-          class="sc-fzoLsD jPSZMC"
+          class="sc-fzoLsD jhmsZA"
           id="downshift-2-menu"
           role="listbox"
           tabindex="-1"
@@ -131,7 +131,7 @@ exports[`SelectDropdown should render invalid 1`] = `
         />
         <ul
           aria-labelledby="downshift-1-label"
-          class="sc-fzoLsD jPSZMC"
+          class="sc-fzoLsD jhmsZA"
           id="downshift-1-menu"
           role="listbox"
           tabindex="-1"
@@ -182,7 +182,7 @@ exports[`SelectDropdown should render with empty options 1`] = `
         />
         <ul
           aria-labelledby="downshift-5-label"
-          class="sc-fzoLsD jPSZMC"
+          class="sc-fzoLsD jhmsZA"
           id="downshift-5-menu"
           role="listbox"
           tabindex="-1"
@@ -235,7 +235,7 @@ exports[`SelectDropdown should render with initial default value 1`] = `
         </button>
         <ul
           aria-labelledby="downshift-3-label"
-          class="sc-fzoLsD jPSZMC"
+          class="sc-fzoLsD jhmsZA"
           id="downshift-3-menu"
           role="listbox"
           tabindex="-1"
@@ -286,7 +286,7 @@ exports[`SelectDropdown should render with options values as numbers 1`] = `
         />
         <ul
           aria-labelledby="downshift-6-label"
-          class="sc-fzoLsD jPSZMC"
+          class="sc-fzoLsD jhmsZA"
           id="downshift-6-menu"
           role="listbox"
           tabindex="-1"
@@ -337,7 +337,7 @@ exports[`SelectDropdown should render with wrong default value 1`] = `
         />
         <ul
           aria-labelledby="downshift-4-label"
-          class="sc-fzoLsD jPSZMC"
+          class="sc-fzoLsD jhmsZA"
           id="downshift-4-menu"
           role="listbox"
           tabindex="-1"

--- a/src/domains/exchange/components/ExchangeCard/__snapshots__/ExchangeCard.test.tsx.snap
+++ b/src/domains/exchange/components/ExchangeCard/__snapshots__/ExchangeCard.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`ExchangeCard should render Add Exchange card 1`] = `
 <div>
   <div
-    class="sc-AxiKw cqqpsK col-span-2 border-theme-primary-contrast"
+    class="sc-AxiKw hxJwBY col-span-2 border-theme-primary-contrast"
     data-testid="Exchange__add-exchange-card"
   >
     <div
@@ -27,7 +27,7 @@ exports[`ExchangeCard should render Add Exchange card 1`] = `
 exports[`ExchangeCard should render Blank Exchange card 1`] = `
 <div>
   <div
-    class="sc-AxiKw cqqpsK border-theme-primary-contrast"
+    class="sc-AxiKw hxJwBY border-theme-primary-contrast"
     data-testid="Exchange__blank-card"
   >
     <div
@@ -45,7 +45,7 @@ exports[`ExchangeCard should render Blank Exchange card 1`] = `
 exports[`ExchangeCard should render Exchange card 1`] = `
 <div>
   <div
-    class="sc-AxiKw cqqpsK border-theme-primary-contrast hover:border-theme-background"
+    class="sc-AxiKw hxJwBY border-theme-primary-contrast hover:border-theme-background"
     data-testid="Exchange__exchange-card-test-exchange"
   >
     <div

--- a/src/domains/exchange/pages/Exchange/__snapshots__/Exchange.test.tsx.snap
+++ b/src/domains/exchange/pages/Exchange/__snapshots__/Exchange.test.tsx.snap
@@ -51,7 +51,7 @@ exports[`Exchange should not render filler exchange cards 1`] = `
                   style="height: 155px;"
                 >
                   <div
-                    class="sc-AxgMl kiiwkh border-theme-primary-contrast hover:border-theme-background"
+                    class="sc-AxgMl hCbQhX border-theme-primary-contrast hover:border-theme-background"
                     data-testid="Exchange__exchange-card-changenow-plugin"
                   >
                     <div
@@ -105,7 +105,7 @@ exports[`Exchange should not render filler exchange cards 1`] = `
                   style="height: 155px;"
                 >
                   <div
-                    class="sc-AxgMl kiiwkh border-theme-primary-contrast hover:border-theme-background"
+                    class="sc-AxgMl hCbQhX border-theme-primary-contrast hover:border-theme-background"
                     data-testid="Exchange__exchange-card-binance"
                   >
                     <div
@@ -159,7 +159,7 @@ exports[`Exchange should not render filler exchange cards 1`] = `
                   style="height: 155px;"
                 >
                   <div
-                    class="sc-AxgMl kiiwkh border-theme-primary-contrast hover:border-theme-background"
+                    class="sc-AxgMl hCbQhX border-theme-primary-contrast hover:border-theme-background"
                     data-testid="Exchange__exchange-card-atomars"
                   >
                     <div
@@ -213,7 +213,7 @@ exports[`Exchange should not render filler exchange cards 1`] = `
                   style="height: 155px;"
                 >
                   <div
-                    class="sc-AxgMl kiiwkh col-span-2 border-theme-primary-contrast"
+                    class="sc-AxgMl hCbQhX col-span-2 border-theme-primary-contrast"
                     data-testid="Exchange__add-exchange-card"
                   >
                     <div
@@ -316,7 +316,7 @@ exports[`Exchange should open & close add exchange modal 1`] = `
                   style="height: 155px;"
                 >
                   <div
-                    class="sc-AxgMl kiiwkh border-theme-primary-contrast hover:border-theme-background"
+                    class="sc-AxgMl hCbQhX border-theme-primary-contrast hover:border-theme-background"
                     data-testid="Exchange__exchange-card-changenow-plugin"
                   >
                     <div
@@ -370,7 +370,7 @@ exports[`Exchange should open & close add exchange modal 1`] = `
                   style="height: 155px;"
                 >
                   <div
-                    class="sc-AxgMl kiiwkh border-theme-primary-contrast hover:border-theme-background"
+                    class="sc-AxgMl hCbQhX border-theme-primary-contrast hover:border-theme-background"
                     data-testid="Exchange__exchange-card-binance"
                   >
                     <div
@@ -424,7 +424,7 @@ exports[`Exchange should open & close add exchange modal 1`] = `
                   style="height: 155px;"
                 >
                   <div
-                    class="sc-AxgMl kiiwkh border-theme-primary-contrast hover:border-theme-background"
+                    class="sc-AxgMl hCbQhX border-theme-primary-contrast hover:border-theme-background"
                     data-testid="Exchange__exchange-card-atomars"
                   >
                     <div
@@ -478,7 +478,7 @@ exports[`Exchange should open & close add exchange modal 1`] = `
                   style="height: 155px;"
                 >
                   <div
-                    class="sc-AxgMl kiiwkh col-span-2 border-theme-primary-contrast"
+                    class="sc-AxgMl hCbQhX col-span-2 border-theme-primary-contrast"
                     data-testid="Exchange__add-exchange-card"
                   >
                     <div
@@ -581,7 +581,7 @@ exports[`Exchange should open & close add exchange modal when no existing exchan
             </div>
           </div>
           <div
-            class="sc-AxgMl kiiwkh col-span-2 border-theme-primary-contrast"
+            class="sc-AxgMl hCbQhX col-span-2 border-theme-primary-contrast"
             data-testid="Exchange__add-exchange-card"
           >
             <div
@@ -666,7 +666,7 @@ exports[`Exchange should render 1`] = `
             </div>
           </div>
           <div
-            class="sc-AxgMl kiiwkh col-span-2 border-theme-primary-contrast"
+            class="sc-AxgMl hCbQhX col-span-2 border-theme-primary-contrast"
             data-testid="Exchange__add-exchange-card"
           >
             <div
@@ -751,7 +751,7 @@ exports[`Exchange should render with exchanges 1`] = `
                   style="height: 155px;"
                 >
                   <div
-                    class="sc-AxgMl kiiwkh border-theme-primary-contrast hover:border-theme-background"
+                    class="sc-AxgMl hCbQhX border-theme-primary-contrast hover:border-theme-background"
                     data-testid="Exchange__exchange-card-changenow-plugin"
                   >
                     <div
@@ -805,7 +805,7 @@ exports[`Exchange should render with exchanges 1`] = `
                   style="height: 155px;"
                 >
                   <div
-                    class="sc-AxgMl kiiwkh border-theme-primary-contrast hover:border-theme-background"
+                    class="sc-AxgMl hCbQhX border-theme-primary-contrast hover:border-theme-background"
                     data-testid="Exchange__exchange-card-binance"
                   >
                     <div
@@ -859,7 +859,7 @@ exports[`Exchange should render with exchanges 1`] = `
                   style="height: 155px;"
                 >
                   <div
-                    class="sc-AxgMl kiiwkh border-theme-primary-contrast hover:border-theme-background"
+                    class="sc-AxgMl hCbQhX border-theme-primary-contrast hover:border-theme-background"
                     data-testid="Exchange__exchange-card-atomars"
                   >
                     <div
@@ -913,7 +913,7 @@ exports[`Exchange should render with exchanges 1`] = `
                   style="height: 155px;"
                 >
                   <div
-                    class="sc-AxgMl kiiwkh border-theme-primary-contrast hover:border-theme-background"
+                    class="sc-AxgMl hCbQhX border-theme-primary-contrast hover:border-theme-background"
                     data-testid="Exchange__exchange-card-okex"
                   >
                     <div
@@ -967,7 +967,7 @@ exports[`Exchange should render with exchanges 1`] = `
                   style="height: 155px;"
                 >
                   <div
-                    class="sc-AxgMl kiiwkh col-span-2 border-theme-primary-contrast"
+                    class="sc-AxgMl hCbQhX col-span-2 border-theme-primary-contrast"
                     data-testid="Exchange__add-exchange-card"
                   >
                     <div
@@ -991,7 +991,7 @@ exports[`Exchange should render with exchanges 1`] = `
                   style="height: 155px;"
                 >
                   <div
-                    class="sc-AxgMl kiiwkh border-theme-primary-contrast"
+                    class="sc-AxgMl hCbQhX border-theme-primary-contrast"
                     data-testid="Exchange__blank-card"
                   >
                     <div
@@ -1009,7 +1009,7 @@ exports[`Exchange should render with exchanges 1`] = `
                   style="height: 155px;"
                 >
                   <div
-                    class="sc-AxgMl kiiwkh border-theme-primary-contrast"
+                    class="sc-AxgMl hCbQhX border-theme-primary-contrast"
                     data-testid="Exchange__blank-card"
                   >
                     <div
@@ -1027,7 +1027,7 @@ exports[`Exchange should render with exchanges 1`] = `
                   style="height: 155px;"
                 >
                   <div
-                    class="sc-AxgMl kiiwkh border-theme-primary-contrast"
+                    class="sc-AxgMl hCbQhX border-theme-primary-contrast"
                     data-testid="Exchange__blank-card"
                   >
                     <div
@@ -1124,7 +1124,7 @@ exports[`Exchange should select exchange 1`] = `
                   style="height: 155px;"
                 >
                   <div
-                    class="sc-AxgMl kiiwkh bg-theme-success-contrast border-theme-success-300 hover:border-theme-success-contrast"
+                    class="sc-AxgMl hCbQhX bg-theme-success-contrast border-theme-success-300 hover:border-theme-success-contrast"
                     data-testid="Exchange__exchange-card-changenow-plugin"
                   >
                     <div
@@ -1178,7 +1178,7 @@ exports[`Exchange should select exchange 1`] = `
                   style="height: 155px;"
                 >
                   <div
-                    class="sc-AxgMl kiiwkh border-theme-primary-contrast hover:border-theme-background"
+                    class="sc-AxgMl hCbQhX border-theme-primary-contrast hover:border-theme-background"
                     data-testid="Exchange__exchange-card-binance"
                   >
                     <div
@@ -1232,7 +1232,7 @@ exports[`Exchange should select exchange 1`] = `
                   style="height: 155px;"
                 >
                   <div
-                    class="sc-AxgMl kiiwkh border-theme-primary-contrast hover:border-theme-background"
+                    class="sc-AxgMl hCbQhX border-theme-primary-contrast hover:border-theme-background"
                     data-testid="Exchange__exchange-card-atomars"
                   >
                     <div
@@ -1286,7 +1286,7 @@ exports[`Exchange should select exchange 1`] = `
                   style="height: 155px;"
                 >
                   <div
-                    class="sc-AxgMl kiiwkh col-span-2 border-theme-primary-contrast"
+                    class="sc-AxgMl hCbQhX col-span-2 border-theme-primary-contrast"
                     data-testid="Exchange__add-exchange-card"
                   >
                     <div

--- a/src/domains/help/components/ContactUs/__snapshots__/ContactUs.test.tsx.snap
+++ b/src/domains/help/components/ContactUs/__snapshots__/ContactUs.test.tsx.snap
@@ -207,7 +207,7 @@ exports[`ContactUs should render a modal 1`] = `
                   </button>
                   <ul
                     aria-labelledby="downshift-0-label"
-                    class="sc-fznKkj bhRpuu"
+                    class="sc-fznKkj cEvgLI"
                     id="downshift-0-menu"
                     role="listbox"
                     tabindex="-1"

--- a/src/domains/plugin/components/PluginCard/__snapshots__/PluginCard.test.tsx.snap
+++ b/src/domains/plugin/components/PluginCard/__snapshots__/PluginCard.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`PluginCard should render 1`] = `
 <DocumentFragment>
   <div
-    class="sc-AxiKw dtIfrz border-theme-primary-contrast hover:border-theme-background"
+    class="sc-AxiKw jNXeAh border-theme-primary-contrast hover:border-theme-background"
     data-testid="PluginCard--ark-explorer"
   >
     <div
@@ -74,7 +74,7 @@ exports[`PluginCard should render 1`] = `
 exports[`PluginCard should render grant icon 1`] = `
 <DocumentFragment>
   <div
-    class="sc-AxiKw dtIfrz border-theme-primary-contrast hover:border-theme-background"
+    class="sc-AxiKw jNXeAh border-theme-primary-contrast hover:border-theme-background"
     data-testid="PluginCard--ark-explorer"
   >
     <div
@@ -155,7 +155,7 @@ exports[`PluginCard should render grant icon 1`] = `
 exports[`PluginCard should render official icon 1`] = `
 <DocumentFragment>
   <div
-    class="sc-AxiKw dtIfrz border-theme-primary-contrast hover:border-theme-background"
+    class="sc-AxiKw jNXeAh border-theme-primary-contrast hover:border-theme-background"
     data-testid="PluginCard--ark-explorer"
   >
     <div
@@ -236,7 +236,7 @@ exports[`PluginCard should render official icon 1`] = `
 exports[`PluginCard should trigger delete 1`] = `
 <DocumentFragment>
   <div
-    class="sc-AxiKw dtIfrz border-theme-primary-contrast hover:border-theme-background"
+    class="sc-AxiKw jNXeAh border-theme-primary-contrast hover:border-theme-background"
     data-testid="PluginCard--ark-explorer"
   >
     <div

--- a/src/domains/plugin/components/PluginGrid/__snapshots__/PluginGrid.test.tsx.snap
+++ b/src/domains/plugin/components/PluginGrid/__snapshots__/PluginGrid.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`PluginGrid should render 1`] = `
       class="grid grid-cols-4 gap-5 undefined"
     >
       <div
-        class="sc-AxheI iUGyZq border-theme-primary-contrast hover:border-theme-background"
+        class="sc-AxheI gTGxWU border-theme-primary-contrast hover:border-theme-background"
         data-testid="PluginCard--ark-explorer"
       >
         <div
@@ -85,7 +85,7 @@ exports[`PluginGrid should render 1`] = `
         </div>
       </div>
       <div
-        class="sc-AxheI iUGyZq border-theme-primary-contrast hover:border-theme-background"
+        class="sc-AxheI gTGxWU border-theme-primary-contrast hover:border-theme-background"
         data-testid="PluginCard--ark-avatars"
       >
         <div
@@ -280,7 +280,7 @@ exports[`PluginGrid should render without pagination 1`] = `
       class="grid grid-cols-4 gap-5 undefined"
     >
       <div
-        class="sc-AxheI iUGyZq border-theme-primary-contrast hover:border-theme-background"
+        class="sc-AxheI gTGxWU border-theme-primary-contrast hover:border-theme-background"
         data-testid="PluginCard--ark-explorer"
       >
         <div
@@ -356,7 +356,7 @@ exports[`PluginGrid should render without pagination 1`] = `
         </div>
       </div>
       <div
-        class="sc-AxheI iUGyZq border-theme-primary-contrast hover:border-theme-background"
+        class="sc-AxheI gTGxWU border-theme-primary-contrast hover:border-theme-background"
         data-testid="PluginCard--ark-avatars"
       >
         <div
@@ -467,7 +467,7 @@ exports[`PluginGrid should split by page 1`] = `
       class="grid grid-cols-4 gap-5 undefined"
     >
       <div
-        class="sc-AxheI iUGyZq border-theme-primary-contrast hover:border-theme-background"
+        class="sc-AxheI gTGxWU border-theme-primary-contrast hover:border-theme-background"
         data-testid="PluginCard--ark-avatars"
       >
         <div
@@ -665,7 +665,7 @@ exports[`PluginGrid should trigger delete 1`] = `
       class="grid grid-cols-4 gap-5 undefined"
     >
       <div
-        class="sc-AxheI iUGyZq border-theme-primary-contrast hover:border-theme-background"
+        class="sc-AxheI gTGxWU border-theme-primary-contrast hover:border-theme-background"
         data-testid="PluginCard--ark-explorer"
       >
         <div
@@ -741,7 +741,7 @@ exports[`PluginGrid should trigger delete 1`] = `
         </div>
       </div>
       <div
-        class="sc-AxheI iUGyZq border-theme-primary-contrast hover:border-theme-background"
+        class="sc-AxheI gTGxWU border-theme-primary-contrast hover:border-theme-background"
         data-testid="PluginCard--ark-avatars"
       >
         <div
@@ -936,7 +936,7 @@ exports[`PluginGrid should trigger select 1`] = `
       class="grid grid-cols-4 gap-5 undefined"
     >
       <div
-        class="sc-AxheI iUGyZq border-theme-primary-contrast hover:border-theme-background"
+        class="sc-AxheI gTGxWU border-theme-primary-contrast hover:border-theme-background"
         data-testid="PluginCard--ark-explorer"
       >
         <div
@@ -1012,7 +1012,7 @@ exports[`PluginGrid should trigger select 1`] = `
         </div>
       </div>
       <div
-        class="sc-AxheI iUGyZq border-theme-primary-contrast hover:border-theme-background"
+        class="sc-AxheI gTGxWU border-theme-primary-contrast hover:border-theme-background"
         data-testid="PluginCard--ark-avatars"
       >
         <div

--- a/src/domains/plugin/pages/PluginManager/__snapshots__/PluginManager.test.tsx.snap
+++ b/src/domains/plugin/pages/PluginManager/__snapshots__/PluginManager.test.tsx.snap
@@ -10519,7 +10519,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                 class="grid grid-cols-4 gap-5 undefined"
               >
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-0"
                 >
                   <div
@@ -10595,7 +10595,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-0"
                 >
                   <div
@@ -10693,7 +10693,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-1"
                 >
                   <div
@@ -10769,7 +10769,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-1"
                 >
                   <div
@@ -10867,7 +10867,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-2"
                 >
                   <div
@@ -10943,7 +10943,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-2"
                 >
                   <div
@@ -11041,7 +11041,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-3"
                 >
                   <div
@@ -11117,7 +11117,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-3"
                 >
                   <div
@@ -11242,7 +11242,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                 class="grid grid-cols-4 gap-5 undefined"
               >
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-0"
                 >
                   <div
@@ -11318,7 +11318,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-0"
                 >
                   <div
@@ -11416,7 +11416,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-1"
                 >
                   <div
@@ -11492,7 +11492,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-1"
                 >
                   <div
@@ -11590,7 +11590,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-2"
                 >
                   <div
@@ -11666,7 +11666,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-2"
                 >
                   <div
@@ -11764,7 +11764,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-3"
                 >
                   <div
@@ -11840,7 +11840,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-3"
                 >
                   <div
@@ -11955,7 +11955,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                 class="grid grid-cols-4 gap-5 undefined"
               >
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-0"
                 >
                   <div
@@ -12031,7 +12031,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-0"
                 >
                   <div
@@ -12129,7 +12129,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-1"
                 >
                   <div
@@ -12205,7 +12205,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-1"
                 >
                   <div
@@ -12303,7 +12303,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-2"
                 >
                   <div
@@ -12379,7 +12379,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-2"
                 >
                   <div
@@ -12477,7 +12477,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-3"
                 >
                   <div
@@ -12553,7 +12553,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-3"
                 >
                   <div
@@ -19483,7 +19483,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
                 class="grid grid-cols-4 gap-5 undefined"
               >
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-0"
                 >
                   <div
@@ -19559,7 +19559,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-0"
                 >
                   <div
@@ -19657,7 +19657,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-1"
                 >
                   <div
@@ -19733,7 +19733,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-1"
                 >
                   <div
@@ -19831,7 +19831,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-2"
                 >
                   <div
@@ -19907,7 +19907,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-2"
                 >
                   <div
@@ -20005,7 +20005,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-3"
                 >
                   <div
@@ -20081,7 +20081,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-3"
                 >
                   <div
@@ -20206,7 +20206,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
                 class="grid grid-cols-4 gap-5 undefined"
               >
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-0"
                 >
                   <div
@@ -20282,7 +20282,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-0"
                 >
                   <div
@@ -20380,7 +20380,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-1"
                 >
                   <div
@@ -20456,7 +20456,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-1"
                 >
                   <div
@@ -20554,7 +20554,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-2"
                 >
                   <div
@@ -20630,7 +20630,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-2"
                 >
                   <div
@@ -20728,7 +20728,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-3"
                 >
                   <div
@@ -20804,7 +20804,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-3"
                 >
                   <div
@@ -20919,7 +20919,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
                 class="grid grid-cols-4 gap-5 undefined"
               >
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-0"
                 >
                   <div
@@ -20995,7 +20995,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-0"
                 >
                   <div
@@ -21093,7 +21093,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-1"
                 >
                   <div
@@ -21169,7 +21169,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-1"
                 >
                   <div
@@ -21267,7 +21267,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-2"
                 >
                   <div
@@ -21343,7 +21343,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-2"
                 >
                   <div
@@ -21441,7 +21441,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-3"
                 >
                   <div
@@ -21517,7 +21517,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-3"
                 >
                   <div
@@ -21925,7 +21925,7 @@ exports[`PluginManager should render 1`] = `
                 class="grid grid-cols-4 gap-5 undefined"
               >
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-0"
                 >
                   <div
@@ -22001,7 +22001,7 @@ exports[`PluginManager should render 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-0"
                 >
                   <div
@@ -22099,7 +22099,7 @@ exports[`PluginManager should render 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-1"
                 >
                   <div
@@ -22175,7 +22175,7 @@ exports[`PluginManager should render 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-1"
                 >
                   <div
@@ -22273,7 +22273,7 @@ exports[`PluginManager should render 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-2"
                 >
                   <div
@@ -22349,7 +22349,7 @@ exports[`PluginManager should render 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-2"
                 >
                   <div
@@ -22447,7 +22447,7 @@ exports[`PluginManager should render 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-3"
                 >
                   <div
@@ -22523,7 +22523,7 @@ exports[`PluginManager should render 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-3"
                 >
                   <div
@@ -22648,7 +22648,7 @@ exports[`PluginManager should render 1`] = `
                 class="grid grid-cols-4 gap-5 undefined"
               >
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-0"
                 >
                   <div
@@ -22724,7 +22724,7 @@ exports[`PluginManager should render 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-0"
                 >
                   <div
@@ -22822,7 +22822,7 @@ exports[`PluginManager should render 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-1"
                 >
                   <div
@@ -22898,7 +22898,7 @@ exports[`PluginManager should render 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-1"
                 >
                   <div
@@ -22996,7 +22996,7 @@ exports[`PluginManager should render 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-2"
                 >
                   <div
@@ -23072,7 +23072,7 @@ exports[`PluginManager should render 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-2"
                 >
                   <div
@@ -23170,7 +23170,7 @@ exports[`PluginManager should render 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-3"
                 >
                   <div
@@ -23246,7 +23246,7 @@ exports[`PluginManager should render 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-3"
                 >
                   <div
@@ -23361,7 +23361,7 @@ exports[`PluginManager should render 1`] = `
                 class="grid grid-cols-4 gap-5 undefined"
               >
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-0"
                 >
                   <div
@@ -23437,7 +23437,7 @@ exports[`PluginManager should render 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-0"
                 >
                   <div
@@ -23535,7 +23535,7 @@ exports[`PluginManager should render 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-1"
                 >
                   <div
@@ -23611,7 +23611,7 @@ exports[`PluginManager should render 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-1"
                 >
                   <div
@@ -23709,7 +23709,7 @@ exports[`PluginManager should render 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-2"
                 >
                   <div
@@ -23785,7 +23785,7 @@ exports[`PluginManager should render 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-2"
                 >
                   <div
@@ -23883,7 +23883,7 @@ exports[`PluginManager should render 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-3"
                 >
                   <div
@@ -23959,7 +23959,7 @@ exports[`PluginManager should render 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-3"
                 >
                   <div
@@ -24419,7 +24419,7 @@ exports[`PluginManager should search for plugin 1`] = `
                 class="grid grid-cols-4 gap-5 undefined"
               >
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-0"
                 >
                   <div
@@ -24495,7 +24495,7 @@ exports[`PluginManager should search for plugin 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-0"
                 >
                   <div
@@ -24593,7 +24593,7 @@ exports[`PluginManager should search for plugin 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-1"
                 >
                   <div
@@ -24669,7 +24669,7 @@ exports[`PluginManager should search for plugin 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-1"
                 >
                   <div
@@ -24767,7 +24767,7 @@ exports[`PluginManager should search for plugin 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-2"
                 >
                   <div
@@ -24843,7 +24843,7 @@ exports[`PluginManager should search for plugin 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-2"
                 >
                   <div
@@ -24941,7 +24941,7 @@ exports[`PluginManager should search for plugin 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-3"
                 >
                   <div
@@ -25017,7 +25017,7 @@ exports[`PluginManager should search for plugin 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-3"
                 >
                   <div
@@ -25142,7 +25142,7 @@ exports[`PluginManager should search for plugin 1`] = `
                 class="grid grid-cols-4 gap-5 undefined"
               >
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-0"
                 >
                   <div
@@ -25218,7 +25218,7 @@ exports[`PluginManager should search for plugin 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-0"
                 >
                   <div
@@ -25316,7 +25316,7 @@ exports[`PluginManager should search for plugin 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-1"
                 >
                   <div
@@ -25392,7 +25392,7 @@ exports[`PluginManager should search for plugin 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-1"
                 >
                   <div
@@ -25490,7 +25490,7 @@ exports[`PluginManager should search for plugin 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-2"
                 >
                   <div
@@ -25566,7 +25566,7 @@ exports[`PluginManager should search for plugin 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-2"
                 >
                   <div
@@ -25664,7 +25664,7 @@ exports[`PluginManager should search for plugin 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-3"
                 >
                   <div
@@ -25740,7 +25740,7 @@ exports[`PluginManager should search for plugin 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-3"
                 >
                   <div
@@ -25855,7 +25855,7 @@ exports[`PluginManager should search for plugin 1`] = `
                 class="grid grid-cols-4 gap-5 undefined"
               >
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-0"
                 >
                   <div
@@ -25931,7 +25931,7 @@ exports[`PluginManager should search for plugin 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-0"
                 >
                   <div
@@ -26029,7 +26029,7 @@ exports[`PluginManager should search for plugin 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-1"
                 >
                   <div
@@ -26105,7 +26105,7 @@ exports[`PluginManager should search for plugin 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-1"
                 >
                   <div
@@ -26203,7 +26203,7 @@ exports[`PluginManager should search for plugin 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-2"
                 >
                   <div
@@ -26279,7 +26279,7 @@ exports[`PluginManager should search for plugin 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-2"
                 >
                   <div
@@ -26377,7 +26377,7 @@ exports[`PluginManager should search for plugin 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-3"
                 >
                   <div
@@ -26453,7 +26453,7 @@ exports[`PluginManager should search for plugin 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-3"
                 >
                   <div
@@ -26839,7 +26839,7 @@ exports[`PluginManager should select plugin on game grid 1`] = `
             class="grid grid-cols-4 gap-5 mt-6"
           >
             <div
-              class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-explorer-0"
             >
               <div
@@ -26915,7 +26915,7 @@ exports[`PluginManager should select plugin on game grid 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-avatars-0"
             >
               <div
@@ -27013,7 +27013,7 @@ exports[`PluginManager should select plugin on game grid 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-explorer-1"
             >
               <div
@@ -27089,7 +27089,7 @@ exports[`PluginManager should select plugin on game grid 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-avatars-1"
             >
               <div
@@ -27187,7 +27187,7 @@ exports[`PluginManager should select plugin on game grid 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-explorer-2"
             >
               <div
@@ -27263,7 +27263,7 @@ exports[`PluginManager should select plugin on game grid 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-avatars-2"
             >
               <div
@@ -27361,7 +27361,7 @@ exports[`PluginManager should select plugin on game grid 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-explorer-3"
             >
               <div
@@ -27437,7 +27437,7 @@ exports[`PluginManager should select plugin on game grid 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-avatars-3"
             >
               <div
@@ -27535,7 +27535,7 @@ exports[`PluginManager should select plugin on game grid 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-explorer-4"
             >
               <div
@@ -27611,7 +27611,7 @@ exports[`PluginManager should select plugin on game grid 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-avatars-4"
             >
               <div
@@ -27709,7 +27709,7 @@ exports[`PluginManager should select plugin on game grid 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-explorer-5"
             >
               <div
@@ -27785,7 +27785,7 @@ exports[`PluginManager should select plugin on game grid 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-avatars-5"
             >
               <div
@@ -27883,7 +27883,7 @@ exports[`PluginManager should select plugin on game grid 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-explorer-6"
             >
               <div
@@ -27959,7 +27959,7 @@ exports[`PluginManager should select plugin on game grid 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-avatars-6"
             >
               <div
@@ -28057,7 +28057,7 @@ exports[`PluginManager should select plugin on game grid 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-explorer-7"
             >
               <div
@@ -28133,7 +28133,7 @@ exports[`PluginManager should select plugin on game grid 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-avatars-7"
             >
               <div
@@ -28231,7 +28231,7 @@ exports[`PluginManager should select plugin on game grid 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-explorer-8"
             >
               <div
@@ -28307,7 +28307,7 @@ exports[`PluginManager should select plugin on game grid 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-avatars-8"
             >
               <div
@@ -28405,7 +28405,7 @@ exports[`PluginManager should select plugin on game grid 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-explorer-9"
             >
               <div
@@ -28481,7 +28481,7 @@ exports[`PluginManager should select plugin on game grid 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-avatars-9"
             >
               <div
@@ -28971,7 +28971,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                 class="grid grid-cols-4 gap-5 undefined"
               >
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-0"
                 >
                   <div
@@ -29047,7 +29047,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-0"
                 >
                   <div
@@ -29145,7 +29145,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-1"
                 >
                   <div
@@ -29221,7 +29221,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-1"
                 >
                   <div
@@ -29319,7 +29319,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-2"
                 >
                   <div
@@ -29395,7 +29395,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-2"
                 >
                   <div
@@ -29493,7 +29493,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-3"
                 >
                   <div
@@ -29569,7 +29569,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-3"
                 >
                   <div
@@ -29694,7 +29694,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                 class="grid grid-cols-4 gap-5 undefined"
               >
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-0"
                 >
                   <div
@@ -29770,7 +29770,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-0"
                 >
                   <div
@@ -29868,7 +29868,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-1"
                 >
                   <div
@@ -29944,7 +29944,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-1"
                 >
                   <div
@@ -30042,7 +30042,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-2"
                 >
                   <div
@@ -30118,7 +30118,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-2"
                 >
                   <div
@@ -30216,7 +30216,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-3"
                 >
                   <div
@@ -30292,7 +30292,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-3"
                 >
                   <div
@@ -30407,7 +30407,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                 class="grid grid-cols-4 gap-5 undefined"
               >
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-0"
                 >
                   <div
@@ -30483,7 +30483,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-0"
                 >
                   <div
@@ -30581,7 +30581,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-1"
                 >
                   <div
@@ -30657,7 +30657,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-1"
                 >
                   <div
@@ -30755,7 +30755,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-2"
                 >
                   <div
@@ -30831,7 +30831,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-2"
                 >
                   <div
@@ -30929,7 +30929,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-3"
                 >
                   <div
@@ -31005,7 +31005,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-3"
                 >
                   <div
@@ -31391,7 +31391,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
             class="grid grid-cols-4 gap-5 mt-6"
           >
             <div
-              class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-explorer-0"
             >
               <div
@@ -31467,7 +31467,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-avatars-0"
             >
               <div
@@ -31565,7 +31565,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-explorer-1"
             >
               <div
@@ -31641,7 +31641,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-avatars-1"
             >
               <div
@@ -31739,7 +31739,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-explorer-2"
             >
               <div
@@ -31815,7 +31815,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-avatars-2"
             >
               <div
@@ -31913,7 +31913,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-explorer-3"
             >
               <div
@@ -31989,7 +31989,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-avatars-3"
             >
               <div
@@ -32087,7 +32087,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-explorer-4"
             >
               <div
@@ -32163,7 +32163,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-avatars-4"
             >
               <div
@@ -32261,7 +32261,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-explorer-5"
             >
               <div
@@ -32337,7 +32337,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-avatars-5"
             >
               <div
@@ -32435,7 +32435,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-explorer-6"
             >
               <div
@@ -32511,7 +32511,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-avatars-6"
             >
               <div
@@ -32609,7 +32609,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-explorer-7"
             >
               <div
@@ -32685,7 +32685,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-avatars-7"
             >
               <div
@@ -32783,7 +32783,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-explorer-8"
             >
               <div
@@ -32859,7 +32859,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-avatars-8"
             >
               <div
@@ -32957,7 +32957,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-explorer-9"
             >
               <div
@@ -33033,7 +33033,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-avatars-9"
             >
               <div
@@ -33523,7 +33523,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                 class="grid grid-cols-4 gap-5 undefined"
               >
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-0"
                 >
                   <div
@@ -33599,7 +33599,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-0"
                 >
                   <div
@@ -33697,7 +33697,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-1"
                 >
                   <div
@@ -33773,7 +33773,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-1"
                 >
                   <div
@@ -33871,7 +33871,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-2"
                 >
                   <div
@@ -33947,7 +33947,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-2"
                 >
                   <div
@@ -34045,7 +34045,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-3"
                 >
                   <div
@@ -34121,7 +34121,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-3"
                 >
                   <div
@@ -34246,7 +34246,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                 class="grid grid-cols-4 gap-5 undefined"
               >
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-0"
                 >
                   <div
@@ -34322,7 +34322,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-0"
                 >
                   <div
@@ -34420,7 +34420,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-1"
                 >
                   <div
@@ -34496,7 +34496,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-1"
                 >
                   <div
@@ -34594,7 +34594,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-2"
                 >
                   <div
@@ -34670,7 +34670,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-2"
                 >
                   <div
@@ -34768,7 +34768,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-3"
                 >
                   <div
@@ -34844,7 +34844,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-3"
                 >
                   <div
@@ -34959,7 +34959,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                 class="grid grid-cols-4 gap-5 undefined"
               >
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-0"
                 >
                   <div
@@ -35035,7 +35035,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-0"
                 >
                   <div
@@ -35133,7 +35133,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-1"
                 >
                   <div
@@ -35209,7 +35209,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-1"
                 >
                   <div
@@ -35307,7 +35307,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-2"
                 >
                   <div
@@ -35383,7 +35383,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-2"
                 >
                   <div
@@ -35481,7 +35481,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-3"
                 >
                   <div
@@ -35557,7 +35557,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-3"
                 >
                   <div

--- a/src/domains/plugin/pages/PluginManager/__snapshots__/PluginManager.test.tsx.snap
+++ b/src/domains/plugin/pages/PluginManager/__snapshots__/PluginManager.test.tsx.snap
@@ -10509,7 +10509,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                 class="grid grid-cols-4 gap-5 undefined"
               >
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-0"
                 >
                   <div
@@ -10585,7 +10585,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-0"
                 >
                   <div
@@ -10683,7 +10683,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-1"
                 >
                   <div
@@ -10759,7 +10759,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-1"
                 >
                   <div
@@ -10857,7 +10857,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-2"
                 >
                   <div
@@ -10933,7 +10933,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-2"
                 >
                   <div
@@ -11031,7 +11031,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-3"
                 >
                   <div
@@ -11107,7 +11107,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-3"
                 >
                   <div
@@ -11230,7 +11230,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                 class="grid grid-cols-4 gap-5 undefined"
               >
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-0"
                 >
                   <div
@@ -11306,7 +11306,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-0"
                 >
                   <div
@@ -11404,7 +11404,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-1"
                 >
                   <div
@@ -11480,7 +11480,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-1"
                 >
                   <div
@@ -11578,7 +11578,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-2"
                 >
                   <div
@@ -11654,7 +11654,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-2"
                 >
                   <div
@@ -11752,7 +11752,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-3"
                 >
                   <div
@@ -11828,7 +11828,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-3"
                 >
                   <div
@@ -11943,7 +11943,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                 class="grid grid-cols-4 gap-5 undefined"
               >
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-0"
                 >
                   <div
@@ -12019,7 +12019,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-0"
                 >
                   <div
@@ -12117,7 +12117,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-1"
                 >
                   <div
@@ -12193,7 +12193,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-1"
                 >
                   <div
@@ -12291,7 +12291,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-2"
                 >
                   <div
@@ -12367,7 +12367,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-2"
                 >
                   <div
@@ -12465,7 +12465,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-3"
                 >
                   <div
@@ -12541,7 +12541,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-3"
                 >
                   <div
@@ -19310,7 +19310,7 @@ exports[`PluginManager should open & close featured modal 1`] = `
                 class="grid grid-cols-4 gap-5 undefined"
               >
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-0"
                 >
                   <div
@@ -19386,7 +19386,7 @@ exports[`PluginManager should open & close featured modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-0"
                 >
                   <div
@@ -19484,7 +19484,7 @@ exports[`PluginManager should open & close featured modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-1"
                 >
                   <div
@@ -19560,7 +19560,7 @@ exports[`PluginManager should open & close featured modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-1"
                 >
                   <div
@@ -19658,7 +19658,7 @@ exports[`PluginManager should open & close featured modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-2"
                 >
                   <div
@@ -19734,7 +19734,7 @@ exports[`PluginManager should open & close featured modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-2"
                 >
                   <div
@@ -19832,7 +19832,7 @@ exports[`PluginManager should open & close featured modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-3"
                 >
                   <div
@@ -19908,7 +19908,7 @@ exports[`PluginManager should open & close featured modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-3"
                 >
                   <div
@@ -20031,7 +20031,7 @@ exports[`PluginManager should open & close featured modal 1`] = `
                 class="grid grid-cols-4 gap-5 undefined"
               >
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-0"
                 >
                   <div
@@ -20107,7 +20107,7 @@ exports[`PluginManager should open & close featured modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-0"
                 >
                   <div
@@ -20205,7 +20205,7 @@ exports[`PluginManager should open & close featured modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-1"
                 >
                   <div
@@ -20281,7 +20281,7 @@ exports[`PluginManager should open & close featured modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-1"
                 >
                   <div
@@ -20379,7 +20379,7 @@ exports[`PluginManager should open & close featured modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-2"
                 >
                   <div
@@ -20455,7 +20455,7 @@ exports[`PluginManager should open & close featured modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-2"
                 >
                   <div
@@ -20553,7 +20553,7 @@ exports[`PluginManager should open & close featured modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-3"
                 >
                   <div
@@ -20629,7 +20629,7 @@ exports[`PluginManager should open & close featured modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-3"
                 >
                   <div
@@ -20744,7 +20744,7 @@ exports[`PluginManager should open & close featured modal 1`] = `
                 class="grid grid-cols-4 gap-5 undefined"
               >
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-0"
                 >
                   <div
@@ -20820,7 +20820,7 @@ exports[`PluginManager should open & close featured modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-0"
                 >
                   <div
@@ -20918,7 +20918,7 @@ exports[`PluginManager should open & close featured modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-1"
                 >
                   <div
@@ -20994,7 +20994,7 @@ exports[`PluginManager should open & close featured modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-1"
                 >
                   <div
@@ -21092,7 +21092,7 @@ exports[`PluginManager should open & close featured modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-2"
                 >
                   <div
@@ -21168,7 +21168,7 @@ exports[`PluginManager should open & close featured modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-2"
                 >
                   <div
@@ -21266,7 +21266,7 @@ exports[`PluginManager should open & close featured modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-3"
                 >
                   <div
@@ -21342,7 +21342,7 @@ exports[`PluginManager should open & close featured modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-3"
                 >
                   <div
@@ -21748,7 +21748,7 @@ exports[`PluginManager should open & close top rated modal 1`] = `
                 class="grid grid-cols-4 gap-5 undefined"
               >
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-0"
                 >
                   <div
@@ -21824,7 +21824,7 @@ exports[`PluginManager should open & close top rated modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-0"
                 >
                   <div
@@ -21922,7 +21922,7 @@ exports[`PluginManager should open & close top rated modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-1"
                 >
                   <div
@@ -21998,7 +21998,7 @@ exports[`PluginManager should open & close top rated modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-1"
                 >
                   <div
@@ -22096,7 +22096,7 @@ exports[`PluginManager should open & close top rated modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-2"
                 >
                   <div
@@ -22172,7 +22172,7 @@ exports[`PluginManager should open & close top rated modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-2"
                 >
                   <div
@@ -22270,7 +22270,7 @@ exports[`PluginManager should open & close top rated modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-3"
                 >
                   <div
@@ -22346,7 +22346,7 @@ exports[`PluginManager should open & close top rated modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-3"
                 >
                   <div
@@ -22469,7 +22469,7 @@ exports[`PluginManager should open & close top rated modal 1`] = `
                 class="grid grid-cols-4 gap-5 undefined"
               >
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-0"
                 >
                   <div
@@ -22545,7 +22545,7 @@ exports[`PluginManager should open & close top rated modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-0"
                 >
                   <div
@@ -22643,7 +22643,7 @@ exports[`PluginManager should open & close top rated modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-1"
                 >
                   <div
@@ -22719,7 +22719,7 @@ exports[`PluginManager should open & close top rated modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-1"
                 >
                   <div
@@ -22817,7 +22817,7 @@ exports[`PluginManager should open & close top rated modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-2"
                 >
                   <div
@@ -22893,7 +22893,7 @@ exports[`PluginManager should open & close top rated modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-2"
                 >
                   <div
@@ -22991,7 +22991,7 @@ exports[`PluginManager should open & close top rated modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-3"
                 >
                   <div
@@ -23067,7 +23067,7 @@ exports[`PluginManager should open & close top rated modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-3"
                 >
                   <div
@@ -23182,7 +23182,7 @@ exports[`PluginManager should open & close top rated modal 1`] = `
                 class="grid grid-cols-4 gap-5 undefined"
               >
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-0"
                 >
                   <div
@@ -23258,7 +23258,7 @@ exports[`PluginManager should open & close top rated modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-0"
                 >
                   <div
@@ -23356,7 +23356,7 @@ exports[`PluginManager should open & close top rated modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-1"
                 >
                   <div
@@ -23432,7 +23432,7 @@ exports[`PluginManager should open & close top rated modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-1"
                 >
                   <div
@@ -23530,7 +23530,7 @@ exports[`PluginManager should open & close top rated modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-2"
                 >
                   <div
@@ -23606,7 +23606,7 @@ exports[`PluginManager should open & close top rated modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-2"
                 >
                   <div
@@ -23704,7 +23704,7 @@ exports[`PluginManager should open & close top rated modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-3"
                 >
                   <div
@@ -23780,7 +23780,7 @@ exports[`PluginManager should open & close top rated modal 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-3"
                 >
                   <div
@@ -24186,7 +24186,7 @@ exports[`PluginManager should render 1`] = `
                 class="grid grid-cols-4 gap-5 undefined"
               >
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-0"
                 >
                   <div
@@ -24262,7 +24262,7 @@ exports[`PluginManager should render 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-0"
                 >
                   <div
@@ -24360,7 +24360,7 @@ exports[`PluginManager should render 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-1"
                 >
                   <div
@@ -24436,7 +24436,7 @@ exports[`PluginManager should render 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-1"
                 >
                   <div
@@ -24534,7 +24534,7 @@ exports[`PluginManager should render 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-2"
                 >
                   <div
@@ -24610,7 +24610,7 @@ exports[`PluginManager should render 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-2"
                 >
                   <div
@@ -24708,7 +24708,7 @@ exports[`PluginManager should render 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-3"
                 >
                   <div
@@ -24784,7 +24784,7 @@ exports[`PluginManager should render 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-3"
                 >
                   <div
@@ -24907,7 +24907,7 @@ exports[`PluginManager should render 1`] = `
                 class="grid grid-cols-4 gap-5 undefined"
               >
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-0"
                 >
                   <div
@@ -24983,7 +24983,7 @@ exports[`PluginManager should render 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-0"
                 >
                   <div
@@ -25081,7 +25081,7 @@ exports[`PluginManager should render 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-1"
                 >
                   <div
@@ -25157,7 +25157,7 @@ exports[`PluginManager should render 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-1"
                 >
                   <div
@@ -25255,7 +25255,7 @@ exports[`PluginManager should render 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-2"
                 >
                   <div
@@ -25331,7 +25331,7 @@ exports[`PluginManager should render 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-2"
                 >
                   <div
@@ -25429,7 +25429,7 @@ exports[`PluginManager should render 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-3"
                 >
                   <div
@@ -25505,7 +25505,7 @@ exports[`PluginManager should render 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-3"
                 >
                   <div
@@ -25620,7 +25620,7 @@ exports[`PluginManager should render 1`] = `
                 class="grid grid-cols-4 gap-5 undefined"
               >
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-0"
                 >
                   <div
@@ -25696,7 +25696,7 @@ exports[`PluginManager should render 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-0"
                 >
                   <div
@@ -25794,7 +25794,7 @@ exports[`PluginManager should render 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-1"
                 >
                   <div
@@ -25870,7 +25870,7 @@ exports[`PluginManager should render 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-1"
                 >
                   <div
@@ -25968,7 +25968,7 @@ exports[`PluginManager should render 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-2"
                 >
                   <div
@@ -26044,7 +26044,7 @@ exports[`PluginManager should render 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-2"
                 >
                   <div
@@ -26142,7 +26142,7 @@ exports[`PluginManager should render 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-3"
                 >
                   <div
@@ -26218,7 +26218,7 @@ exports[`PluginManager should render 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-3"
                 >
                   <div
@@ -26676,7 +26676,7 @@ exports[`PluginManager should search for plugin 1`] = `
                 class="grid grid-cols-4 gap-5 undefined"
               >
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-0"
                 >
                   <div
@@ -26752,7 +26752,7 @@ exports[`PluginManager should search for plugin 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-0"
                 >
                   <div
@@ -26850,7 +26850,7 @@ exports[`PluginManager should search for plugin 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-1"
                 >
                   <div
@@ -26926,7 +26926,7 @@ exports[`PluginManager should search for plugin 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-1"
                 >
                   <div
@@ -27024,7 +27024,7 @@ exports[`PluginManager should search for plugin 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-2"
                 >
                   <div
@@ -27100,7 +27100,7 @@ exports[`PluginManager should search for plugin 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-2"
                 >
                   <div
@@ -27198,7 +27198,7 @@ exports[`PluginManager should search for plugin 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-3"
                 >
                   <div
@@ -27274,7 +27274,7 @@ exports[`PluginManager should search for plugin 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-3"
                 >
                   <div
@@ -27397,7 +27397,7 @@ exports[`PluginManager should search for plugin 1`] = `
                 class="grid grid-cols-4 gap-5 undefined"
               >
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-0"
                 >
                   <div
@@ -27473,7 +27473,7 @@ exports[`PluginManager should search for plugin 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-0"
                 >
                   <div
@@ -27571,7 +27571,7 @@ exports[`PluginManager should search for plugin 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-1"
                 >
                   <div
@@ -27647,7 +27647,7 @@ exports[`PluginManager should search for plugin 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-1"
                 >
                   <div
@@ -27745,7 +27745,7 @@ exports[`PluginManager should search for plugin 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-2"
                 >
                   <div
@@ -27821,7 +27821,7 @@ exports[`PluginManager should search for plugin 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-2"
                 >
                   <div
@@ -27919,7 +27919,7 @@ exports[`PluginManager should search for plugin 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-3"
                 >
                   <div
@@ -27995,7 +27995,7 @@ exports[`PluginManager should search for plugin 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-3"
                 >
                   <div
@@ -28110,7 +28110,7 @@ exports[`PluginManager should search for plugin 1`] = `
                 class="grid grid-cols-4 gap-5 undefined"
               >
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-0"
                 >
                   <div
@@ -28186,7 +28186,7 @@ exports[`PluginManager should search for plugin 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-0"
                 >
                   <div
@@ -28284,7 +28284,7 @@ exports[`PluginManager should search for plugin 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-1"
                 >
                   <div
@@ -28360,7 +28360,7 @@ exports[`PluginManager should search for plugin 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-1"
                 >
                   <div
@@ -28458,7 +28458,7 @@ exports[`PluginManager should search for plugin 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-2"
                 >
                   <div
@@ -28534,7 +28534,7 @@ exports[`PluginManager should search for plugin 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-2"
                 >
                   <div
@@ -28632,7 +28632,7 @@ exports[`PluginManager should search for plugin 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-3"
                 >
                   <div
@@ -28708,7 +28708,7 @@ exports[`PluginManager should search for plugin 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-3"
                 >
                   <div
@@ -29094,7 +29094,7 @@ exports[`PluginManager should select plugin on game grid 1`] = `
             class="grid grid-cols-4 gap-5 mt-6"
           >
             <div
-              class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-explorer-0"
             >
               <div
@@ -29170,7 +29170,7 @@ exports[`PluginManager should select plugin on game grid 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-avatars-0"
             >
               <div
@@ -29268,7 +29268,7 @@ exports[`PluginManager should select plugin on game grid 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-explorer-1"
             >
               <div
@@ -29344,7 +29344,7 @@ exports[`PluginManager should select plugin on game grid 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-avatars-1"
             >
               <div
@@ -29442,7 +29442,7 @@ exports[`PluginManager should select plugin on game grid 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-explorer-2"
             >
               <div
@@ -29518,7 +29518,7 @@ exports[`PluginManager should select plugin on game grid 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-avatars-2"
             >
               <div
@@ -29616,7 +29616,7 @@ exports[`PluginManager should select plugin on game grid 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-explorer-3"
             >
               <div
@@ -29692,7 +29692,7 @@ exports[`PluginManager should select plugin on game grid 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-avatars-3"
             >
               <div
@@ -29790,7 +29790,7 @@ exports[`PluginManager should select plugin on game grid 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-explorer-4"
             >
               <div
@@ -29866,7 +29866,7 @@ exports[`PluginManager should select plugin on game grid 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-avatars-4"
             >
               <div
@@ -29964,7 +29964,7 @@ exports[`PluginManager should select plugin on game grid 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-explorer-5"
             >
               <div
@@ -30040,7 +30040,7 @@ exports[`PluginManager should select plugin on game grid 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-avatars-5"
             >
               <div
@@ -30138,7 +30138,7 @@ exports[`PluginManager should select plugin on game grid 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-explorer-6"
             >
               <div
@@ -30214,7 +30214,7 @@ exports[`PluginManager should select plugin on game grid 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-avatars-6"
             >
               <div
@@ -30312,7 +30312,7 @@ exports[`PluginManager should select plugin on game grid 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-explorer-7"
             >
               <div
@@ -30388,7 +30388,7 @@ exports[`PluginManager should select plugin on game grid 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-avatars-7"
             >
               <div
@@ -30486,7 +30486,7 @@ exports[`PluginManager should select plugin on game grid 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-explorer-8"
             >
               <div
@@ -30562,7 +30562,7 @@ exports[`PluginManager should select plugin on game grid 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-avatars-8"
             >
               <div
@@ -30660,7 +30660,7 @@ exports[`PluginManager should select plugin on game grid 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-explorer-9"
             >
               <div
@@ -30736,7 +30736,7 @@ exports[`PluginManager should select plugin on game grid 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-avatars-9"
             >
               <div
@@ -31224,7 +31224,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                 class="grid grid-cols-4 gap-5 undefined"
               >
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-0"
                 >
                   <div
@@ -31300,7 +31300,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-0"
                 >
                   <div
@@ -31398,7 +31398,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-1"
                 >
                   <div
@@ -31474,7 +31474,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-1"
                 >
                   <div
@@ -31572,7 +31572,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-2"
                 >
                   <div
@@ -31648,7 +31648,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-2"
                 >
                   <div
@@ -31746,7 +31746,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-3"
                 >
                   <div
@@ -31822,7 +31822,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-3"
                 >
                   <div
@@ -31945,7 +31945,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                 class="grid grid-cols-4 gap-5 undefined"
               >
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-0"
                 >
                   <div
@@ -32021,7 +32021,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-0"
                 >
                   <div
@@ -32119,7 +32119,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-1"
                 >
                   <div
@@ -32195,7 +32195,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-1"
                 >
                   <div
@@ -32293,7 +32293,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-2"
                 >
                   <div
@@ -32369,7 +32369,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-2"
                 >
                   <div
@@ -32467,7 +32467,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-3"
                 >
                   <div
@@ -32543,7 +32543,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-3"
                 >
                   <div
@@ -32658,7 +32658,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                 class="grid grid-cols-4 gap-5 undefined"
               >
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-0"
                 >
                   <div
@@ -32734,7 +32734,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-0"
                 >
                   <div
@@ -32832,7 +32832,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-1"
                 >
                   <div
@@ -32908,7 +32908,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-1"
                 >
                   <div
@@ -33006,7 +33006,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-2"
                 >
                   <div
@@ -33082,7 +33082,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-2"
                 >
                   <div
@@ -33180,7 +33180,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-3"
                 >
                   <div
@@ -33256,7 +33256,7 @@ exports[`PluginManager should select plugin on home grids 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-3"
                 >
                   <div
@@ -33642,7 +33642,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
             class="grid grid-cols-4 gap-5 mt-6"
           >
             <div
-              class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-explorer-0"
             >
               <div
@@ -33718,7 +33718,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-avatars-0"
             >
               <div
@@ -33816,7 +33816,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-explorer-1"
             >
               <div
@@ -33892,7 +33892,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-avatars-1"
             >
               <div
@@ -33990,7 +33990,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-explorer-2"
             >
               <div
@@ -34066,7 +34066,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-avatars-2"
             >
               <div
@@ -34164,7 +34164,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-explorer-3"
             >
               <div
@@ -34240,7 +34240,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-avatars-3"
             >
               <div
@@ -34338,7 +34338,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-explorer-4"
             >
               <div
@@ -34414,7 +34414,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-avatars-4"
             >
               <div
@@ -34512,7 +34512,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-explorer-5"
             >
               <div
@@ -34588,7 +34588,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-avatars-5"
             >
               <div
@@ -34686,7 +34686,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-explorer-6"
             >
               <div
@@ -34762,7 +34762,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-avatars-6"
             >
               <div
@@ -34860,7 +34860,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-explorer-7"
             >
               <div
@@ -34936,7 +34936,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-avatars-7"
             >
               <div
@@ -35034,7 +35034,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-explorer-8"
             >
               <div
@@ -35110,7 +35110,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-avatars-8"
             >
               <div
@@ -35208,7 +35208,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-explorer-9"
             >
               <div
@@ -35284,7 +35284,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
               </div>
             </div>
             <div
-              class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+              class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
               data-testid="PluginCard--ark-avatars-9"
             >
               <div
@@ -35772,7 +35772,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                 class="grid grid-cols-4 gap-5 undefined"
               >
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-0"
                 >
                   <div
@@ -35848,7 +35848,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-0"
                 >
                   <div
@@ -35946,7 +35946,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-1"
                 >
                   <div
@@ -36022,7 +36022,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-1"
                 >
                   <div
@@ -36120,7 +36120,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-2"
                 >
                   <div
@@ -36196,7 +36196,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-2"
                 >
                   <div
@@ -36294,7 +36294,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-3"
                 >
                   <div
@@ -36370,7 +36370,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-3"
                 >
                   <div
@@ -36493,7 +36493,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                 class="grid grid-cols-4 gap-5 undefined"
               >
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-0"
                 >
                   <div
@@ -36569,7 +36569,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-0"
                 >
                   <div
@@ -36667,7 +36667,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-1"
                 >
                   <div
@@ -36743,7 +36743,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-1"
                 >
                   <div
@@ -36841,7 +36841,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-2"
                 >
                   <div
@@ -36917,7 +36917,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-2"
                 >
                   <div
@@ -37015,7 +37015,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-3"
                 >
                   <div
@@ -37091,7 +37091,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-3"
                 >
                   <div
@@ -37206,7 +37206,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                 class="grid grid-cols-4 gap-5 undefined"
               >
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-0"
                 >
                   <div
@@ -37282,7 +37282,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-0"
                 >
                   <div
@@ -37380,7 +37380,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-1"
                 >
                   <div
@@ -37456,7 +37456,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-1"
                 >
                   <div
@@ -37554,7 +37554,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-2"
                 >
                   <div
@@ -37630,7 +37630,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-2"
                 >
                   <div
@@ -37728,7 +37728,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-3"
                 >
                   <div
@@ -37804,7 +37804,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoXzr gmpeGY border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoXzr iejXhe border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-3"
                 >
                   <div

--- a/src/domains/plugin/pages/PluginsCategory/__snapshots__/PluginsCategory.test.tsx.snap
+++ b/src/domains/plugin/pages/PluginsCategory/__snapshots__/PluginsCategory.test.tsx.snap
@@ -11166,7 +11166,7 @@ exports[`PluginsCategory should select plugin on grid 1`] = `
                 class="grid grid-cols-4 gap-5 undefined"
               >
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-0"
                 >
                   <div
@@ -11242,7 +11242,7 @@ exports[`PluginsCategory should select plugin on grid 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-0"
                 >
                   <div
@@ -11340,7 +11340,7 @@ exports[`PluginsCategory should select plugin on grid 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-1"
                 >
                   <div
@@ -11416,7 +11416,7 @@ exports[`PluginsCategory should select plugin on grid 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-1"
                 >
                   <div
@@ -11514,7 +11514,7 @@ exports[`PluginsCategory should select plugin on grid 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-2"
                 >
                   <div
@@ -11590,7 +11590,7 @@ exports[`PluginsCategory should select plugin on grid 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-2"
                 >
                   <div
@@ -11688,7 +11688,7 @@ exports[`PluginsCategory should select plugin on grid 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-3"
                 >
                   <div
@@ -11764,7 +11764,7 @@ exports[`PluginsCategory should select plugin on grid 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-3"
                 >
                   <div
@@ -12030,7 +12030,7 @@ exports[`PluginsCategory should toggle between list and grid 1`] = `
                 class="grid grid-cols-4 gap-5 undefined"
               >
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-0"
                 >
                   <div
@@ -12106,7 +12106,7 @@ exports[`PluginsCategory should toggle between list and grid 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-0"
                 >
                   <div
@@ -12204,7 +12204,7 @@ exports[`PluginsCategory should toggle between list and grid 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-1"
                 >
                   <div
@@ -12280,7 +12280,7 @@ exports[`PluginsCategory should toggle between list and grid 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-1"
                 >
                   <div
@@ -12378,7 +12378,7 @@ exports[`PluginsCategory should toggle between list and grid 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-2"
                 >
                   <div
@@ -12454,7 +12454,7 @@ exports[`PluginsCategory should toggle between list and grid 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-2"
                 >
                   <div
@@ -12552,7 +12552,7 @@ exports[`PluginsCategory should toggle between list and grid 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-explorer-3"
                 >
                   <div
@@ -12628,7 +12628,7 @@ exports[`PluginsCategory should toggle between list and grid 1`] = `
                   </div>
                 </div>
                 <div
-                  class="sc-fzoLag ePrjYq border-theme-primary-contrast hover:border-theme-background"
+                  class="sc-fzoLag dKoxQc border-theme-primary-contrast hover:border-theme-background"
                   data-testid="PluginCard--ark-avatars-3"
                 >
                   <div

--- a/src/domains/profile/pages/CreateProfile/__snapshots__/CreateProfile.test.tsx.snap
+++ b/src/domains/profile/pages/CreateProfile/__snapshots__/CreateProfile.test.tsx.snap
@@ -213,7 +213,7 @@ exports[`CreateProfile should render 1`] = `
                       </button>
                       <ul
                         aria-labelledby="downshift-0-label"
-                        class="sc-fznKkj bhRpuu"
+                        class="sc-fznKkj cEvgLI"
                         id="downshift-0-menu"
                         role="listbox"
                         tabindex="-1"
@@ -274,7 +274,7 @@ exports[`CreateProfile should render 1`] = `
                       </button>
                       <ul
                         aria-labelledby="downshift-1-label"
-                        class="sc-fznKkj bhRpuu"
+                        class="sc-fznKkj cEvgLI"
                         id="downshift-1-menu"
                         role="listbox"
                         tabindex="-1"

--- a/src/domains/setting/pages/Settings/__snapshots__/Settings.test.tsx.snap
+++ b/src/domains/setting/pages/Settings/__snapshots__/Settings.test.tsx.snap
@@ -294,7 +294,7 @@ exports[`Settings should open & close modals in the plugin settings 1`] = `
                       </button>
                       <ul
                         aria-labelledby="downshift-25-label"
-                        class="sc-fznZeY jSUIcW"
+                        class="sc-fznZeY cAOkZU"
                         id="downshift-25-menu"
                         role="listbox"
                         tabindex="-1"
@@ -614,7 +614,7 @@ exports[`Settings should render 1`] = `
                       </button>
                       <ul
                         aria-labelledby="downshift-0-label"
-                        class="sc-fznZeY jSUIcW"
+                        class="sc-fznZeY cAOkZU"
                         id="downshift-0-menu"
                         role="listbox"
                         tabindex="-1"
@@ -675,7 +675,7 @@ exports[`Settings should render 1`] = `
                       </button>
                       <ul
                         aria-labelledby="downshift-1-label"
-                        class="sc-fznZeY jSUIcW"
+                        class="sc-fznZeY cAOkZU"
                         id="downshift-1-menu"
                         role="listbox"
                         tabindex="-1"
@@ -740,7 +740,7 @@ exports[`Settings should render 1`] = `
                       </button>
                       <ul
                         aria-labelledby="downshift-2-label"
-                        class="sc-fznZeY jSUIcW"
+                        class="sc-fznZeY cAOkZU"
                         id="downshift-2-menu"
                         role="listbox"
                         tabindex="-1"
@@ -801,7 +801,7 @@ exports[`Settings should render 1`] = `
                       </button>
                       <ul
                         aria-labelledby="downshift-3-label"
-                        class="sc-fznZeY jSUIcW"
+                        class="sc-fznZeY cAOkZU"
                         id="downshift-3-menu"
                         role="listbox"
                         tabindex="-1"
@@ -862,7 +862,7 @@ exports[`Settings should render 1`] = `
                       </button>
                       <ul
                         aria-labelledby="downshift-4-label"
-                        class="sc-fznZeY jSUIcW"
+                        class="sc-fznZeY cAOkZU"
                         id="downshift-4-menu"
                         role="listbox"
                         tabindex="-1"
@@ -1063,7 +1063,7 @@ exports[`Settings should render 1`] = `
                         </button>
                         <ul
                           aria-labelledby="downshift-5-label"
-                          class="sc-fznZeY jSUIcW"
+                          class="sc-fznZeY cAOkZU"
                           id="downshift-5-menu"
                           role="listbox"
                           tabindex="-1"
@@ -2137,7 +2137,7 @@ exports[`Settings should render plugin settings 1`] = `
                       </button>
                       <ul
                         aria-labelledby="downshift-18-label"
-                        class="sc-fznZeY jSUIcW"
+                        class="sc-fznZeY cAOkZU"
                         id="downshift-18-menu"
                         role="listbox"
                         tabindex="-1"

--- a/src/domains/transaction/components/LinkCollection/__snapshots__/LinkCollection.test.tsx.snap
+++ b/src/domains/transaction/components/LinkCollection/__snapshots__/LinkCollection.test.tsx.snap
@@ -85,7 +85,7 @@ exports[`LinkCollection should add and remove links 1`] = `
                     </button>
                     <ul
                       aria-labelledby="downshift-1-label"
-                      class="sc-fznyAO jqtNXL"
+                      class="sc-fznyAO hRuprx"
                       id="downshift-1-menu"
                       role="listbox"
                       tabindex="-1"
@@ -367,7 +367,7 @@ exports[`LinkCollection should select a specific link type 1`] = `
                     />
                     <ul
                       aria-labelledby="downshift-8-label"
-                      class="sc-fznyAO jqtNXL"
+                      class="sc-fznyAO hRuprx"
                       id="downshift-8-menu"
                       role="listbox"
                       tabindex="-1"

--- a/src/domains/transaction/pages/Registration/__snapshots__/Registration.test.tsx.snap
+++ b/src/domains/transaction/pages/Registration/__snapshots__/Registration.test.tsx.snap
@@ -294,7 +294,7 @@ exports[`Registration should render 1st step 1`] = `
                             />
                             <ul
                               aria-labelledby="downshift-1-label"
-                              class="sc-fznZeY jSUIcW"
+                              class="sc-fznZeY cAOkZU"
                               id="downshift-1-menu"
                               role="listbox"
                               tabindex="-1"
@@ -2087,7 +2087,7 @@ exports[`Registration should select registration type 1`] = `
                             </button>
                             <ul
                               aria-labelledby="downshift-26-label"
-                              class="sc-fznZeY jSUIcW"
+                              class="sc-fznZeY cAOkZU"
                               id="downshift-26-menu"
                               role="listbox"
                               tabindex="-1"
@@ -2436,7 +2436,7 @@ exports[`Registration should should go back 1`] = `
                             />
                             <ul
                               aria-labelledby="downshift-6-label"
-                              class="sc-fznZeY jSUIcW"
+                              class="sc-fznZeY cAOkZU"
                               id="downshift-6-menu"
                               role="listbox"
                               tabindex="-1"

--- a/src/tailwind.config.js
+++ b/src/tailwind.config.js
@@ -172,7 +172,7 @@ module.exports = {
 				default: "0 1px 3px 0 var(--theme-color-neutral-200), 0 1px 2px 0 var(--theme-color-neutral-100)",
 				md: "0 4px 6px -1px var(--theme-color-neutral-200), 0 2px 4px -1px var(--theme-color-neutral-100)",
 				lg: "0 10px 15px -3px var(--theme-color-neutral-200), 0 4px 6px -2px var(--theme-color-neutral-100)",
-				xl: "0px 15px 29px #B8CDD44D",
+				xl: "0 15px 29px rgba(var(--theme-color-neutral-rgb), 0.17)",
 				outline: "0 0 0 3px rgba(var(--theme-color-primary-rgb), 0.4)",
 			},
 			listStyleType: {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Replace hardcoded value with `neutral-rbg` and opacity for `shadow-xl`

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
