### PR TITLE
fix: webpack config

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,4 +1,5 @@
-const configOverrides = require("../config-overrides");
+const path = require("path");
+const { override, addPostcssPlugins } = require("customize-cra");
 
 module.exports = {
 	stories: ["../src/**/**/*.stories.tsx"],
@@ -9,29 +10,45 @@ module.exports = {
 		"@storybook/preset-create-react-app",
 		"storybook-addon-themes",
 	],
-	webpackFinal: async (storybookConfig) => {
-		const customConfig = configOverrides(storybookConfig);
-
-		(storybookConfig.module.rules = [
-			...storybookConfig.module.rules,
-			{
-				test: /\.(ts|tsx)$/,
-				use: [
-					{
-						loader: require.resolve("babel-loader"),
-						options: {
-							presets: [require.resolve("babel-preset-react-app")],
-						},
-					},
-					require.resolve("react-docgen-typescript-loader"),
-				],
-			},
+	webpackFinal: override(
+		addPostcssPlugins([
+			require("postcss-import"),
+			require("tailwindcss")("./src/tailwind.config.js"),
+			require("autoprefixer"),
 		]),
-			storybookConfig.resolve.extensions.push(".ts", ".tsx");
+		async (storybookConfig) => {
+			storybookConfig.module.rules = [
+				...storybookConfig.module.rules,
+				{
+					test: /\.(ts|tsx)$/,
+					use: [
+						{
+							loader: require.resolve("babel-loader"),
+							options: {
+								presets: [require.resolve("babel-preset-react-app")],
+							},
+						},
+						require.resolve("react-docgen-typescript-loader"),
+					],
+				},
+			];
 
-		return {
-			...storybookConfig,
-			module: { ...storybookConfig.module, rules: customConfig.module.rules },
-		};
-	},
+			storybookConfig.resolve = {
+				extensions: [".ts", ".js", ".jsx", ".tsx", ".scss", ".json", ".node"],
+				alias: {
+					app: path.resolve(__dirname, "../src/app/"),
+					domains: path.resolve(__dirname, "../src/domains"),
+					resources: path.resolve(__dirname, "../src/resources"),
+					styles: path.resolve(__dirname, "../src/styles"),
+					utils: path.resolve(__dirname, "../src/utils"),
+					tests: path.resolve(__dirname, "../src/tests"),
+					fs: path.resolve(__dirname, "mocks/fsMock.js"),
+				},
+			};
+
+			console.log(storybookConfig);
+
+			return storybookConfig;
+		},
+	),
 };

--- a/.storybook/mocks/fsMock.js
+++ b/.storybook/mocks/fsMock.js
@@ -1,0 +1,5 @@
+module.exports = {
+	readFileSync: () => "mocked file",
+	existsSync: () => "mocked file",
+	// other things in fs that you are using
+};

--- a/config-overrides.js
+++ b/config-overrides.js
@@ -23,6 +23,8 @@ module.exports = override(
 			"usb-detection": "commonjs usb-detection",
 		};
 
+		config.target = "electron-renderer";
+
 		config.resolve = {
 			extensions: [".ts", ".js", ".jsx", ".tsx", ".scss", ".json", ".node"],
 			alias: {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
- This adds a custom configuration for the storybook webpack to avoid the `electron-renderer` target removal from the base config to make storybook works since this target is needed to correctly load the node packages used into the app.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
