### PR TITLE
feat: create `SelectRecipient` form input

### DIFF
--- a/src/domains/profile/components/SelectRecipient/SelectRecipient.stories.tsx
+++ b/src/domains/profile/components/SelectRecipient/SelectRecipient.stories.tsx
@@ -1,0 +1,30 @@
+import { contacts } from "domains/contact/data";
+import React from "react";
+
+import { SelectRecipient } from "./SelectRecipient";
+
+export default { title: "Domains / Profile / Components / Select Recipient" };
+
+export const Default = () => {
+	return (
+		<div className="max-w-lg space-y-8">
+			<div>
+				<SelectRecipient contacts={contacts} />
+			</div>
+			<div>
+				<SelectRecipient contacts={contacts} isInvalid />
+			</div>
+			<div>
+				<SelectRecipient contacts={contacts} disabled />
+			</div>
+			<div>
+				<div className="mb-3">Selected address</div>
+				<SelectRecipient contacts={contacts} address="bP6T9GQ3kqP6T9GQ3kqP6T9GQ3kqTTTP6T9GQ3kqT" />
+			</div>
+			<div>
+				<div className="mb-3">Selected address (disabled)</div>
+				<SelectRecipient disabled contacts={contacts} address="bP6T9GQ3kqP6T9GQ3kqP6T9GQ3kqTTTP6T9GQ3kqT" />
+			</div>
+		</div>
+	);
+};

--- a/src/domains/profile/components/SelectRecipient/SelectRecipient.test.tsx
+++ b/src/domains/profile/components/SelectRecipient/SelectRecipient.test.tsx
@@ -1,0 +1,134 @@
+/* eslint-disable @typescript-eslint/require-await */
+import { contacts } from "domains/contact/data";
+import React from "react";
+import { act, fireEvent, render, waitFor } from "testing-library";
+
+import { SelectRecipient } from "./SelectRecipient";
+
+describe("SelectRecipient", () => {
+	it("should render empty", () => {
+		const { container } = render(<SelectRecipient contacts={contacts} />);
+		expect(container).toMatchSnapshot();
+	});
+
+	it("should render disabled", () => {
+		const { container } = render(<SelectRecipient disabled contacts={contacts} />);
+		expect(container).toMatchSnapshot();
+	});
+
+	it("should render invalid", () => {
+		const { container } = render(<SelectRecipient isInvalid contacts={contacts} />);
+		expect(container).toMatchSnapshot();
+	});
+
+	it("should render with preselected address", () => {
+		const { container } = render(
+			<SelectRecipient contacts={contacts} address="bP6T9GQ3kqP6T9GQ3kqP6T9GQ3kqTTTP6T9GQ3kqT" />,
+		);
+		expect(container).toMatchSnapshot();
+	});
+
+	it("should open and close contacts modal", () => {
+		const { getByTestId } = render(
+			<SelectRecipient contacts={contacts} address="bP6T9GQ3kqP6T9GQ3kqP6T9GQ3kqTTTP6T9GQ3kqT" />,
+		);
+
+		expect(() => getByTestId("modal__inner")).toThrow(/Unable to find an element by/);
+
+		act(() => {
+			fireEvent.click(getByTestId("SelectRecipient__select-contact"));
+		});
+
+		expect(getByTestId("modal__inner")).toBeTruthy();
+
+		act(() => {
+			fireEvent.click(getByTestId("modal__close-btn"));
+		});
+
+		waitFor(() => expect(getByTestId("modal__inner")).toBeFalsy());
+	});
+
+	it("should select address from contacts modal", () => {
+		const { getByTestId, getAllByTestId } = render(
+			<SelectRecipient contacts={contacts} address="bP6T9GQ3kqP6T9GQ3kqP6T9GQ3kqTTTP6T9GQ3kqT" />,
+		);
+
+		expect(() => getByTestId("modal__inner")).toThrow(/Unable to find an element by/);
+
+		act(() => {
+			fireEvent.click(getByTestId("SelectRecipient__select-contact"));
+		});
+
+		expect(getByTestId("modal__inner")).toBeTruthy();
+
+		const firstAddress = getAllByTestId("ContactListItem__one-option-button-0")[0];
+
+		act(() => {
+			fireEvent.click(firstAddress);
+		});
+
+		waitFor(() => {
+			expect(getByTestId("modal__inner").toThrow(/Unable to find an element by/));
+
+			const selectedAddressValue = contacts[0]?.addresses()[0]?.address;
+			expect(getByTestId("SelectRecipient__input")).toHaveValue(selectedAddressValue);
+		});
+	});
+
+	it("should not open contacts modal if disabled", () => {
+		const { getByTestId } = render(
+			<SelectRecipient contacts={contacts} disabled address="bP6T9GQ3kqP6T9GQ3kqP6T9GQ3kqTTTP6T9GQ3kqT" />,
+		);
+
+		expect(() => getByTestId("modal__inner")).toThrow(/Unable to find an element by/);
+
+		act(() => {
+			fireEvent.click(getByTestId("SelectRecipient__select-contact"));
+		});
+
+		expect(() => getByTestId("modal__inner")).toThrow(/Unable to find an element by/);
+	});
+
+	it("should call onChange prop when entered address in input", async () => {
+		const fn = jest.fn();
+		const { getByTestId } = render(<SelectRecipient contacts={contacts} onChange={fn} />);
+		const address = "bP6T9GQ3kqP6T9GQ3kqP6T9GQ3kqTTTP6T9GQ3kqT";
+		const recipientInputField = getByTestId("SelectRecipient__input");
+
+		await act(async () => {
+			fireEvent.change(recipientInputField, { target: { value: address } });
+		});
+
+		expect(fn).toBeCalledWith(address);
+	});
+
+	it("should call onChange prop if provided", () => {
+		const fn = jest.fn();
+		const { getByTestId, getAllByTestId } = render(
+			<SelectRecipient contacts={contacts} onChange={fn} address="bP6T9GQ3kqP6T9GQ3kqP6T9GQ3kqTTTP6T9GQ3kqT" />,
+		);
+
+		expect(() => getByTestId("modal__inner")).toThrow(/Unable to find an element by/);
+
+		act(() => {
+			fireEvent.click(getByTestId("SelectRecipient__select-contact"));
+		});
+
+		expect(getByTestId("modal__inner")).toBeTruthy();
+
+		const firstAddress = getAllByTestId("ContactListItem__one-option-button-0")[0];
+
+		act(() => {
+			fireEvent.click(firstAddress);
+		});
+
+		waitFor(() => {
+			expect(getByTestId("modal__inner").toThrow(/Unable to find an element by/));
+
+			const selectedAddressValue = contacts[0]?.addresses()[0]?.address;
+			expect(getByTestId("SelectRecipient__input")).toHaveValue(selectedAddressValue);
+
+			expect(fn).toBeCalledWith(selectedAddressValue);
+		});
+	});
+});

--- a/src/domains/profile/components/SelectRecipient/SelectRecipient.tsx
+++ b/src/domains/profile/components/SelectRecipient/SelectRecipient.tsx
@@ -1,0 +1,108 @@
+import { Avatar } from "app/components/Avatar";
+import { Circle } from "app/components/Circle";
+import { useFormField } from "app/components/Form/useFormField";
+import { Icon } from "app/components/Icon";
+import { Input } from "app/components/Input";
+import { SearchContact } from "domains/contact/components/SearchContact";
+import React, { useEffect, useState } from "react";
+
+type SelectRecipientProps = {
+	address?: string;
+	contacts: any[];
+	disabled?: boolean;
+	isInvalid?: boolean;
+	contactSearchTitle?: string;
+	contactSearchDescription?: string;
+	selectActionLabel?: string;
+	onChange?: (address: string) => void;
+} & React.InputHTMLAttributes<any>;
+
+const ProfileAvatar = ({ address }: any) => {
+	if (!address) return <Circle className="mx-3 bg-theme-neutral-200 border-theme-neutral-200" size="sm" noShadow />;
+	return <Avatar address={address} size="sm" className="mx-3" noShadow />;
+};
+
+export const SelectRecipient = React.forwardRef<HTMLInputElement, SelectRecipientProps>(
+	(
+		{
+			contactSearchTitle,
+			contactSearchDescription,
+			selectActionLabel,
+			address,
+			contacts,
+			disabled,
+			isInvalid,
+			onChange,
+		}: SelectRecipientProps,
+		ref,
+	) => {
+		const [isContactSearchOpen, setIsContactSearchOpen] = useState(false);
+		const [selectedAddress, setSelectedAddress] = useState(address);
+		useEffect(() => setSelectedAddress(address), [address]);
+
+		const fieldContext = useFormField();
+		const isInvalidField = fieldContext?.isInvalid || isInvalid;
+
+		const onSelectProfile = (address: any) => {
+			setSelectedAddress(address);
+			setIsContactSearchOpen(false);
+			onChange?.(address);
+		};
+
+		const openContacts = () => {
+			if (disabled) return;
+			setIsContactSearchOpen(true);
+		};
+
+		const onInputChange = (value: string) => {
+			setSelectedAddress(value);
+			onChange?.(value);
+		};
+
+		return (
+			<div>
+				<div data-testid="SelectRecipient__wrapper" className="text-left w-full flex items-center relative">
+					<div className="absolute left-1">
+						<ProfileAvatar address={selectedAddress} />
+					</div>
+					<Input
+						className="pl-14 pr-11"
+						data-testid="SelectRecipient__input"
+						type="text"
+						ref={ref}
+						value={selectedAddress || ""}
+						onChange={(ev: any) => onInputChange?.(ev.target.value)}
+						disabled={disabled}
+						isInvalid={isInvalidField}
+					/>
+
+					<div
+						data-testid="SelectRecipient__select-contact"
+						className="absolute flex items-center right-4 space-x-3 cursor-pointer"
+						onClick={openContacts}
+					>
+						<Icon name="User" width={20} height={20} />
+					</div>
+				</div>
+
+				<SearchContact
+					title={contactSearchTitle}
+					description={contactSearchDescription}
+					isOpen={isContactSearchOpen}
+					contacts={contacts}
+					options={[{ value: "select", label: selectActionLabel }]}
+					onAction={(_, { address }: any) => onSelectProfile(address)}
+					onClose={() => setIsContactSearchOpen(false)}
+				/>
+			</div>
+		);
+	},
+);
+
+SelectRecipient.defaultProps = {
+	contactSearchTitle: "Recipient search",
+	contactSearchDescription: "Find and select the recipient from your contacts",
+	selectActionLabel: "Select",
+};
+
+SelectRecipient.displayName = "SelectRecipient";

--- a/src/domains/profile/components/SelectRecipient/SelectRecipient.tsx
+++ b/src/domains/profile/components/SelectRecipient/SelectRecipient.tsx
@@ -61,7 +61,7 @@ export const SelectRecipient = React.forwardRef<HTMLInputElement, SelectRecipien
 
 		return (
 			<div>
-				<div data-testid="SelectRecipient__wrapper" className="text-left w-full flex items-center relative">
+				<div data-testid="SelectRecipient__wrapper" className="relative flex items-center w-full text-left">
 					<div className="absolute left-1">
 						<ProfileAvatar address={selectedAddress} />
 					</div>
@@ -78,7 +78,7 @@ export const SelectRecipient = React.forwardRef<HTMLInputElement, SelectRecipien
 
 					<div
 						data-testid="SelectRecipient__select-contact"
-						className="absolute flex items-center right-4 space-x-3 cursor-pointer"
+						className="absolute flex items-center cursor-pointer right-4 space-x-3"
 						onClick={openContacts}
 					>
 						<Icon name="User" width={20} height={20} />

--- a/src/domains/profile/components/SelectRecipient/__snapshots__/SelectRecipient.test.tsx.snap
+++ b/src/domains/profile/components/SelectRecipient/__snapshots__/SelectRecipient.test.tsx.snap
@@ -1,0 +1,170 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SelectRecipient should render disabled 1`] = `
+<div>
+  <div>
+    <div
+      class="text-left w-full flex items-center relative"
+      data-testid="SelectRecipient__wrapper"
+    >
+      <div
+        class="absolute left-1"
+      >
+        <div
+          class="sc-AxjAm jDAceZ mx-3 bg-theme-neutral-200 border-theme-neutral-200"
+        />
+      </div>
+      <input
+        class="sc-AxiKw dRuQsB overflow-hidden w-full bg-theme-background appearance-none rounded border border-theme-neutral-300 text-theme-neutral-900 transition-colors duration-200 px-4 py-3 pl-14 pr-11"
+        data-testid="SelectRecipient__input"
+        disabled=""
+        type="text"
+        value=""
+      />
+      <div
+        class="absolute flex items-center right-4 space-x-3 cursor-pointer"
+        data-testid="SelectRecipient__select-contact"
+      >
+        <div
+          class="sc-AxirZ eEbZjj"
+          height="20"
+          width="20"
+        >
+          <svg>
+            user.svg
+          </svg>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`SelectRecipient should render empty 1`] = `
+<div>
+  <div>
+    <div
+      class="text-left w-full flex items-center relative"
+      data-testid="SelectRecipient__wrapper"
+    >
+      <div
+        class="absolute left-1"
+      >
+        <div
+          class="sc-AxjAm jDAceZ mx-3 bg-theme-neutral-200 border-theme-neutral-200"
+        />
+      </div>
+      <input
+        class="sc-AxiKw dRuQsB overflow-hidden w-full bg-theme-background appearance-none rounded border border-theme-neutral-300 text-theme-neutral-900 transition-colors duration-200 px-4 py-3 pl-14 pr-11"
+        data-testid="SelectRecipient__input"
+        type="text"
+        value=""
+      />
+      <div
+        class="absolute flex items-center right-4 space-x-3 cursor-pointer"
+        data-testid="SelectRecipient__select-contact"
+      >
+        <div
+          class="sc-AxirZ eEbZjj"
+          height="20"
+          width="20"
+        >
+          <svg>
+            user.svg
+          </svg>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`SelectRecipient should render invalid 1`] = `
+<div>
+  <div>
+    <div
+      class="text-left w-full flex items-center relative"
+      data-testid="SelectRecipient__wrapper"
+    >
+      <div
+        class="absolute left-1"
+      >
+        <div
+          class="sc-AxjAm jDAceZ mx-3 bg-theme-neutral-200 border-theme-neutral-200"
+        />
+      </div>
+      <input
+        aria-invalid="true"
+        class="sc-AxiKw dRuQsB overflow-hidden w-full bg-theme-background appearance-none rounded border border-theme-neutral-300 text-theme-neutral-900 transition-colors duration-200 px-4 py-3 pl-14 pr-11"
+        data-testid="SelectRecipient__input"
+        type="text"
+        value=""
+      />
+      <div
+        class="absolute flex items-center right-4 space-x-3 cursor-pointer"
+        data-testid="SelectRecipient__select-contact"
+      >
+        <div
+          class="sc-AxirZ eEbZjj"
+          height="20"
+          width="20"
+        >
+          <svg>
+            user.svg
+          </svg>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`SelectRecipient should render with preselected address 1`] = `
+<div>
+  <div>
+    <div
+      class="text-left w-full flex items-center relative"
+      data-testid="SelectRecipient__wrapper"
+    >
+      <div
+        class="absolute left-1"
+      >
+        <div
+          class="Avatar__AvatarWrapper-sc-1vsy2s2-0 laNXvc mx-3"
+          data-testid="Avatar"
+        >
+          <div
+            class="w-full h-full"
+          >
+            <img
+              alt="bP6T9GQ3kqP6T9GQ3kqP6T9GQ3kqTTTP6T9GQ3kqT"
+              src="data:image/svg+xml;utf8,<svg version=\\"1.1\\" xmlns=\\"http://www.w3.org/2000/svg\\" width=\\"100\\" height=\\"100\\" viewBox=\\"0 0 100 100\\"><style>circle{mix-blend-mode:soft-light;}</style><rect fill=\\"rgb(255, 193, 7)\\" width=\\"100\\" height=\\"100\\"/><circle r=\\"45\\" cx=\\"20\\" cy=\\"40\\" fill=\\"rgb(244, 67, 54)\\"/><circle r=\\"35\\" cx=\\"100\\" cy=\\"70\\" fill=\\"rgb(233, 30, 99)\\"/><circle r=\\"55\\" cx=\\"70\\" cy=\\"50\\" fill=\\"rgb(139, 195, 74)\\"/></svg>"
+              title="bP6T9GQ3kqP6T9GQ3kqP6T9GQ3kqTTTP6T9GQ3kqT"
+            />
+          </div>
+        </div>
+      </div>
+      <input
+        class="sc-AxiKw dRuQsB overflow-hidden w-full bg-theme-background appearance-none rounded border border-theme-neutral-300 text-theme-neutral-900 transition-colors duration-200 px-4 py-3 pl-14 pr-11"
+        data-testid="SelectRecipient__input"
+        type="text"
+        value="bP6T9GQ3kqP6T9GQ3kqP6T9GQ3kqTTTP6T9GQ3kqT"
+      />
+      <div
+        class="absolute flex items-center right-4 space-x-3 cursor-pointer"
+        data-testid="SelectRecipient__select-contact"
+      >
+        <div
+          class="sc-AxirZ eEbZjj"
+          height="20"
+          width="20"
+        >
+          <svg>
+            user.svg
+          </svg>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/domains/profile/components/SelectRecipient/__snapshots__/SelectRecipient.test.tsx.snap
+++ b/src/domains/profile/components/SelectRecipient/__snapshots__/SelectRecipient.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`SelectRecipient should render disabled 1`] = `
 <div>
   <div>
     <div
-      class="text-left w-full flex items-center relative"
+      class="relative flex items-center w-full text-left"
       data-testid="SelectRecipient__wrapper"
     >
       <div
@@ -22,7 +22,7 @@ exports[`SelectRecipient should render disabled 1`] = `
         value=""
       />
       <div
-        class="absolute flex items-center right-4 space-x-3 cursor-pointer"
+        class="absolute flex items-center cursor-pointer right-4 space-x-3"
         data-testid="SelectRecipient__select-contact"
       >
         <div
@@ -44,7 +44,7 @@ exports[`SelectRecipient should render empty 1`] = `
 <div>
   <div>
     <div
-      class="text-left w-full flex items-center relative"
+      class="relative flex items-center w-full text-left"
       data-testid="SelectRecipient__wrapper"
     >
       <div
@@ -61,7 +61,7 @@ exports[`SelectRecipient should render empty 1`] = `
         value=""
       />
       <div
-        class="absolute flex items-center right-4 space-x-3 cursor-pointer"
+        class="absolute flex items-center cursor-pointer right-4 space-x-3"
         data-testid="SelectRecipient__select-contact"
       >
         <div
@@ -83,7 +83,7 @@ exports[`SelectRecipient should render invalid 1`] = `
 <div>
   <div>
     <div
-      class="text-left w-full flex items-center relative"
+      class="relative flex items-center w-full text-left"
       data-testid="SelectRecipient__wrapper"
     >
       <div
@@ -101,7 +101,7 @@ exports[`SelectRecipient should render invalid 1`] = `
         value=""
       />
       <div
-        class="absolute flex items-center right-4 space-x-3 cursor-pointer"
+        class="absolute flex items-center cursor-pointer right-4 space-x-3"
         data-testid="SelectRecipient__select-contact"
       >
         <div
@@ -123,7 +123,7 @@ exports[`SelectRecipient should render with preselected address 1`] = `
 <div>
   <div>
     <div
-      class="text-left w-full flex items-center relative"
+      class="relative flex items-center w-full text-left"
       data-testid="SelectRecipient__wrapper"
     >
       <div
@@ -151,7 +151,7 @@ exports[`SelectRecipient should render with preselected address 1`] = `
         value="bP6T9GQ3kqP6T9GQ3kqP6T9GQ3kqTTTP6T9GQ3kqT"
       />
       <div
-        class="absolute flex items-center right-4 space-x-3 cursor-pointer"
+        class="absolute flex items-center cursor-pointer right-4 space-x-3"
         data-testid="SelectRecipient__select-contact"
       >
         <div

--- a/src/domains/profile/components/SelectRecipient/index.ts
+++ b/src/domains/profile/components/SelectRecipient/index.ts
@@ -1,0 +1,1 @@
+export * from "./SelectRecipient";


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Create `SelectRecipient` component to be used in Transaction Send form
* Allows user to enter custom address (free text input)
* When clicked on the "user" icon, the `ContactSearch` modal is opened to pick existing contacts.


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
