### PR TITLE
fix: enforce numeric slip44

### DIFF
--- a/src/renderer/components/Network/NetworkModal.vue
+++ b/src/renderer/components/Network/NetworkModal.vue
@@ -686,7 +686,8 @@ export default {
         numeric
       },
       slip44: {
-        requiredIfFull
+        requiredIfFull,
+        numeric
       },
       activeDelegates: {
         requiredIfFull,


### PR DESCRIPTION

## Summary

Changing the Network Slip44 does not enforce that the value should only be a number.

As a result, a user may assume they can specify their Account index here as well (`111'/1'`, `123'/5'`, etc).

This results in an invalid Path (`44'/111'/1'/0'/0/0`) with 6 elements instead of only 5 per-spec.
(`m / purpose' / coin_type' / account' / change / address_index`)

The "Slip/Account" is also inserted as if it were only the Slip itself,
and DW unsuspectingly uses the `Change` index as if it were the `Account` index.
(`m / purpose' / Slip44(coin_type' / account') / change' / address_index / nothing`)

The proposed change simply enforces that a Slip44 value in the Network Modal only be a number.

## Checklist

- [x] Ready to be merged
