### PR TITLE
chore: add `noShadow` to the network icon in the `SelectNetworkInput`

### DIFF
--- a/src/domains/contact/components/ContactForm/__snapshots__/ContactForm.test.tsx.snap
+++ b/src/domains/contact/components/ContactForm/__snapshots__/ContactForm.test.tsx.snap
@@ -52,7 +52,7 @@ exports[`ContactForm when creating a new contact should render the form 1`] = `
             class="sc-AxgMl sc-AxheI hUEXQW px-4"
           >
             <div
-              class="sc-fzplWN fEJfwQ border-theme-neutral-light text-theme-neutral"
+              class="sc-fzplWN exzsOf border-theme-neutral-light text-theme-neutral"
               data-testid="SelectNetworkInput__network"
             />
           </div>
@@ -185,7 +185,7 @@ exports[`ContactForm when editing an existing contact should render the form 1`]
             class="sc-AxgMl sc-AxheI hUEXQW px-4"
           >
             <div
-              class="sc-fzplWN fEJfwQ border-theme-neutral-light text-theme-neutral"
+              class="sc-fzplWN exzsOf border-theme-neutral-light text-theme-neutral"
               data-testid="SelectNetworkInput__network"
             />
           </div>

--- a/src/domains/contact/components/CreateContact/__snapshots__/CreateContact.test.tsx.snap
+++ b/src/domains/contact/components/CreateContact/__snapshots__/CreateContact.test.tsx.snap
@@ -105,7 +105,7 @@ exports[`CreateContact should render a modal 1`] = `
                     class="sc-AxheI sc-Axmtr kSmZlB px-4"
                   >
                     <div
-                      class="sc-fznyAO iBucrA border-theme-neutral-light text-theme-neutral"
+                      class="sc-fznyAO crOapn border-theme-neutral-light text-theme-neutral"
                       data-testid="SelectNetworkInput__network"
                     />
                   </div>

--- a/src/domains/contact/components/UpdateContact/__snapshots__/UpdateContact.test.tsx.snap
+++ b/src/domains/contact/components/UpdateContact/__snapshots__/UpdateContact.test.tsx.snap
@@ -100,7 +100,7 @@ exports[`UpdateContact should render a modal 1`] = `
                     class="sc-AxheI sc-Axmtr kSmZlB px-4"
                   >
                     <div
-                      class="sc-fznyAO iBucrA border-theme-neutral-light text-theme-neutral"
+                      class="sc-fznyAO crOapn border-theme-neutral-light text-theme-neutral"
                       data-testid="SelectNetworkInput__network"
                     />
                   </div>

--- a/src/domains/network/components/SelectNetwork/SelectNetworkInput.tsx
+++ b/src/domains/network/components/SelectNetwork/SelectNetworkInput.tsx
@@ -28,6 +28,7 @@ export const SelectNetworkInput = React.forwardRef<HTMLInputElement, Props>(
 					network={network?.id()}
 					size="sm"
 					showTooltip={false}
+					noShadow
 				/>
 			</InputAddonStart>
 			{suggestion && <TypeAhead value={suggestion} />}

--- a/src/domains/network/components/SelectNetwork/__snapshots__/SelectNetwork.test.tsx.snap
+++ b/src/domains/network/components/SelectNetwork/__snapshots__/SelectNetwork.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`SelectNetwork should render 1`] = `
         class="sc-AxhCb sc-AxhUy jFkFxS px-4"
       >
         <div
-          class="sc-AxjAm IjnG border-theme-neutral-light text-theme-neutral"
+          class="sc-AxjAm jDAceZ border-theme-neutral-light text-theme-neutral"
           data-testid="SelectNetworkInput__network"
         />
       </div>
@@ -67,7 +67,7 @@ exports[`SelectNetwork should render with networks 1`] = `
         class="sc-AxhCb sc-AxhUy jFkFxS px-4"
       >
         <div
-          class="sc-AxjAm IjnG border-theme-neutral-light text-theme-neutral"
+          class="sc-AxjAm jDAceZ border-theme-neutral-light text-theme-neutral"
           data-testid="SelectNetworkInput__network"
         />
       </div>

--- a/src/domains/news/components/AddAssets/__snapshots__/AddAssets.test.tsx.snap
+++ b/src/domains/news/components/AddAssets/__snapshots__/AddAssets.test.tsx.snap
@@ -85,7 +85,7 @@ exports[`AddAssets should render a modal 1`] = `
                   class="sc-Axmtr sc-AxmLO VVqBg px-4"
                 >
                   <div
-                    class="sc-AxhCb jSOIkt border-theme-neutral-light text-theme-neutral"
+                    class="sc-AxhCb ditBgK border-theme-neutral-light text-theme-neutral"
                     data-testid="SelectNetworkInput__network"
                   />
                 </div>

--- a/src/domains/setting/components/CustomPeers/__snapshots__/CustomPeers.test.tsx.snap
+++ b/src/domains/setting/components/CustomPeers/__snapshots__/CustomPeers.test.tsx.snap
@@ -80,7 +80,7 @@ exports[`CustomPeers should render a modal 1`] = `
                   class="sc-AxhUy sc-AxgMl kAPRWA px-4"
                 >
                   <div
-                    class="sc-fznyAO iBucrA border-theme-neutral-light text-theme-neutral"
+                    class="sc-fznyAO crOapn border-theme-neutral-light text-theme-neutral"
                     data-testid="SelectNetworkInput__network"
                   />
                 </div>

--- a/src/domains/setting/components/PeerList/__snapshots__/PeerList.test.tsx.snap
+++ b/src/domains/setting/components/PeerList/__snapshots__/PeerList.test.tsx.snap
@@ -79,7 +79,7 @@ exports[`PeerList should add peer 1`] = `
                     class="sc-AxheI sc-Axmtr kSmZlB px-4"
                   >
                     <div
-                      class="sc-fznKkj dTqEVN border-theme-neutral-light text-theme-neutral"
+                      class="sc-fznKkj bnRNAS border-theme-neutral-light text-theme-neutral"
                       data-testid="SelectNetworkInput__network"
                     />
                   </div>

--- a/src/domains/transaction/components/SendTransactionForm/__snapshots__/SendTransactionForm.test.tsx.snap
+++ b/src/domains/transaction/components/SendTransactionForm/__snapshots__/SendTransactionForm.test.tsx.snap
@@ -44,7 +44,7 @@ exports[`SendTransactionForm should render 1`] = `
               class="sc-AxhCb sc-AxhUy jFkFxS px-4"
             >
               <div
-                class="sc-fzplWN fEJfwQ border-theme-neutral-light text-theme-neutral"
+                class="sc-fzplWN exzsOf border-theme-neutral-light text-theme-neutral"
                 data-testid="SelectNetworkInput__network"
               />
             </div>
@@ -554,7 +554,7 @@ exports[`SendTransactionForm should set available amount 1`] = `
               class="sc-AxhCb sc-AxhUy jFkFxS px-4"
             >
               <div
-                class="sc-fzplWN fEJfwQ border-theme-neutral-light text-theme-neutral"
+                class="sc-fzplWN exzsOf border-theme-neutral-light text-theme-neutral"
                 data-testid="SelectNetworkInput__network"
               />
             </div>

--- a/src/domains/transaction/pages/Registration/__snapshots__/Registration.test.tsx.snap
+++ b/src/domains/transaction/pages/Registration/__snapshots__/Registration.test.tsx.snap
@@ -339,7 +339,7 @@ exports[`Registration should render 1st step 1`] = `
                               class="sc-AxheI sc-Axmtr kSmZlB px-4"
                             >
                               <div
-                                class="sc-AxiKw dEJjWx border-theme-neutral-light text-theme-neutral"
+                                class="sc-AxiKw cxOZEi border-theme-neutral-light text-theme-neutral"
                                 data-testid="SelectNetworkInput__network"
                               />
                             </div>
@@ -3355,7 +3355,7 @@ exports[`Registration should select registration type 1`] = `
                               class="sc-AxheI sc-Axmtr kSmZlB px-4"
                             >
                               <div
-                                class="sc-AxiKw dEJjWx border-theme-neutral-light text-theme-neutral"
+                                class="sc-AxiKw cxOZEi border-theme-neutral-light text-theme-neutral"
                                 data-testid="SelectNetworkInput__network"
                               />
                             </div>
@@ -3944,7 +3944,7 @@ exports[`Registration should should go back 1`] = `
                               class="sc-AxheI sc-Axmtr kSmZlB px-4"
                             >
                               <div
-                                class="sc-AxiKw dEJjWx border-theme-neutral-light text-theme-neutral"
+                                class="sc-AxiKw cxOZEi border-theme-neutral-light text-theme-neutral"
                                 data-testid="SelectNetworkInput__network"
                               />
                             </div>

--- a/src/domains/transaction/pages/SendIPFSTransaction/__snapshots__/SendIPFSTransaction.test.tsx.snap
+++ b/src/domains/transaction/pages/SendIPFSTransaction/__snapshots__/SendIPFSTransaction.test.tsx.snap
@@ -331,7 +331,7 @@ exports[`SendIPFSTransaction should render 1`] = `
                                   class="sc-AxheI sc-Axmtr kSmZlB px-4"
                                 >
                                   <div
-                                    class="sc-AxiKw dEJjWx border-theme-neutral-light text-theme-neutral"
+                                    class="sc-AxiKw cxOZEi border-theme-neutral-light text-theme-neutral"
                                     data-testid="SelectNetworkInput__network"
                                   />
                                 </div>
@@ -623,7 +623,7 @@ exports[`SendIPFSTransaction should render 1st step 1`] = `
                   class="sc-AxheI sc-Axmtr kSmZlB px-4"
                 >
                   <div
-                    class="sc-AxiKw dEJjWx border-theme-neutral-light text-theme-neutral"
+                    class="sc-AxiKw cxOZEi border-theme-neutral-light text-theme-neutral"
                     data-testid="SelectNetworkInput__network"
                   />
                 </div>

--- a/src/domains/transaction/pages/TransactionSend/__snapshots__/TransactionSend.test.tsx.snap
+++ b/src/domains/transaction/pages/TransactionSend/__snapshots__/TransactionSend.test.tsx.snap
@@ -348,7 +348,7 @@ exports[`Transaction Send should navigate between teps 1`] = `
                                   class="sc-AxheI sc-Axmtr kSmZlB px-4"
                                 >
                                   <div
-                                    class="sc-AxiKw dEJjWx border-theme-neutral-light text-theme-neutral"
+                                    class="sc-AxiKw cxOZEi border-theme-neutral-light text-theme-neutral"
                                     data-testid="SelectNetworkInput__network"
                                   />
                                 </div>
@@ -816,7 +816,7 @@ exports[`Transaction Send should render 1st step 1`] = `
                   class="sc-AxheI sc-Axmtr kSmZlB px-4"
                 >
                   <div
-                    class="sc-AxiKw dEJjWx border-theme-neutral-light text-theme-neutral"
+                    class="sc-AxiKw cxOZEi border-theme-neutral-light text-theme-neutral"
                     data-testid="SelectNetworkInput__network"
                   />
                 </div>

--- a/src/domains/vote/pages/Votes/__snapshots__/Votes.test.tsx.snap
+++ b/src/domains/vote/pages/Votes/__snapshots__/Votes.test.tsx.snap
@@ -280,7 +280,7 @@ exports[`Votes should render 1`] = `
                       class="sc-AxhUy sc-AxgMl kAPRWA px-4"
                     >
                       <div
-                        class="sc-AxirZ dVFFmZ border-theme-neutral-light text-theme-neutral"
+                        class="sc-AxirZ HSPq border-theme-neutral-light text-theme-neutral"
                         data-testid="SelectNetworkInput__network"
                       />
                     </div>
@@ -742,7 +742,7 @@ exports[`Votes should select a delegate 1`] = `
                     >
                       <div
                         aria-label="Bitcoin"
-                        class="sc-AxirZ dVFFmZ border-theme-warning-200 text-theme-warning-400"
+                        class="sc-AxirZ HSPq border-theme-warning-200 text-theme-warning-400"
                         data-testid="SelectNetworkInput__network"
                       >
                         <div
@@ -2062,7 +2062,7 @@ exports[`Votes should select a network 1`] = `
                     >
                       <div
                         aria-label="Bitcoin"
-                        class="sc-AxirZ dVFFmZ border-theme-warning-200 text-theme-warning-400"
+                        class="sc-AxirZ HSPq border-theme-warning-200 text-theme-warning-400"
                         data-testid="SelectNetworkInput__network"
                       >
                         <div
@@ -3205,7 +3205,7 @@ exports[`Votes should select address 1`] = `
                     >
                       <div
                         aria-label="Bitcoin"
-                        class="sc-AxirZ dVFFmZ border-theme-warning-200 text-theme-warning-400"
+                        class="sc-AxirZ HSPq border-theme-warning-200 text-theme-warning-400"
                         data-testid="SelectNetworkInput__network"
                       >
                         <div

--- a/src/domains/wallet/pages/CreateWallet/__snapshots__/CreateWallet.test.tsx.snap
+++ b/src/domains/wallet/pages/CreateWallet/__snapshots__/CreateWallet.test.tsx.snap
@@ -337,7 +337,7 @@ exports[`CreateWallet should not allow quick swapping of networks 1`] = `
                               class="sc-Axmtr sc-AxmLO VVqBg px-4"
                             >
                               <div
-                                class="sc-fznZeY eebuSp border-theme-neutral-light text-theme-neutral"
+                                class="sc-fznZeY eNkokG border-theme-neutral-light text-theme-neutral"
                                 data-testid="SelectNetworkInput__network"
                               />
                             </div>
@@ -783,7 +783,7 @@ exports[`CreateWallet should remove pending wallet if not submitted 1`] = `
                               class="sc-Axmtr sc-AxmLO VVqBg px-4"
                             >
                               <div
-                                class="sc-fznZeY eebuSp border-theme-neutral-light text-theme-neutral"
+                                class="sc-fznZeY eNkokG border-theme-neutral-light text-theme-neutral"
                                 data-testid="SelectNetworkInput__network"
                               />
                             </div>
@@ -1229,7 +1229,7 @@ exports[`CreateWallet should render 1`] = `
                               class="sc-Axmtr sc-AxmLO VVqBg px-4"
                             >
                               <div
-                                class="sc-fznZeY eebuSp border-theme-neutral-light text-theme-neutral"
+                                class="sc-fznZeY eNkokG border-theme-neutral-light text-theme-neutral"
                                 data-testid="SelectNetworkInput__network"
                               />
                             </div>
@@ -1401,7 +1401,7 @@ exports[`CreateWallet should render 1st step 1`] = `
               class="sc-Axmtr sc-AxmLO VVqBg px-4"
             >
               <div
-                class="sc-fznZeY eebuSp border-theme-neutral-light text-theme-neutral"
+                class="sc-fznZeY eNkokG border-theme-neutral-light text-theme-neutral"
                 data-testid="SelectNetworkInput__network"
               />
             </div>

--- a/src/domains/wallet/pages/ImportWallet/__snapshots__/ImportWallet.test.tsx.snap
+++ b/src/domains/wallet/pages/ImportWallet/__snapshots__/ImportWallet.test.tsx.snap
@@ -341,7 +341,7 @@ exports[`ImportWallet should go to previous step 1`] = `
                               class="sc-AxheI sc-Axmtr kSmZlB px-4"
                             >
                               <div
-                                class="sc-fznZeY eebuSp border-theme-neutral-light text-theme-neutral"
+                                class="sc-fznZeY eNkokG border-theme-neutral-light text-theme-neutral"
                                 data-testid="SelectNetworkInput__network"
                               />
                             </div>
@@ -780,7 +780,7 @@ exports[`ImportWallet should import by address 1`] = `
                               class="sc-AxheI sc-Axmtr kSmZlB px-4"
                             >
                               <div
-                                class="sc-fznZeY eebuSp border-theme-neutral-light text-theme-neutral"
+                                class="sc-fznZeY eNkokG border-theme-neutral-light text-theme-neutral"
                                 data-testid="SelectNetworkInput__network"
                               />
                             </div>
@@ -1219,7 +1219,7 @@ exports[`ImportWallet should import by mnemonic 1`] = `
                               class="sc-AxheI sc-Axmtr kSmZlB px-4"
                             >
                               <div
-                                class="sc-fznZeY eebuSp border-theme-neutral-light text-theme-neutral"
+                                class="sc-fznZeY eNkokG border-theme-neutral-light text-theme-neutral"
                                 data-testid="SelectNetworkInput__network"
                               />
                             </div>
@@ -1382,7 +1382,7 @@ exports[`ImportWallet should render 1st step 1`] = `
               class="sc-AxheI sc-Axmtr kSmZlB px-4"
             >
               <div
-                class="sc-fznZeY eebuSp border-theme-neutral-light text-theme-neutral"
+                class="sc-fznZeY eNkokG border-theme-neutral-light text-theme-neutral"
                 data-testid="SelectNetworkInput__network"
               />
             </div>
@@ -1913,7 +1913,7 @@ exports[`ImportWallet should show an error if import a NEO mainnet address 1`] =
                               class="sc-AxheI sc-Axmtr kSmZlB px-4"
                             >
                               <div
-                                class="sc-fznZeY eebuSp border-theme-neutral-light text-theme-neutral"
+                                class="sc-fznZeY eNkokG border-theme-neutral-light text-theme-neutral"
                                 data-testid="SelectNetworkInput__network"
                               />
                             </div>
@@ -2352,7 +2352,7 @@ exports[`ImportWallet should show an error message for invalid address 1`] = `
                               class="sc-AxheI sc-Axmtr kSmZlB px-4"
                             >
                               <div
-                                class="sc-fznZeY eebuSp border-theme-neutral-light text-theme-neutral"
+                                class="sc-fznZeY eNkokG border-theme-neutral-light text-theme-neutral"
                                 data-testid="SelectNetworkInput__network"
                               />
                             </div>
@@ -2791,7 +2791,7 @@ exports[`ImportWallet should show an error message if trying to import a duplica
                               class="sc-AxheI sc-Axmtr kSmZlB px-4"
                             >
                               <div
-                                class="sc-fznZeY eebuSp border-theme-neutral-light text-theme-neutral"
+                                class="sc-fznZeY eNkokG border-theme-neutral-light text-theme-neutral"
                                 data-testid="SelectNetworkInput__network"
                               />
                             </div>


### PR DESCRIPTION
## Summary

Remove white shadow from the network icon when the `SelectNetworkInput` component is disabled.

![Screenshot from 2020-08-03 17-27-11](https://user-images.githubusercontent.com/1894191/89225321-6396a980-d5b0-11ea-87e0-ef1616675548.png)

## Checklist

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged
