### PR TITLE
chore: move currency icons to own module

### DIFF
--- a/src/app/assets/svg/currencies/index.ts
+++ b/src/app/assets/svg/currencies/index.ts
@@ -1,0 +1,13 @@
+import { ReactComponent as Ark } from "./ark.svg";
+import { ReactComponent as Bitcoin } from "./btc.svg";
+import { ReactComponent as Ethereum } from "./eth.svg";
+import { ReactComponent as Lisk } from "./lsk.svg";
+import { ReactComponent as Ripple } from "./xrp.svg";
+
+export const Currencies: any = {
+	Ark,
+	Bitcoin,
+	Ethereum,
+	Lisk,
+	Ripple,
+};

--- a/src/app/assets/svg/index.ts
+++ b/src/app/assets/svg/index.ts
@@ -17,11 +17,7 @@ import { ReactComponent as ChevronUp } from "./chevron-up.svg";
 import { ReactComponent as Close } from "./close.svg";
 import { ReactComponent as Copy } from "./copy.svg";
 import { ReactComponent as CrossSlim } from "./cross-slim.svg";
-import { ReactComponent as Ark } from "./currencies/ark.svg";
-import { ReactComponent as Bitcoin } from "./currencies/btc.svg";
-import { ReactComponent as Ethereum } from "./currencies/eth.svg";
-import { ReactComponent as Lisk } from "./currencies/lsk.svg";
-import { ReactComponent as Ripple } from "./currencies/xrp.svg";
+import { Currencies } from "./currencies";
 import { ReactComponent as Dash } from "./dash.svg";
 import { ReactComponent as Delegate } from "./delegate.svg";
 import { ReactComponent as Discord } from "./discord.svg";
@@ -98,16 +94,12 @@ export const SvgCollection: any = {
 	AlertDanger,
 	AlertDefault,
 	AlertSuccess,
-	Ark,
 	ArrowBack,
 	ArrowDown,
 	ArrowUp,
 	Back,
 	BitBucket,
 	Blockfolio,
-	Bitcoin,
-	Lisk,
-	Ripple,
 	Bridgechain,
 	Business,
 	Checkmark,
@@ -121,7 +113,6 @@ export const SvgCollection: any = {
 	Discord,
 	Download,
 	Edit,
-	Ethereum,
 	Explorer,
 	Eye,
 	EyeOff,
@@ -190,4 +181,5 @@ export const SvgCollection: any = {
 	ChartActiveDot,
 	Placeholder,
 	QuestionMark,
+	...Currencies,
 };


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Moves the currency icons to their own module.
<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
