### PR TITLE
fix: modify webpack config for storybook

### DIFF
--- a/config-overrides.js
+++ b/config-overrides.js
@@ -8,8 +8,6 @@ module.exports = override(
 		require("autoprefixer"),
 	]),
 	(config) => {
-		config.target = "electron-renderer";
-
 		config.node = {
 			fs: "empty",
 		};


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Prevent using `electron-renderer` as config target in webpack config-overrides.
Fixes `global is not defined` error in storybook.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
