### PR TITLE
refactor: remove readonly and add disabled property

### DIFF
--- a/src/app/components/Card/Card.stories.tsx
+++ b/src/app/components/Card/Card.stories.tsx
@@ -8,7 +8,7 @@ export default { title: "App / Components / Card" };
 export const Default = () => <Card className="inline-flex">ARK Ecosystem</Card>;
 
 export const Control = () => (
-	<div className="grid max-w-lg grid-cols-3 gap-4">
+	<div className="max-w-lg grid grid-cols-3 gap-4">
 		<CardControl defaultChecked={true} className="grid">
 			<div className="flex flex-col items-center justify-between h-full space-y-3">
 				<span className="text-center">ARK Ecosystem</span>

--- a/src/app/components/Card/Card.stories.tsx
+++ b/src/app/components/Card/Card.stories.tsx
@@ -6,8 +6,9 @@ import { CardControl, CardControlState } from "./CardControl";
 export default { title: "App / Components / Card" };
 
 export const Default = () => <Card className="inline-flex">ARK Ecosystem</Card>;
+
 export const Control = () => (
-	<div className="grid grid-cols-2 gap-4 w-80">
+	<div className="grid max-w-lg grid-cols-3 gap-4">
 		<CardControl defaultChecked={true} className="grid">
 			<div className="flex flex-col items-center justify-between h-full space-y-3">
 				<span className="text-center">ARK Ecosystem</span>
@@ -17,6 +18,12 @@ export const Control = () => (
 		<CardControl className="grid">
 			<div className="flex flex-col items-center justify-between h-full">
 				<span>Bitcoin</span>
+				<CardControlState />
+			</div>
+		</CardControl>
+		<CardControl className="grid" disabled>
+			<div className="flex flex-col items-center justify-between h-full">
+				<span>Ethereum</span>
 				<CardControlState />
 			</div>
 		</CardControl>

--- a/src/app/components/Card/CardControl.tsx
+++ b/src/app/components/Card/CardControl.tsx
@@ -1,7 +1,7 @@
+import { Icon } from "app/components/Icon";
 import React from "react";
 import tw, { styled } from "twin.macro";
 
-import { Icon } from "../Icon";
 import { Card } from "./Card";
 
 type CardControlProps = {
@@ -9,7 +9,7 @@ type CardControlProps = {
 	type?: "radio" | "checkbox";
 	checked?: boolean;
 	defaultChecked?: boolean;
-	readonly?: boolean;
+	disabled?: boolean;
 	value?: string | number;
 	name?: string | number;
 } & React.HTMLProps<any>;
@@ -23,13 +23,16 @@ const CustomCard = styled(Card)`
 	${Input}:checked + & {
 		${tw`bg-theme-success-contrast border-theme-success`}
 	}
+	${Input}:disabled + & {
+		${tw`cursor-not-allowed`}
+	}
 `;
 
 const StateStyle = styled.div`
-    ${tw`rounded-full w-4 h-4 border-2 border-theme-primary-contrast inline-flex items-center justify-center text-transparent`}
-    ${Input}:checked + ${CustomCard} & {
-        ${tw`bg-theme-success border-transparent text-theme-success-contrast`}
-    }
+	${tw`inline-flex items-center justify-center w-4 h-4 text-transparent border-2 rounded-full border-theme-primary-contrast`}
+	${Input}:checked + ${CustomCard} & {
+		${tw`border-transparent bg-theme-success text-theme-success-contrast`}
+	}
 `;
 
 export const CardControlState = () => {
@@ -41,7 +44,7 @@ export const CardControlState = () => {
 };
 
 export const CardControl = React.forwardRef<HTMLInputElement, CardControlProps>(
-	({ children, type, checked, defaultChecked, onChange, readOnly, value, name, ...props }: CardControlProps, ref) => {
+	({ children, type, checked, defaultChecked, onChange, disabled, value, name, ...props }: CardControlProps, ref) => {
 		return (
 			<label tw="cursor-pointer" {...props}>
 				<Input
@@ -51,7 +54,7 @@ export const CardControl = React.forwardRef<HTMLInputElement, CardControlProps>(
 					checked={checked}
 					onChange={onChange}
 					defaultChecked={defaultChecked}
-					readOnly={readOnly}
+					disabled={disabled}
 					value={value}
 					name={name}
 				/>

--- a/src/app/components/Card/__snapshots__/CardControl.test.tsx.snap
+++ b/src/app/components/Card/__snapshots__/CardControl.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`Card Control should render 1`] = `
       value=""
     />
     <div
-      class="sc-AxirZ PHAyy CardControl__CustomCard-sc-28luv0-1 dojmPD"
+      class="sc-AxirZ PHAyy CardControl__CustomCard-sc-28luv0-1 hBgxxm"
     />
   </label>
 </DocumentFragment>
@@ -30,7 +30,7 @@ exports[`Card Control should render with a control state 1`] = `
       value=""
     />
     <div
-      class="sc-AxirZ PHAyy CardControl__CustomCard-sc-28luv0-1 dojmPD"
+      class="sc-AxirZ PHAyy CardControl__CustomCard-sc-28luv0-1 hBgxxm"
     >
       <div
         class="flex flex-col items-center justify-between h-full"
@@ -39,7 +39,7 @@ exports[`Card Control should render with a control state 1`] = `
           Bitcoin
         </span>
         <div
-          class="CardControl__StateStyle-sc-28luv0-2 iismIz"
+          class="CardControl__StateStyle-sc-28luv0-2 gwKAJL"
           data-testid="card__control-state"
         >
           <div


### PR DESCRIPTION
## Summary

The `readonly` is not supported for `checkbox` and `radio`.

> The readonly attribute is supported by  text, search, url, tel, email, password, date, month, week, time, datetime-local, and number<input> types and the <textarea> form control elements.

**Reference:** https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/readonly

## Checklist

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged
