### PR TITLE
feat: cache HTTP requests based on their URL

### DIFF
--- a/src/app/services/Cache.test.ts
+++ b/src/app/services/Cache.test.ts
@@ -1,0 +1,21 @@
+import { Cache } from "./Cache";
+
+let subject: Cache;
+
+beforeAll(() => (subject = new Cache(10)));
+
+describe("Cache", () => {
+	it("should remember a value and return it next time without calling any functions", async () => {
+		subject.flush();
+
+		const valueFn = jest.fn(() => "value");
+
+		await expect(subject.remember("cacheKey", valueFn)).resolves.toBe("value");
+		await expect(subject.remember("cacheKey", valueFn)).resolves.toBe("value");
+		await expect(subject.remember("cacheKey", valueFn)).resolves.toBe("value");
+		await expect(subject.remember("cacheKey", valueFn)).resolves.toBe("value");
+		await expect(subject.remember("cacheKey", valueFn)).resolves.toBe("value");
+
+		expect(valueFn).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/app/services/Cache.test.ts
+++ b/src/app/services/Cache.test.ts
@@ -5,7 +5,13 @@ let subject: Cache;
 beforeAll(() => (subject = new Cache(10)));
 
 describe("Cache", () => {
-	it("should remember a value and return it next time without calling any functions", async () => {
+	it("should remember a value if it is a string", async () => {
+		subject.flush();
+
+		await expect(subject.remember("cacheKey", "value")).resolves.toBe("value");
+	});
+
+	it("should remember a value if it is a function", async () => {
 		subject.flush();
 
 		const valueFn = jest.fn(() => "value");

--- a/src/app/services/Cache.ts
+++ b/src/app/services/Cache.ts
@@ -1,0 +1,39 @@
+import { DateTime } from "@arkecosystem/platform-sdk-intl";
+
+interface CacheItem {
+	value: any;
+	expires_at: DateTime;
+}
+
+export class Cache {
+	private store: Record<string, CacheItem> = {};
+	private ttl: number;
+
+	public constructor(ttl: number) {
+		this.ttl = ttl;
+	}
+
+	public async remember(key: string, value: unknown): Promise<any> {
+		// 1. Check if we still have a matching item for the key.
+		const cacheItem = this.store[key];
+
+		if (cacheItem && cacheItem.expires_at.isAfter(DateTime.make())) {
+			return cacheItem.value;
+		}
+
+		// 2. We don't have a matching value so we need to set it.
+		let result: unknown = value;
+
+		if (typeof value === "function") {
+			result = await value();
+		}
+
+		this.store[key] = { value: result, expires_at: DateTime.make().addSeconds(this.ttl) };
+
+		return result;
+	}
+
+	public flush() {
+		this.store = {};
+	}
+}

--- a/src/app/services/HttpClient.test.ts
+++ b/src/app/services/HttpClient.test.ts
@@ -7,7 +7,7 @@ let subject: HttpClient;
 beforeAll(() => {
 	nock.disableNetConnect();
 
-	subject = new HttpClient();
+	subject = new HttpClient(0);
 });
 
 describe("HttpClient", () => {

--- a/src/app/services/HttpClient.ts
+++ b/src/app/services/HttpClient.ts
@@ -11,10 +11,10 @@ export class HttpClient extends Http.Request {
 
 	private readonly cache: Cache;
 
-	public constructor() {
+	public constructor(ttl: number) {
 		super();
 
-		this.cache = new Cache(10);
+		this.cache = new Cache(ttl);
 	}
 
 	protected async send(

--- a/src/app/services/HttpClient.ts
+++ b/src/app/services/HttpClient.ts
@@ -14,7 +14,7 @@ export class HttpClient extends Http.Request {
 	public constructor() {
 		super();
 
-		this.cache = new Cache(60);
+		this.cache = new Cache(10);
 	}
 
 	protected async send(

--- a/src/app/services/HttpClient.ts
+++ b/src/app/services/HttpClient.ts
@@ -1,11 +1,21 @@
 import { Contracts, Http } from "@arkecosystem/platform-sdk";
 import fetch from "isomorphic-fetch";
 
+import { Cache } from "./Cache";
+
 export class HttpClient extends Http.Request {
 	private readonly headers: Record<string, string> = {
 		Accept: "application/json",
 		"Content-Type": "application/json",
 	};
+
+	private readonly cache: Cache;
+
+	public constructor() {
+		super();
+
+		this.cache = new Cache(60);
+	}
 
 	protected async send(
 		method: string,
@@ -15,24 +25,30 @@ export class HttpClient extends Http.Request {
 			data?: any;
 		},
 	): Promise<Contracts.HttpResponse> {
-		let response;
-
 		if (data?.query && Object.keys(data?.query).length > 0) {
 			url = `${url}?${new URLSearchParams(data.query as any)}`;
 		}
 
-		if (method === "GET") {
-			response = await fetch(url, { headers: this.headers });
-		}
+		return this.cache.remember(url, async () => {
+			let response;
 
-		if (method === "POST") {
-			response = await fetch(url, { method: "POST", body: JSON.stringify(data?.data), headers: this.headers });
-		}
+			if (method === "GET") {
+				response = await fetch(url, { headers: this.headers });
+			}
 
-		return new Http.Response({
-			body: await response?.text(),
-			headers: response?.headers,
-			statusCode: response?.status,
+			if (method === "POST") {
+				response = await fetch(url, {
+					method: "POST",
+					body: JSON.stringify(data?.data),
+					headers: this.headers,
+				});
+			}
+
+			return new Http.Response({
+				body: await response?.text(),
+				headers: response?.headers,
+				statusCode: response?.status,
+			});
 		});
 	}
 }

--- a/src/app/services/index.ts
+++ b/src/app/services/index.ts
@@ -1,3 +1,3 @@
 import { HttpClient } from "./HttpClient";
 
-export const httpClient = new HttpClient();
+export const httpClient = new HttpClient(10);


### PR DESCRIPTION
This will cache HTTP requests for 10 seconds based on their URL. This reduces the number of requests that have to be sent when the wallet boots because it would retrieve things like the network configuration once instead of 100 times if you have 100 wallets.