### PR TITLE
refactor: move screenshotprotection to profile middleware

### DIFF
--- a/src/domains/dashboard/pages/Dashboard/Dashboard.tsx
+++ b/src/domains/dashboard/pages/Dashboard/Dashboard.tsx
@@ -9,7 +9,6 @@ import { TransactionDetailModal } from "domains/transaction/components/Transacti
 import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useHistory } from "react-router-dom";
-import { setScreenshotProtection } from "utils/electron-utils";
 
 import { balances, portfolioPercentages } from "../../data";
 
@@ -50,7 +49,6 @@ export const Dashboard = ({ networks, portfolioPercentages, balances }: Dashboar
 			return allTransactions && setAllTransactions(allTransactions);
 		};
 
-		setScreenshotProtection(activeProfile.settings().get(ProfileSetting.ScreenshotProtection) === true);
 		fetchProfileTransactions();
 	}, [activeProfile]);
 

--- a/src/domains/profile/components/SignIn/SignIn.test.tsx
+++ b/src/domains/profile/components/SignIn/SignIn.test.tsx
@@ -105,6 +105,8 @@ describe("SignIn", () => {
 	});
 
 	it("should set an error and disable the input if the password is invalid multiple times", async () => {
+		jest.setTimeout(10000);
+
 		const onSuccess = jest.fn();
 
 		let renderContext: any;

--- a/src/domains/profile/components/SignIn/SignIn.test.tsx
+++ b/src/domains/profile/components/SignIn/SignIn.test.tsx
@@ -8,6 +8,8 @@ import { SignIn } from "./SignIn";
 
 let profile: Profile;
 
+jest.setTimeout(30000);
+
 describe("SignIn", () => {
 	beforeEach(async () => {
 		profile = env.profiles().findById("cba050f1-880f-45f0-9af9-cfe48f406052");
@@ -105,8 +107,6 @@ describe("SignIn", () => {
 	});
 
 	it("should set an error and disable the input if the password is invalid multiple times", async () => {
-		jest.setTimeout(10000);
-
 		const onSuccess = jest.fn();
 
 		let renderContext: any;

--- a/src/domains/profile/middleware.test.ts
+++ b/src/domains/profile/middleware.test.ts
@@ -6,13 +6,20 @@ import { ProfileMiddleware } from "./middleware";
 
 let subject: Middleware;
 
-jest.mock("electron", () => ({
-	remote: {
-		powerMonitor: {
-			getSystemIdleState: jest.fn(),
+jest.mock("electron", () => {
+	const setContentProtection = jest.fn();
+
+	return {
+		remote: {
+			powerMonitor: {
+				getSystemIdleState: jest.fn(),
+			},
+			getCurrentWindow: () => ({
+				setContentProtection,
+			}),
 		},
-	},
-}));
+	};
+});
 
 describe("ProfileMiddleware", () => {
 	beforeEach(() => {

--- a/src/domains/profile/middleware.ts
+++ b/src/domains/profile/middleware.ts
@@ -26,9 +26,9 @@ export class ProfileMiddleware implements Middleware {
 					this.clearActivityState();
 				}
 
-				return true;
-
 				setScreenshotProtection(true);
+
+				return true;
 			}
 
 			try {

--- a/src/domains/profile/middleware.ts
+++ b/src/domains/profile/middleware.ts
@@ -1,7 +1,7 @@
 import { ProfileSetting } from "@arkecosystem/platform-sdk-profiles";
 import { matchPath } from "react-router-dom";
 import { Middleware, MiddlewareParams } from "router/interfaces";
-import { isIdle } from "utils/electron-utils";
+import { isIdle, setScreenshotProtection } from "utils/electron-utils";
 
 type ActivityState = {
 	intervalId?: ReturnType<typeof setInterval>;
@@ -27,10 +27,13 @@ export class ProfileMiddleware implements Middleware {
 				}
 
 				return true;
+
+				setScreenshotProtection(true);
 			}
 
 			try {
 				const profile = env.profiles().findById(profileId);
+
 				const idleThreshold = (profile.settings().get(ProfileSetting.AutomaticSignOutPeriod) as number) * 60;
 
 				if (this.state.intervalId === undefined || this.state.threshold !== idleThreshold) {
@@ -44,6 +47,8 @@ export class ProfileMiddleware implements Middleware {
 						idleThreshold,
 					);
 				}
+
+				setScreenshotProtection(profile.settings().get(ProfileSetting.ScreenshotProtection) === true);
 			} catch {
 				return false;
 			}

--- a/src/domains/splash/e2e/splash-screen.e2e.ts
+++ b/src/domains/splash/e2e/splash-screen.e2e.ts
@@ -19,6 +19,6 @@ test("should show splash screen", async (t) => {
 
 test("should show welcome screen after splash screen", async (t) => {
 	await t.expect(Selector('[data-testid="Splash__text"]').exists).ok();
-	await t.expect(Selector('[data-testid="Splash__text"]').exists).notOk({ timeout: 6000 });
+	await t.expect(Selector('[data-testid="Splash__text"]').exists).notOk({ timeout: 10000 });
 	await t.expect(Selector("h1").withExactText(translations().COMMON.WELCOME).exists).ok();
 }).clientScripts({ content: mockWindowNavigator });

--- a/src/domains/transaction/pages/Registration/__snapshots__/Registration.test.tsx.snap
+++ b/src/domains/transaction/pages/Registration/__snapshots__/Registration.test.tsx.snap
@@ -950,16 +950,16 @@ exports[`Registration should not have delegate option if wallet is a delegate 1`
                                 <button
                                   aria-expanded="true"
                                   aria-haspopup="listbox"
-                                  aria-labelledby="downshift-25-label downshift-25-toggle-button"
+                                  aria-labelledby="downshift-24-label downshift-24-toggle-button"
                                   class="sc-fzpjYC krtBbm is-open  "
                                   data-testid="select-list__toggle-button"
-                                  id="downshift-25-toggle-button"
+                                  id="downshift-24-toggle-button"
                                   type="button"
                                 />
                                 <ul
-                                  aria-labelledby="downshift-25-label"
+                                  aria-labelledby="downshift-24-label"
                                   class="sc-fznxsB jPuBaU is-open"
-                                  id="downshift-25-menu"
+                                  id="downshift-24-menu"
                                   role="listbox"
                                   tabindex="-1"
                                 >
@@ -967,7 +967,7 @@ exports[`Registration should not have delegate option if wallet is a delegate 1`
                                     aria-selected="false"
                                     class="select-list-option "
                                     data-testid="select-list__toggle-option-0"
-                                    id="downshift-25-item-0"
+                                    id="downshift-24-item-0"
                                     role="option"
                                   >
                                     <div


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Moves the setting of the screenshot protection to the profile middleware, so that it's enabled / disabled on every matching route change.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
