### PR TITLE
refactor: `SignMessage` modal tweaks

### DIFF
--- a/src/domains/transaction/e2e/transactions-routing.e2e.ts
+++ b/src/domains/transaction/e2e/transactions-routing.e2e.ts
@@ -1,36 +1,8 @@
-import { ClientFunction, Selector } from "testcafe";
+import { Selector } from "testcafe";
 
 import { buildTranslations as translations } from "../../../app/i18n/helpers";
 
 fixture`Transactions routing`.page`http://localhost:3000/`;
-
-const scrollBy = ClientFunction((x, y) => {
-	window.scrollBy(x, y);
-});
-
-test("should navigate to portfolio and sign message", async (t) => {
-	await t.click(Selector("p").withText("John Doe"));
-	await t.expect(Selector("div").withText(translations().COMMON.WALLETS).exists).ok();
-	await t.click(Selector("[data-testid=navbar__buttons--send]"));
-	await t
-		.expect(
-			Selector("div").withText(translations().TRANSACTION.PAGE_TRANSACTION_SEND.FIRST_STEP.DESCRIPTION).exists,
-		)
-		.ok();
-
-	// Handle sign message
-	await t.click(Selector("span").withText(translations().COMMON.GO_BACK_TO_PORTFOLIO));
-	await t.click(Selector("[data-testid=WalletCard__ac38fe6d-4b67-4ef1-85be-17c5f6841129]"));
-	await scrollBy(0, -200);
-	await t.click(Selector("[data-testid=WalletHeader__more-button]"));
-	await t.click(Selector("li").withText(translations().WALLETS.PAGE_WALLET_DETAILS.OPTIONS.SIGN_MESSAGE));
-
-	await t.typeText(Selector("input[name=message]"), "Hello World");
-	await t.typeText(Selector("input[name=mnemonic]"), "this is a top secret passphrase");
-	await t.click(Selector("[data-testid=SignMessage__submit-button]"));
-	await t.expect(Selector("h2").withText(translations().WALLETS.MODAL_SIGN_MESSAGE.SUCCESS_TITLE).exists).ok();
-	await t.click(Selector("[data-testid=modal__close-btn]"));
-});
 
 test("should navigate to portfolio and access registrations", async (t) => {
 	await t.click(Selector("p").withText("John Doe"));

--- a/src/domains/wallet/components/SignMessage/SignMessage.test.tsx
+++ b/src/domains/wallet/components/SignMessage/SignMessage.test.tsx
@@ -61,6 +61,12 @@ describe("SignMessage", () => {
 	});
 
 	it("should sign message", async () => {
+		const signedMessage = {
+			message: "Hello World",
+			signatory: "034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed192",
+			signature:
+				"304402200fb4adddd1f1d652b544ea6ab62828a0a65b712ed447e2538db0caebfa68929e02205ecb2e1c63b29879c2ecf1255db506d671c8b3fa6017f67cfd1bf07e6edd1cc8",
+		};
 		let rendered: RenderResult;
 
 		await act(async () => {
@@ -102,6 +108,18 @@ describe("SignMessage", () => {
 					translations.MODAL_SIGN_MESSAGE.SUCCESS_TITLE,
 				),
 			);
+
+			const writeTextMock = jest.fn();
+			const clipboardOriginal = navigator.clipboard;
+
+			// @ts-ignore
+			navigator.clipboard = { writeText: writeTextMock };
+
+			await fireEvent.click(getByTestId(`SignMessage__copy-button`));
+			await waitFor(() => expect(writeTextMock).toHaveBeenCalledWith(JSON.stringify(signedMessage)));
+
+			// @ts-ignore
+			navigator.clipboard = clipboardOriginal;
 		});
 	});
 });

--- a/src/domains/wallet/components/SignMessage/SignMessage.test.tsx
+++ b/src/domains/wallet/components/SignMessage/SignMessage.test.tsx
@@ -51,7 +51,7 @@ describe("SignMessage", () => {
 				<SignMessage
 					profileId={profile.id()}
 					walletId={wallet.id()}
-					signatoryAddress="AUexKjGtgsSpVzPLs6jNMM6vJ6znEVTQWK"
+					signatoryAddress="D61mfSggzbvQgTUe6JhYKH2doHaqJ3Dyib"
 					isOpen={true}
 				/>
 			</EnvironmentProvider>,
@@ -69,7 +69,7 @@ describe("SignMessage", () => {
 					<SignMessage
 						profileId={profile.id()}
 						walletId={wallet.id()}
-						signatoryAddress="AUexKjGtgsSpVzPLs6jNMM6vJ6znEVTQWK"
+						signatoryAddress="D61mfSggzbvQgTUe6JhYKH2doHaqJ3Dyib"
 						isOpen={true}
 					/>
 				</EnvironmentProvider>,

--- a/src/domains/wallet/components/SignMessage/SignMessage.tsx
+++ b/src/domains/wallet/components/SignMessage/SignMessage.tsx
@@ -93,11 +93,11 @@ export const SignMessage = ({ profileId, walletId, signatoryAddress, isOpen, onC
 				<FormHelperText />
 			</FormField>
 			<div className="flex justify-end space-x-3">
-				<Button variant="plain" onClick={onCancel}>
-					Cancel
+				<Button variant="plain" onClick={onCancel} data-testid="SignMessage__cancel">
+					{t("COMMON.CANCEL")}
 				</Button>
 				<Button type="submit" data-testid="SignMessage__submit-button">
-					Sign
+					{t("WALLETS.MODAL_SIGN_MESSAGE.SIGN")}
 				</Button>
 			</div>
 		</Form>

--- a/src/domains/wallet/components/SignMessage/SignMessage.tsx
+++ b/src/domains/wallet/components/SignMessage/SignMessage.tsx
@@ -49,8 +49,10 @@ export const SignMessage = ({ profileId, walletId, signatoryAddress, isOpen, onC
 			mnemonic,
 		});
 
-		setIsSigned(true);
+		console.log("signedMessageResult", signedMessageResult);
+
 		setSignedMessage(signedMessageResult);
+		setIsSigned(true);
 	};
 
 	const SignFormRender = (
@@ -128,12 +130,12 @@ export const SignMessage = ({ profileId, walletId, signatoryAddress, isOpen, onC
 					name="signature"
 					wrap="hard"
 					ref={messageRef}
-					defaultValue={signedMessage.signature}
+					defaultValue={JSON.stringify(signedMessage)}
 				/>
 			</TransactionDetail>
 
 			<div className="flex justify-end pb-5 mt-3">
-				<Clipboard data={signedMessage.signature}>
+				<Clipboard data={JSON.stringify(signedMessage)}>
 					<Button variant="plain">
 						<Icon name="Copy" />
 						<span>{t("WALLETS.MODAL_SIGN_MESSAGE.COPY_SIGNATURE")}</span>

--- a/src/domains/wallet/components/SignMessage/SignMessage.tsx
+++ b/src/domains/wallet/components/SignMessage/SignMessage.tsx
@@ -149,7 +149,7 @@ export const SignMessage = ({ profileId, walletId, signatoryAddress, isOpen, onC
 		<Modal
 			isOpen={isOpen}
 			title={!isSigned ? t("WALLETS.MODAL_SIGN_MESSAGE.TITLE") : t("WALLETS.MODAL_SIGN_MESSAGE.SUCCESS_TITLE")}
-			description={!isSigned ? t("WALLETS.MODAL_SIGN_MESSAGE.SUBTITLE") : ""}
+			description={!isSigned ? t("WALLETS.MODAL_SIGN_MESSAGE.DESCRIPTION") : ""}
 			onClose={onClose}
 		>
 			<div className={!isSigned ? "mt-8" : "mt-2"}>{renderSignedMessageContent()}</div>

--- a/src/domains/wallet/components/SignMessage/SignMessage.tsx
+++ b/src/domains/wallet/components/SignMessage/SignMessage.tsx
@@ -134,7 +134,7 @@ export const SignMessage = ({ profileId, walletId, signatoryAddress, isOpen, onC
 
 			<div className="flex justify-end pb-5 mt-3">
 				<Clipboard data={JSON.stringify(signedMessage)}>
-					<Button variant="plain">
+					<Button variant="plain" data-testid="SignMessage__copy-button">
 						<Icon name="Copy" />
 						<span>{t("WALLETS.MODAL_SIGN_MESSAGE.COPY_SIGNATURE")}</span>
 					</Button>

--- a/src/domains/wallet/components/SignMessage/SignMessage.tsx
+++ b/src/domains/wallet/components/SignMessage/SignMessage.tsx
@@ -149,7 +149,7 @@ export const SignMessage = ({ profileId, walletId, signatoryAddress, isOpen, onC
 		<Modal
 			isOpen={isOpen}
 			title={!isSigned ? t("WALLETS.MODAL_SIGN_MESSAGE.TITLE") : t("WALLETS.MODAL_SIGN_MESSAGE.SUCCESS_TITLE")}
-			description={!isSigned ? t("WALLETS.MODAL_SIGN_MESSAGE.TITLE") : ""}
+			description={!isSigned ? t("WALLETS.MODAL_SIGN_MESSAGE.SUBTITLE") : ""}
 			onClose={onClose}
 		>
 			<div className={!isSigned ? "mt-8" : "mt-2"}>{renderSignedMessageContent()}</div>

--- a/src/domains/wallet/components/SignMessage/SignMessage.tsx
+++ b/src/domains/wallet/components/SignMessage/SignMessage.tsx
@@ -49,8 +49,6 @@ export const SignMessage = ({ profileId, walletId, signatoryAddress, isOpen, onC
 			mnemonic,
 		});
 
-		console.log("signedMessageResult", signedMessageResult);
-
 		setSignedMessage(signedMessageResult);
 		setIsSigned(true);
 	};

--- a/src/domains/wallet/components/SignMessage/__snapshots__/SignMessage.test.tsx.snap
+++ b/src/domains/wallet/components/SignMessage/__snapshots__/SignMessage.test.tsx.snap
@@ -172,6 +172,7 @@ exports[`SignMessage should render 1`] = `
               <button
                 class="sc-AxirZ fhzkRl"
                 color="primary"
+                data-testid="SignMessage__cancel"
                 type="button"
               >
                 Cancel
@@ -365,6 +366,7 @@ exports[`SignMessage should sign message 1`] = `
               <button
                 class="sc-AxirZ fhzkRl"
                 color="primary"
+                data-testid="SignMessage__cancel"
                 type="button"
               >
                 Cancel

--- a/src/domains/wallet/components/SignMessage/__snapshots__/SignMessage.test.tsx.snap
+++ b/src/domains/wallet/components/SignMessage/__snapshots__/SignMessage.test.tsx.snap
@@ -48,7 +48,7 @@ exports[`SignMessage should render 1`] = `
         <div
           class="mt-1 text-theme-neutral-dark"
         >
-          Sign Message
+          Insert a message below to sign using your private key
         </div>
         <div
           class="mt-8"
@@ -101,7 +101,7 @@ exports[`SignMessage should render 1`] = `
                     <span
                       class="ml-3 font-semibold "
                     >
-                      AUexKjGtgsSpVzPLs6jNMM6vJ6znEVTQWK
+                      D61mfSggzbvQgTUe6JhYKH2doHaqJ3Dyib
                     </span>
                   </div>
                 </div>
@@ -241,7 +241,7 @@ exports[`SignMessage should sign message 1`] = `
         <div
           class="mt-1 text-theme-neutral-dark"
         >
-          Sign Message
+          Insert a message below to sign using your private key
         </div>
         <div
           class="mt-8"
@@ -294,7 +294,7 @@ exports[`SignMessage should sign message 1`] = `
                     <span
                       class="ml-3 font-semibold "
                     >
-                      AUexKjGtgsSpVzPLs6jNMM6vJ6znEVTQWK
+                      D61mfSggzbvQgTUe6JhYKH2doHaqJ3Dyib
                     </span>
                   </div>
                 </div>

--- a/src/domains/wallet/e2e/sign-message-action.e2e.ts
+++ b/src/domains/wallet/e2e/sign-message-action.e2e.ts
@@ -1,0 +1,79 @@
+import { ClientFunction, Selector } from "testcafe";
+
+import { buildTranslations as translations } from "../../../app/i18n/helpers";
+
+fixture`Sign Message`.page`http://localhost:3000/`;
+
+const scrollTop = ClientFunction(() => {
+	window.scrollTo({ top: 0 });
+});
+
+test("Should open and close sign message modal", async (t) => {
+	await t.click(Selector("p").withText("John Doe"));
+	await t.expect(Selector("div").withText(translations().COMMON.WALLETS).exists).ok();
+
+	// Navigate to wallet details page
+	await t.click(Selector("[data-testid=WalletCard__ac38fe6d-4b67-4ef1-85be-17c5f6841129]"));
+	await t.expect(Selector("[data-testid=WalletHeader]").exists).ok();
+
+	// Click sign message option in dropdown menu
+	await scrollTop();
+	await t.click(Selector('[data-testid="WalletHeader__more-button"]'));
+	await t.click(
+		Selector('[data-testid="WalletHeader__more-button"] li').withText(
+			translations().WALLETS.PAGE_WALLET_DETAILS.OPTIONS.SIGN_MESSAGE,
+		),
+	);
+
+	await t.expect(Selector("[data-testid=modal__inner]").exists).ok();
+	await t.expect(Selector('[data-testid="modal__close-btn"]').exists).ok();
+	await t.click(Selector('[data-testid="modal__close-btn"]'));
+	await t.expect(Selector("[data-testid=modal__inner]").exists).notOk();
+});
+
+test("Should open and cancel sign message modal", async (t) => {
+	await t.click(Selector("p").withText("John Doe"));
+	await t.expect(Selector("div").withText(translations().COMMON.WALLETS).exists).ok();
+
+	// Navigate to wallet details page
+	await t.click(Selector("[data-testid=WalletCard__ac38fe6d-4b67-4ef1-85be-17c5f6841129]"));
+	await t.expect(Selector("[data-testid=WalletHeader]").exists).ok();
+
+	// Click sign message option in dropdown menu
+	await scrollTop();
+	await t.click(Selector('[data-testid="WalletHeader__more-button"]'));
+	await t.click(
+		Selector('[data-testid="WalletHeader__more-button"] li').withText(
+			translations().WALLETS.PAGE_WALLET_DETAILS.OPTIONS.SIGN_MESSAGE,
+		),
+	);
+
+	await t.expect(Selector("[data-testid=modal__inner]").exists).ok();
+	await t.expect(Selector("[data-testid=SignMessage__cancel]").exists).ok();
+	await t.click(Selector("[data-testid=SignMessage__cancel]"));
+	await t.expect(Selector("[data-testid=modal__inner]").exists).notOk();
+});
+
+test("Should successfully sign message", async (t) => {
+	await t.click(Selector("p").withText("John Doe"));
+	await t.expect(Selector("div").withText("Wallets").exists).ok();
+
+	// Navigate to wallet details page
+	await t.click(Selector("[data-testid=WalletCard__ac38fe6d-4b67-4ef1-85be-17c5f6841129]"));
+	await t.expect(Selector("[data-testid=WalletHeader]").exists).ok();
+
+	// Click sign message option in dropdown menu
+	await scrollTop();
+	await t.click(Selector('[data-testid="WalletHeader__more-button"]'));
+	await t.click(
+		Selector('[data-testid="WalletHeader__more-button"] li').withText(
+			translations().WALLETS.PAGE_WALLET_DETAILS.OPTIONS.SIGN_MESSAGE,
+		),
+	);
+
+	await t.typeText(Selector("input[name=message]"), "Hello World");
+	await t.typeText(Selector("input[name=mnemonic]"), "this is a top secret passphrase");
+	await t.click(Selector("[data-testid=SignMessage__submit-button]"));
+	await t.expect(Selector("h2").withText(translations().WALLETS.MODAL_SIGN_MESSAGE.SUCCESS_TITLE).exists).ok();
+	await t.click(Selector("[data-testid=modal__close-btn]"));
+});

--- a/src/domains/wallet/e2e/verify-message-action.e2e.ts
+++ b/src/domains/wallet/e2e/verify-message-action.e2e.ts
@@ -89,7 +89,7 @@ test("Should fail verification", async (t) => {
 		.ok();
 });
 
-test("Should succesfully verify message", async (t) => {
+test("Should successfully verify message", async (t) => {
 	await t.click(Selector("p").withText("John Doe"));
 	await t.expect(Selector("div").withText("Wallets").exists).ok();
 

--- a/src/domains/wallet/i18n.ts
+++ b/src/domains/wallet/i18n.ts
@@ -42,6 +42,7 @@ export const translations: { [key: string]: any } = {
 		SUBTITLE: "Insert a message below to sign using your private key",
 		SUCCESS_TITLE: "Message Successfully Signed",
 		DESCRIPTION: "Insert a message below to sign using your private key",
+		SIGN: "Sign",
 		COPY_SIGNATURE: "Copy Signature",
 	},
 

--- a/src/domains/wallet/i18n.ts
+++ b/src/domains/wallet/i18n.ts
@@ -39,6 +39,7 @@ export const translations: { [key: string]: any } = {
 
 	MODAL_SIGN_MESSAGE: {
 		TITLE: "Sign Message",
+		SUBTITLE: "Insert a message below to sign using your private key",
 		SUCCESS_TITLE: "Message Successfully Signed",
 		DESCRIPTION: "Insert a message below to sign using your private key",
 		COPY_SIGNATURE: "Copy Signature",

--- a/src/domains/wallet/i18n.ts
+++ b/src/domains/wallet/i18n.ts
@@ -39,7 +39,6 @@ export const translations: { [key: string]: any } = {
 
 	MODAL_SIGN_MESSAGE: {
 		TITLE: "Sign Message",
-		SUBTITLE: "Insert a message below to sign using your private key",
 		SUCCESS_TITLE: "Message Successfully Signed",
 		DESCRIPTION: "Insert a message below to sign using your private key",
 		SIGN: "Sign",


### PR DESCRIPTION
## Summary

- Add i18n
- Add json data for signature
- Add test to the copy button
- Move E2E tests to wallet domain

![Screenshot from 2020-07-29 15-23-59](https://user-images.githubusercontent.com/1894191/88846420-fe137900-d1bb-11ea-8d68-69344eb8c7c4.png)

## Checklist

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged