### PR TITLE
fix: use default timeout to fetch the plugin logo

### DIFF
--- a/src/renderer/services/plugin-manager.js
+++ b/src/renderer/services/plugin-manager.js
@@ -210,9 +210,7 @@ export class PluginManager {
     const {
       body
     } = await reqwest(url, {
-      encoding: null,
-      timeout: 100,
-      retry: 0
+      encoding: null
     })
     return body.toString('base64')
   }


### PR DESCRIPTION
## Summary

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged
