### PR TITLE
refactor: add delegate resignation loading state

### DIFF
--- a/src/app/__snapshots__/App.test.tsx.snap
+++ b/src/app/__snapshots__/App.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`App should close splash screen if not demo 1`] = `
     class="debug-screens"
   >
     <div
-      class="sc-fzoJus cXGpQF"
+      class="sc-fzqMdD fRMNNm"
       data-testid="RouterView__wrapper"
     >
       <div
@@ -119,7 +119,7 @@ exports[`App should render and schedule delegates sync 1`] = `
     class="debug-screens"
   >
     <div
-      class="sc-fzoJus cXGpQF"
+      class="sc-fzqMdD fRMNNm"
       data-testid="RouterView__wrapper"
     >
       <div
@@ -419,7 +419,7 @@ exports[`App should render mock 1`] = `
     class="debug-screens"
   >
     <div
-      class="sc-fzoJus cXGpQF"
+      class="sc-fzqMdD fRMNNm"
       data-testid="RouterView__wrapper"
     >
       <div
@@ -719,7 +719,7 @@ exports[`App should render splash screen 1`] = `
     class="debug-screens"
   >
     <div
-      class="sc-fzoJus cXGpQF"
+      class="sc-fzqMdD fRMNNm"
       data-testid="RouterView__wrapper"
     >
       <div
@@ -1092,7 +1092,7 @@ exports[`App should render welcome screen after splash screen 1`] = `
     class="debug-screens"
   >
     <div
-      class="sc-fzoJus cXGpQF"
+      class="sc-fzqMdD fRMNNm"
       data-testid="RouterView__wrapper"
     >
       <div

--- a/src/domains/transaction/pages/Registration/__snapshots__/Registration.test.tsx.snap
+++ b/src/domains/transaction/pages/Registration/__snapshots__/Registration.test.tsx.snap
@@ -950,16 +950,16 @@ exports[`Registration should not have delegate option if wallet is a delegate 1`
                                 <button
                                   aria-expanded="true"
                                   aria-haspopup="listbox"
-                                  aria-labelledby="downshift-24-label downshift-24-toggle-button"
+                                  aria-labelledby="downshift-25-label downshift-25-toggle-button"
                                   class="sc-fznxsB hwZFkF is-open  "
                                   data-testid="select-list__toggle-button"
-                                  id="downshift-24-toggle-button"
+                                  id="downshift-25-toggle-button"
                                   type="button"
                                 />
                                 <ul
-                                  aria-labelledby="downshift-24-label"
+                                  aria-labelledby="downshift-25-label"
                                   class="sc-fznJRM KaIHo is-open"
-                                  id="downshift-24-menu"
+                                  id="downshift-25-menu"
                                   role="listbox"
                                   tabindex="-1"
                                 >
@@ -967,7 +967,7 @@ exports[`Registration should not have delegate option if wallet is a delegate 1`
                                     aria-selected="false"
                                     class="select-list-option "
                                     data-testid="select-list__toggle-option-0"
-                                    id="downshift-24-item-0"
+                                    id="downshift-25-item-0"
                                     role="option"
                                   >
                                     <div

--- a/src/domains/transaction/pages/Registration/__snapshots__/Registration.test.tsx.snap
+++ b/src/domains/transaction/pages/Registration/__snapshots__/Registration.test.tsx.snap
@@ -950,16 +950,16 @@ exports[`Registration should not have delegate option if wallet is a delegate 1`
                                 <button
                                   aria-expanded="true"
                                   aria-haspopup="listbox"
-                                  aria-labelledby="downshift-25-label downshift-25-toggle-button"
+                                  aria-labelledby="downshift-24-label downshift-24-toggle-button"
                                   class="sc-fznxsB hwZFkF is-open  "
                                   data-testid="select-list__toggle-button"
-                                  id="downshift-25-toggle-button"
+                                  id="downshift-24-toggle-button"
                                   type="button"
                                 />
                                 <ul
-                                  aria-labelledby="downshift-25-label"
+                                  aria-labelledby="downshift-24-label"
                                   class="sc-fznJRM KaIHo is-open"
-                                  id="downshift-25-menu"
+                                  id="downshift-24-menu"
                                   role="listbox"
                                   tabindex="-1"
                                 >
@@ -967,7 +967,7 @@ exports[`Registration should not have delegate option if wallet is a delegate 1`
                                     aria-selected="false"
                                     class="select-list-option "
                                     data-testid="select-list__toggle-option-0"
-                                    id="downshift-25-item-0"
+                                    id="downshift-24-item-0"
                                     role="option"
                                   >
                                     <div

--- a/src/domains/transaction/pages/ResignRegistration/ResignRegistration.models.ts
+++ b/src/domains/transaction/pages/ResignRegistration/ResignRegistration.models.ts
@@ -15,3 +15,8 @@ export type StepProps = {
 	fee: Contracts.TransactionFee;
 	transaction?: Contracts.SignedTransactionData;
 };
+
+export type SkeletonProps = {
+	wallet: ReadWriteWallet;
+	transaction?: Contracts.SignedTransactionData;
+};

--- a/src/domains/transaction/pages/ResignRegistration/ResignRegistration.tsx
+++ b/src/domains/transaction/pages/ResignRegistration/ResignRegistration.tsx
@@ -4,7 +4,6 @@ import { Button } from "app/components/Button";
 import { Form } from "app/components/Form";
 import { Icon } from "app/components/Icon";
 import { Page, Section } from "app/components/Layout";
-import { Loader } from "app/components/Loader";
 import { StepIndicator } from "app/components/StepIndicator";
 import { TabPanel, Tabs } from "app/components/Tabs";
 import { useEnvironmentContext } from "app/contexts";
@@ -14,7 +13,7 @@ import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { useHistory } from "react-router-dom";
 
-import { FirstStep, FourthStep, SecondStep, ThirdStep } from "./";
+import { FirstStep, FirstStepSkeleton, FourthStep, SecondStep, ThirdStep } from "./";
 import { ResignRegistrationProps } from "./ResignRegistration.models";
 
 export const ResignRegistration = ({ formDefaultData, onDownload, passwordType }: ResignRegistrationProps) => {
@@ -100,10 +99,16 @@ export const ResignRegistration = ({ formDefaultData, onDownload, passwordType }
 			<Section className="flex-1">
 				<Form className="max-w-xl mx-auto" context={form} onSubmit={handleSubmit}>
 					<Tabs activeId={activeTab}>
-						{(!fee || !delegate) && <Loader />}
+						<StepIndicator size={4} activeIndex={activeTab} />
+
+						{(!fee || !delegate) && (
+							<div className="mt-8">
+								<FirstStepSkeleton wallet={activeWallet} />{" "}
+							</div>
+						)}
+
 						{fee && delegate && (
-							<div>
-								<StepIndicator size={4} activeIndex={activeTab} />
+							<div data-testid="ResignRegistration__steps-wrapper">
 								<div className="mt-8">
 									<TabPanel tabId={1}>
 										<FirstStep wallet={activeWallet} delegate={delegate} fee={fee} />

--- a/src/domains/transaction/pages/ResignRegistration/Step1Skeleton.tsx
+++ b/src/domains/transaction/pages/ResignRegistration/Step1Skeleton.tsx
@@ -1,0 +1,56 @@
+import { Address } from "app/components/Address";
+import { Alert } from "app/components/Alert";
+import { Avatar } from "app/components/Avatar";
+import { FormField, FormLabel } from "app/components/Form";
+import { Label } from "app/components/Label";
+import { TransactionDetail } from "app/components/TransactionDetail";
+import React from "react";
+import { useTranslation } from "react-i18next";
+import Skeleton from "react-loading-skeleton";
+
+import { SkeletonProps } from "./ResignRegistration.models";
+
+export const FirstStepSkeleton = ({ wallet }: SkeletonProps) => {
+	const { t } = useTranslation();
+
+	return (
+		<div data-testid="ResignRegistration__skeleton">
+			<h1 className="mb-0">{t("TRANSACTION.PAGE_RESIGN_REGISTRATION.FIRST_STEP.DELEGATE.TITLE")}</h1>
+			<div className="text-theme-neutral-dark">
+				{t("TRANSACTION.PAGE_RESIGN_REGISTRATION.FIRST_STEP.DELEGATE.DESCRIPTION")}
+			</div>
+
+			<div className="mt-6">
+				<Alert size="lg">{t("TRANSACTION.PAGE_RESIGN_REGISTRATION.FIRST_STEP.DELEGATE.WARNING")}</Alert>
+			</div>
+
+			<div>
+				<TransactionDetail extra={<Avatar size="lg" address={wallet.address()} />} border={false}>
+					<div className="mb-2 text-sm font-semibold text-theme-neutral">
+						<span className="mr-1">{t("TRANSACTION.SENDER")}</span>
+						<Label color="warning">
+							<span className="text-sm">{t("TRANSACTION.YOUR_ADDRESS")}</span>
+						</Label>
+					</div>
+					<Address address={wallet.address()} walletName={wallet.alias()} />
+				</TransactionDetail>
+
+				<TransactionDetail label={t("TRANSACTION.DELEGATE_NAME")}>
+					<Skeleton height={6} width={120} className="block" />
+				</TransactionDetail>
+
+				<TransactionDetail className="pt-6 pb-0">
+					<FormField name="name" className="font-normal">
+						<FormLabel>{t("TRANSACTION.TRANSACTION_FEE")}</FormLabel>
+						<Skeleton height={48} width="78%" />
+						<Skeleton height={48} width="20%" className="ml-2" />
+					</FormField>
+				</TransactionDetail>
+			</div>
+			<div className="flex justify-end mt-8 space-x-3">
+				<Skeleton width={70} height={44} className="block" />
+				<Skeleton width={70} height={44} className="block" />
+			</div>
+		</div>
+	);
+};

--- a/src/domains/transaction/pages/ResignRegistration/__snapshots__/ResignRegistration.test.tsx.snap
+++ b/src/domains/transaction/pages/ResignRegistration/__snapshots__/ResignRegistration.test.tsx.snap
@@ -268,23 +268,25 @@ exports[`ResignRegistration should render 1st step 1`] = `
             data-testid="Form"
           >
             <div>
-              <div>
-                <ul
-                  class="sc-fzoiQi fQHPRZ"
-                >
-                  <li
-                    class="sc-fznWqX kPdKVU"
-                  />
-                  <li
-                    class="sc-fznWqX PbNft"
-                  />
-                  <li
-                    class="sc-fznWqX PbNft"
-                  />
-                  <li
-                    class="sc-fznWqX PbNft"
-                  />
-                </ul>
+              <ul
+                class="sc-fznJRM kDmVaQ"
+              >
+                <li
+                  class="sc-fznxsB keKrAv"
+                />
+                <li
+                  class="sc-fznxsB exHzky"
+                />
+                <li
+                  class="sc-fznxsB exHzky"
+                />
+                <li
+                  class="sc-fznxsB exHzky"
+                />
+              </ul>
+              <div
+                data-testid="ResignRegistration__steps-wrapper"
+              >
                 <div
                   class="mt-8"
                 >
@@ -311,7 +313,7 @@ exports[`ResignRegistration should render 1st step 1`] = `
                           class="flex rounded-lg overflow-hidden bg-theme-warning"
                         >
                           <div
-                            class="sc-fzoNJl kzPnWw flex items-center justify-center text-theme-warning bg-theme-warning-200"
+                            class="sc-fzqNqU jnurM flex items-center justify-center text-theme-warning bg-theme-warning-200"
                           >
                             <div
                               class="sc-AxiKw iRsrJT"
@@ -324,7 +326,7 @@ exports[`ResignRegistration should render 1st step 1`] = `
                             </div>
                           </div>
                           <div
-                            class="sc-fzoyTs frnvzS flex-1 bg-theme-warning-100"
+                            class="sc-fzqARJ gjdPAX flex-1 bg-theme-warning-100"
                           >
                             Keep in mind that you cannot restore your delegate after the resignation has been registered on the blockchain.
                           </div>
@@ -463,7 +465,7 @@ exports[`ResignRegistration should render 1st step 1`] = `
                                     >
                                       <button
                                         aria-checked="true"
-                                        class="sc-fzoXWK jyLfpK relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+                                        class="sc-fzoyTs chLCDw relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
                                         data-testid="SelectionBarOption"
                                         role="radio"
                                         type="button"
@@ -472,7 +474,7 @@ exports[`ResignRegistration should render 1st step 1`] = `
                                       </button>
                                       <button
                                         aria-checked="true"
-                                        class="sc-fzoXWK jyLfpK relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+                                        class="sc-fzoyTs chLCDw relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
                                         data-testid="SelectionBarOption"
                                         role="radio"
                                         type="button"
@@ -789,23 +791,25 @@ exports[`ResignRegistration should render 2nd step 1`] = `
             data-testid="Form"
           >
             <div>
-              <div>
-                <ul
-                  class="sc-fzoiQi fQHPRZ"
-                >
-                  <li
-                    class="sc-fznWqX kPdKVU"
-                  />
-                  <li
-                    class="sc-fznWqX kPdKVU"
-                  />
-                  <li
-                    class="sc-fznWqX PbNft"
-                  />
-                  <li
-                    class="sc-fznWqX PbNft"
-                  />
-                </ul>
+              <ul
+                class="sc-fznJRM kDmVaQ"
+              >
+                <li
+                  class="sc-fznxsB keKrAv"
+                />
+                <li
+                  class="sc-fznxsB keKrAv"
+                />
+                <li
+                  class="sc-fznxsB exHzky"
+                />
+                <li
+                  class="sc-fznxsB exHzky"
+                />
+              </ul>
+              <div
+                data-testid="ResignRegistration__steps-wrapper"
+              >
                 <div
                   class="mt-8"
                 >
@@ -1331,23 +1335,25 @@ exports[`ResignRegistration should render 3rd step 1`] = `
             data-testid="Form"
           >
             <div>
-              <div>
-                <ul
-                  class="sc-fzoiQi fQHPRZ"
-                >
-                  <li
-                    class="sc-fznWqX kPdKVU"
-                  />
-                  <li
-                    class="sc-fznWqX kPdKVU"
-                  />
-                  <li
-                    class="sc-fznWqX kPdKVU"
-                  />
-                  <li
-                    class="sc-fznWqX PbNft"
-                  />
-                </ul>
+              <ul
+                class="sc-fznJRM kDmVaQ"
+              >
+                <li
+                  class="sc-fznxsB keKrAv"
+                />
+                <li
+                  class="sc-fznxsB keKrAv"
+                />
+                <li
+                  class="sc-fznxsB keKrAv"
+                />
+                <li
+                  class="sc-fznxsB exHzky"
+                />
+              </ul>
+              <div
+                data-testid="ResignRegistration__steps-wrapper"
+              >
                 <div
                   class="mt-8"
                 >
@@ -1730,23 +1736,25 @@ exports[`ResignRegistration should render 3rd step with ledger 1`] = `
             data-testid="Form"
           >
             <div>
-              <div>
-                <ul
-                  class="sc-fzoiQi fQHPRZ"
-                >
-                  <li
-                    class="sc-fznWqX kPdKVU"
-                  />
-                  <li
-                    class="sc-fznWqX kPdKVU"
-                  />
-                  <li
-                    class="sc-fznWqX kPdKVU"
-                  />
-                  <li
-                    class="sc-fznWqX PbNft"
-                  />
-                </ul>
+              <ul
+                class="sc-fznJRM kDmVaQ"
+              >
+                <li
+                  class="sc-fznxsB keKrAv"
+                />
+                <li
+                  class="sc-fznxsB keKrAv"
+                />
+                <li
+                  class="sc-fznxsB keKrAv"
+                />
+                <li
+                  class="sc-fznxsB exHzky"
+                />
+              </ul>
+              <div
+                data-testid="ResignRegistration__steps-wrapper"
+              >
                 <div
                   class="mt-8"
                 >
@@ -1775,7 +1783,7 @@ exports[`ResignRegistration should render 3rd step with ledger 1`] = `
                           class="inline-flex items-center justify-center w-full mt-8 space-x-3"
                         >
                           <div
-                            class="sc-fzpmMD iqtKtR"
+                            class="sc-fzoNJl jCajfG"
                             color="primary"
                           />
                           <span
@@ -2098,23 +2106,25 @@ exports[`ResignRegistration should render 3rd step with password 1`] = `
             data-testid="Form"
           >
             <div>
-              <div>
-                <ul
-                  class="sc-fzoiQi fQHPRZ"
-                >
-                  <li
-                    class="sc-fznWqX kPdKVU"
-                  />
-                  <li
-                    class="sc-fznWqX kPdKVU"
-                  />
-                  <li
-                    class="sc-fznWqX kPdKVU"
-                  />
-                  <li
-                    class="sc-fznWqX PbNft"
-                  />
-                </ul>
+              <ul
+                class="sc-fznJRM kDmVaQ"
+              >
+                <li
+                  class="sc-fznxsB keKrAv"
+                />
+                <li
+                  class="sc-fznxsB keKrAv"
+                />
+                <li
+                  class="sc-fznxsB keKrAv"
+                />
+                <li
+                  class="sc-fznxsB exHzky"
+                />
+              </ul>
+              <div
+                data-testid="ResignRegistration__steps-wrapper"
+              >
                 <div
                   class="mt-8"
                 >
@@ -2497,23 +2507,25 @@ exports[`ResignRegistration should show authentication error 1`] = `
             data-testid="Form"
           >
             <div>
-              <div>
-                <ul
-                  class="sc-fzoiQi fQHPRZ"
-                >
-                  <li
-                    class="sc-fznWqX kPdKVU"
-                  />
-                  <li
-                    class="sc-fznWqX kPdKVU"
-                  />
-                  <li
-                    class="sc-fznWqX kPdKVU"
-                  />
-                  <li
-                    class="sc-fznWqX PbNft"
-                  />
-                </ul>
+              <ul
+                class="sc-fznJRM kDmVaQ"
+              >
+                <li
+                  class="sc-fznxsB keKrAv"
+                />
+                <li
+                  class="sc-fznxsB keKrAv"
+                />
+                <li
+                  class="sc-fznxsB keKrAv"
+                />
+                <li
+                  class="sc-fznxsB exHzky"
+                />
+              </ul>
+              <div
+                data-testid="ResignRegistration__steps-wrapper"
+              >
                 <div
                   class="mt-8"
                 >
@@ -2903,23 +2915,25 @@ exports[`ResignRegistration should succesfully sign and submit resignation trans
             data-testid="Form"
           >
             <div>
-              <div>
-                <ul
-                  class="sc-fzoiQi fQHPRZ"
-                >
-                  <li
-                    class="sc-fznWqX kPdKVU"
-                  />
-                  <li
-                    class="sc-fznWqX kPdKVU"
-                  />
-                  <li
-                    class="sc-fznWqX kPdKVU"
-                  />
-                  <li
-                    class="sc-fznWqX kPdKVU"
-                  />
-                </ul>
+              <ul
+                class="sc-fznJRM kDmVaQ"
+              >
+                <li
+                  class="sc-fznxsB keKrAv"
+                />
+                <li
+                  class="sc-fznxsB keKrAv"
+                />
+                <li
+                  class="sc-fznxsB keKrAv"
+                />
+                <li
+                  class="sc-fznxsB keKrAv"
+                />
+              </ul>
+              <div
+                data-testid="ResignRegistration__steps-wrapper"
+              >
                 <div
                   class="mt-8"
                 >

--- a/src/domains/transaction/pages/ResignRegistration/index.ts
+++ b/src/domains/transaction/pages/ResignRegistration/index.ts
@@ -1,4 +1,5 @@
 export * from "./ResignRegistration";
+export * from "./Step1Skeleton";
 export * from "./Step1";
 export * from "./Step2";
 export * from "./Step3";


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
When loading fees and wallet delegate on `Resign Resignation` first step, show skeletons instead of page loader.

![2020-08-30-191143_897x755_scrot](https://user-images.githubusercontent.com/22020168/91664646-59a58f00-eaf9-11ea-8191-635b7128d928.png)
<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->

