### PR TITLE
feat: navigate to `SendTransfer` from navbar

### DIFF
--- a/src/app/components/Badge/Badge.stories.tsx
+++ b/src/app/components/Badge/Badge.stories.tsx
@@ -43,7 +43,7 @@ export const Default = () => (
 );
 
 export const Colored = () => (
-	<div className="mt-3 mb-10 text-base space-x-5">
+	<div className="mt-3 mb-10 space-x-5 text-base">
 		<Circle className="relative text-white border-theme-success-500">
 			<Badge className="bg-theme-success-500" position="top" />
 		</Circle>

--- a/src/app/components/Button/Button.stories.tsx
+++ b/src/app/components/Button/Button.stories.tsx
@@ -41,7 +41,7 @@ export const WithIcon = () => {
 	const disabled = boolean("Disabled", false);
 
 	return (
-		<div className="capitalize space-x-4">
+		<div className="space-x-4 capitalize">
 			{variants.map((variant: ButtonVariant) => (
 				<Button key={variant} variant={variant} color={color} size={size} disabled={disabled}>
 					<Icon name="Download" />

--- a/src/app/components/Card/Card.stories.tsx
+++ b/src/app/components/Card/Card.stories.tsx
@@ -8,7 +8,7 @@ export default { title: "App / Components / Card" };
 export const Default = () => <Card className="inline-flex">ARK Ecosystem</Card>;
 
 export const Control = () => (
-	<div className="max-w-lg grid grid-cols-3 gap-4">
+	<div className="grid max-w-lg grid-cols-3 gap-4">
 		<CardControl defaultChecked={true} className="grid">
 			<div className="flex flex-col items-center justify-between h-full space-y-3">
 				<span className="text-center">ARK Ecosystem</span>

--- a/src/app/components/Header/HeaderSearchBar/HeaderSearchBar.tsx
+++ b/src/app/components/Header/HeaderSearchBar/HeaderSearchBar.tsx
@@ -59,7 +59,7 @@ export const HeaderSearchBar = ({ placeholder, children, label, onSearch, extra 
 				<SearchBarInputWrapper
 					data-testid="header-search-bar__input"
 					ref={ref}
-					className="absolute flex items-center px-6 py-4 bg-white shadow-xl rounded-md -bottom-4 -right-6"
+					className="absolute flex items-center px-6 py-4 bg-white rounded-md shadow-xl -bottom-4 -right-6"
 				>
 					{extra && (
 						<div className="flex items-center">

--- a/src/app/components/Link/Link.tsx
+++ b/src/app/components/Link/Link.tsx
@@ -32,7 +32,7 @@ const Anchor = React.forwardRef<HTMLAnchorElement, Props>(
 		<AnchorStyled
 			data-testid="Link"
 			isExternal={isExternal!}
-			className="inline-flex items-center font-semibold cursor-pointer transition-colors duration-200 text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+			className="inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
 			rel={isExternal ? "noopener noreferrer" : rel}
 			ref={ref}
 			onClick={(event) => {

--- a/src/app/components/Link/__snapshots__/Link.test.tsx.snap
+++ b/src/app/components/Link/__snapshots__/Link.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Link should open an external link 1`] = `
 <DocumentFragment>
   <a
-    class="sc-AxirZ fYobRB inline-flex items-center font-semibold cursor-pointer transition-colors duration-200 text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+    class="sc-AxirZ fYobRB inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
     data-testid="Link"
     rel="noopener noreferrer"
     to="https://ark.io"
@@ -25,7 +25,7 @@ exports[`Link should open an external link 1`] = `
 exports[`Link should render 1`] = `
 <DocumentFragment>
   <a
-    class="sc-AxirZ bvOtTg inline-flex items-center font-semibold cursor-pointer transition-colors duration-200 text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+    class="sc-AxirZ bvOtTg inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
     data-testid="Link"
     href="/test"
   >
@@ -37,7 +37,7 @@ exports[`Link should render 1`] = `
 exports[`Link should render external without children 1`] = `
 <DocumentFragment>
   <a
-    class="sc-AxirZ fYobRB inline-flex items-center font-semibold cursor-pointer transition-colors duration-200 text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+    class="sc-AxirZ fYobRB inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
     data-testid="Link"
     rel="noopener noreferrer"
     to="https://ark.io"
@@ -59,7 +59,7 @@ exports[`Link should render external without children 1`] = `
 exports[`Link should render with tooltip 1`] = `
 <DocumentFragment>
   <a
-    class="sc-AxirZ bvOtTg inline-flex items-center font-semibold cursor-pointer transition-colors duration-200 text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+    class="sc-AxirZ bvOtTg inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
     data-testid="Link"
     href="/test"
   >

--- a/src/app/components/NavigationBar/NavigationBar.test.tsx
+++ b/src/app/components/NavigationBar/NavigationBar.test.tsx
@@ -136,7 +136,7 @@ describe("NavigationBar", () => {
 			fireEvent.click(sendButton);
 		});
 
-		expect(history.location.pathname).toMatch(`/profiles/${profile.id()}/transactions/transfer`);
+		expect(history.location.pathname).toMatch(`/profiles/${profile.id()}/send-transfer`);
 	});
 
 	it("should handle receive funds", async () => {

--- a/src/app/components/NavigationBar/NavigationBar.tsx
+++ b/src/app/components/NavigationBar/NavigationBar.tsx
@@ -229,7 +229,7 @@ export const NavigationBar = ({
 										variant="transparent"
 										size="icon"
 										className="text-theme-primary-300 hover:text-theme-primary-dark hover:bg-theme-primary-50"
-										onClick={() => history.push(`/profiles/${profile?.id()}/transactions/transfer`)}
+										onClick={() => history.push(`/profiles/${profile?.id()}/send-transfer`)}
 										data-testid="navbar__buttons--send"
 									>
 										<Icon name="Sent" width={22} height={22} className="p-1" />

--- a/src/app/components/SearchBar/SearchBarPluginFilters/SearchBarPluginFilters.tsx
+++ b/src/app/components/SearchBar/SearchBarPluginFilters/SearchBarPluginFilters.tsx
@@ -38,7 +38,7 @@ const RatingsCheckboxes = ({ ratings, suffixLabel, value, onChange }: any) => (
 		{ratings &&
 			ratings.map((rating: number) => (
 				<label
-					className="flex items-center block px-2 pb-1 cursor-pointer space-x-2 text-theme-neutral-dark hover:bg-theme-neutral-contrast rounded-md"
+					className="flex items-center block px-2 pb-1 space-x-2 rounded-md cursor-pointer text-theme-neutral-dark hover:bg-theme-neutral-contrast"
 					key={rating}
 				>
 					<span>
@@ -80,7 +80,7 @@ const CategoryCheckboxes = ({ categories, selected, onChange }: any) => {
 			{categories &&
 				categories.map((category: Category, index: number) => (
 					<label
-						className="flex items-center block px-2 pb-1 mb-1 cursor-pointer space-x-2 text-theme-neutral-dark hover:bg-theme-neutral-contrast rounded-md"
+						className="flex items-center block px-2 pb-1 mb-1 space-x-2 rounded-md cursor-pointer text-theme-neutral-dark hover:bg-theme-neutral-contrast"
 						key={index}
 					>
 						<span>
@@ -157,7 +157,7 @@ export const SearchBarPluginFilters = ({
 				}
 			>
 				<div className="w-64 px-6 py-4">
-					<label className="flex items-center block px-2 pb-1 cursor-pointer space-x-3 text-theme-neutral-dark hover:bg-theme-neutral-contrast rounded-md">
+					<label className="flex items-center block px-2 pb-1 space-x-3 rounded-md cursor-pointer text-theme-neutral-dark hover:bg-theme-neutral-contrast">
 						<span>
 							<Checkbox
 								name="claim"

--- a/src/app/components/SearchBar/SearchBarPluginFilters/__snapshots__/SearchBarPluginFilters.test.tsx.snap
+++ b/src/app/components/SearchBar/SearchBarPluginFilters/__snapshots__/SearchBarPluginFilters.test.tsx.snap
@@ -66,7 +66,7 @@ exports[`SearchBarPluginFilters should render categories 1`] = `
               class="w-64 px-6 py-4"
             >
               <label
-                class="flex items-center block px-2 pb-1 cursor-pointer space-x-3 text-theme-neutral-dark hover:bg-theme-neutral-contrast rounded-md"
+                class="flex items-center block px-2 pb-1 space-x-3 rounded-md cursor-pointer text-theme-neutral-dark hover:bg-theme-neutral-contrast"
               >
                 <span>
                   <input
@@ -93,7 +93,7 @@ exports[`SearchBarPluginFilters should render categories 1`] = `
               </div>
               <fieldset>
                 <label
-                  class="flex items-center block px-2 pb-1 mb-1 cursor-pointer space-x-2 text-theme-neutral-dark hover:bg-theme-neutral-contrast rounded-md"
+                  class="flex items-center block px-2 pb-1 mb-1 space-x-2 rounded-md cursor-pointer text-theme-neutral-dark hover:bg-theme-neutral-contrast"
                 >
                   <span>
                     <input
@@ -121,7 +121,7 @@ exports[`SearchBarPluginFilters should render categories 1`] = `
               </div>
               <fieldset>
                 <label
-                  class="flex items-center block px-2 pb-1 cursor-pointer space-x-2 text-theme-neutral-dark hover:bg-theme-neutral-contrast rounded-md"
+                  class="flex items-center block px-2 pb-1 space-x-2 rounded-md cursor-pointer text-theme-neutral-dark hover:bg-theme-neutral-contrast"
                 >
                   <span>
                     <input
@@ -210,7 +210,7 @@ exports[`SearchBarPluginFilters should render categories 1`] = `
                   </span>
                 </label>
                 <label
-                  class="flex items-center block px-2 pb-1 cursor-pointer space-x-2 text-theme-neutral-dark hover:bg-theme-neutral-contrast rounded-md"
+                  class="flex items-center block px-2 pb-1 space-x-2 rounded-md cursor-pointer text-theme-neutral-dark hover:bg-theme-neutral-contrast"
                 >
                   <span>
                     <input
@@ -299,7 +299,7 @@ exports[`SearchBarPluginFilters should render categories 1`] = `
                   </span>
                 </label>
                 <label
-                  class="flex items-center block px-2 pb-1 cursor-pointer space-x-2 text-theme-neutral-dark hover:bg-theme-neutral-contrast rounded-md"
+                  class="flex items-center block px-2 pb-1 space-x-2 rounded-md cursor-pointer text-theme-neutral-dark hover:bg-theme-neutral-contrast"
                 >
                   <span>
                     <input
@@ -388,7 +388,7 @@ exports[`SearchBarPluginFilters should render categories 1`] = `
                   </span>
                 </label>
                 <label
-                  class="flex items-center block px-2 pb-1 cursor-pointer space-x-2 text-theme-neutral-dark hover:bg-theme-neutral-contrast rounded-md"
+                  class="flex items-center block px-2 pb-1 space-x-2 rounded-md cursor-pointer text-theme-neutral-dark hover:bg-theme-neutral-contrast"
                 >
                   <span>
                     <input
@@ -477,7 +477,7 @@ exports[`SearchBarPluginFilters should render categories 1`] = `
                   </span>
                 </label>
                 <label
-                  class="flex items-center block px-2 pb-1 cursor-pointer space-x-2 text-theme-neutral-dark hover:bg-theme-neutral-contrast rounded-md"
+                  class="flex items-center block px-2 pb-1 space-x-2 rounded-md cursor-pointer text-theme-neutral-dark hover:bg-theme-neutral-contrast"
                 >
                   <span>
                     <input
@@ -635,7 +635,7 @@ exports[`SearchBarPluginFilters should render ratings 1`] = `
               class="w-64 px-6 py-4"
             >
               <label
-                class="flex items-center block px-2 pb-1 cursor-pointer space-x-3 text-theme-neutral-dark hover:bg-theme-neutral-contrast rounded-md"
+                class="flex items-center block px-2 pb-1 space-x-3 rounded-md cursor-pointer text-theme-neutral-dark hover:bg-theme-neutral-contrast"
               >
                 <span>
                   <input
@@ -662,7 +662,7 @@ exports[`SearchBarPluginFilters should render ratings 1`] = `
               </div>
               <fieldset>
                 <label
-                  class="flex items-center block px-2 pb-1 mb-1 cursor-pointer space-x-2 text-theme-neutral-dark hover:bg-theme-neutral-contrast rounded-md"
+                  class="flex items-center block px-2 pb-1 mb-1 space-x-2 rounded-md cursor-pointer text-theme-neutral-dark hover:bg-theme-neutral-contrast"
                 >
                   <span>
                     <input
@@ -680,7 +680,7 @@ exports[`SearchBarPluginFilters should render ratings 1`] = `
                   </span>
                 </label>
                 <label
-                  class="flex items-center block px-2 pb-1 mb-1 cursor-pointer space-x-2 text-theme-neutral-dark hover:bg-theme-neutral-contrast rounded-md"
+                  class="flex items-center block px-2 pb-1 mb-1 space-x-2 rounded-md cursor-pointer text-theme-neutral-dark hover:bg-theme-neutral-contrast"
                 >
                   <span>
                     <input
@@ -698,7 +698,7 @@ exports[`SearchBarPluginFilters should render ratings 1`] = `
                   </span>
                 </label>
                 <label
-                  class="flex items-center block px-2 pb-1 mb-1 cursor-pointer space-x-2 text-theme-neutral-dark hover:bg-theme-neutral-contrast rounded-md"
+                  class="flex items-center block px-2 pb-1 mb-1 space-x-2 rounded-md cursor-pointer text-theme-neutral-dark hover:bg-theme-neutral-contrast"
                 >
                   <span>
                     <input
@@ -716,7 +716,7 @@ exports[`SearchBarPluginFilters should render ratings 1`] = `
                   </span>
                 </label>
                 <label
-                  class="flex items-center block px-2 pb-1 mb-1 cursor-pointer space-x-2 text-theme-neutral-dark hover:bg-theme-neutral-contrast rounded-md"
+                  class="flex items-center block px-2 pb-1 mb-1 space-x-2 rounded-md cursor-pointer text-theme-neutral-dark hover:bg-theme-neutral-contrast"
                 >
                   <span>
                     <input
@@ -744,7 +744,7 @@ exports[`SearchBarPluginFilters should render ratings 1`] = `
               </div>
               <fieldset>
                 <label
-                  class="flex items-center block px-2 pb-1 cursor-pointer space-x-2 text-theme-neutral-dark hover:bg-theme-neutral-contrast rounded-md"
+                  class="flex items-center block px-2 pb-1 space-x-2 rounded-md cursor-pointer text-theme-neutral-dark hover:bg-theme-neutral-contrast"
                 >
                   <span>
                     <input
@@ -833,7 +833,7 @@ exports[`SearchBarPluginFilters should render ratings 1`] = `
                   </span>
                 </label>
                 <label
-                  class="flex items-center block px-2 pb-1 cursor-pointer space-x-2 text-theme-neutral-dark hover:bg-theme-neutral-contrast rounded-md"
+                  class="flex items-center block px-2 pb-1 space-x-2 rounded-md cursor-pointer text-theme-neutral-dark hover:bg-theme-neutral-contrast"
                 >
                   <span>
                     <input
@@ -922,7 +922,7 @@ exports[`SearchBarPluginFilters should render ratings 1`] = `
                   </span>
                 </label>
                 <label
-                  class="flex items-center block px-2 pb-1 cursor-pointer space-x-2 text-theme-neutral-dark hover:bg-theme-neutral-contrast rounded-md"
+                  class="flex items-center block px-2 pb-1 space-x-2 rounded-md cursor-pointer text-theme-neutral-dark hover:bg-theme-neutral-contrast"
                 >
                   <span>
                     <input
@@ -1011,7 +1011,7 @@ exports[`SearchBarPluginFilters should render ratings 1`] = `
                   </span>
                 </label>
                 <label
-                  class="flex items-center block px-2 pb-1 cursor-pointer space-x-2 text-theme-neutral-dark hover:bg-theme-neutral-contrast rounded-md"
+                  class="flex items-center block px-2 pb-1 space-x-2 rounded-md cursor-pointer text-theme-neutral-dark hover:bg-theme-neutral-contrast"
                 >
                   <span>
                     <input
@@ -1100,7 +1100,7 @@ exports[`SearchBarPluginFilters should render ratings 1`] = `
                   </span>
                 </label>
                 <label
-                  class="flex items-center block px-2 pb-1 cursor-pointer space-x-2 text-theme-neutral-dark hover:bg-theme-neutral-contrast rounded-md"
+                  class="flex items-center block px-2 pb-1 space-x-2 rounded-md cursor-pointer text-theme-neutral-dark hover:bg-theme-neutral-contrast"
                 >
                   <span>
                     <input
@@ -1258,7 +1258,7 @@ exports[`SearchBarPluginFilters should render with null initialValues 1`] = `
               class="w-64 px-6 py-4"
             >
               <label
-                class="flex items-center block px-2 pb-1 cursor-pointer space-x-3 text-theme-neutral-dark hover:bg-theme-neutral-contrast rounded-md"
+                class="flex items-center block px-2 pb-1 space-x-3 rounded-md cursor-pointer text-theme-neutral-dark hover:bg-theme-neutral-contrast"
               >
                 <span>
                   <input
@@ -1286,7 +1286,7 @@ exports[`SearchBarPluginFilters should render with null initialValues 1`] = `
               </div>
               <fieldset>
                 <label
-                  class="flex items-center block px-2 pb-1 mb-1 cursor-pointer space-x-2 text-theme-neutral-dark hover:bg-theme-neutral-contrast rounded-md"
+                  class="flex items-center block px-2 pb-1 mb-1 space-x-2 rounded-md cursor-pointer text-theme-neutral-dark hover:bg-theme-neutral-contrast"
                 >
                   <span>
                     <input
@@ -1304,7 +1304,7 @@ exports[`SearchBarPluginFilters should render with null initialValues 1`] = `
                   </span>
                 </label>
                 <label
-                  class="flex items-center block px-2 pb-1 mb-1 cursor-pointer space-x-2 text-theme-neutral-dark hover:bg-theme-neutral-contrast rounded-md"
+                  class="flex items-center block px-2 pb-1 mb-1 space-x-2 rounded-md cursor-pointer text-theme-neutral-dark hover:bg-theme-neutral-contrast"
                 >
                   <span>
                     <input
@@ -1332,7 +1332,7 @@ exports[`SearchBarPluginFilters should render with null initialValues 1`] = `
               </div>
               <fieldset>
                 <label
-                  class="flex items-center block px-2 pb-1 cursor-pointer space-x-2 text-theme-neutral-dark hover:bg-theme-neutral-contrast rounded-md"
+                  class="flex items-center block px-2 pb-1 space-x-2 rounded-md cursor-pointer text-theme-neutral-dark hover:bg-theme-neutral-contrast"
                 >
                   <span>
                     <input
@@ -1421,7 +1421,7 @@ exports[`SearchBarPluginFilters should render with null initialValues 1`] = `
                   </span>
                 </label>
                 <label
-                  class="flex items-center block px-2 pb-1 cursor-pointer space-x-2 text-theme-neutral-dark hover:bg-theme-neutral-contrast rounded-md"
+                  class="flex items-center block px-2 pb-1 space-x-2 rounded-md cursor-pointer text-theme-neutral-dark hover:bg-theme-neutral-contrast"
                 >
                   <span>
                     <input
@@ -1510,7 +1510,7 @@ exports[`SearchBarPluginFilters should render with null initialValues 1`] = `
                   </span>
                 </label>
                 <label
-                  class="flex items-center block px-2 pb-1 cursor-pointer space-x-2 text-theme-neutral-dark hover:bg-theme-neutral-contrast rounded-md"
+                  class="flex items-center block px-2 pb-1 space-x-2 rounded-md cursor-pointer text-theme-neutral-dark hover:bg-theme-neutral-contrast"
                 >
                   <span>
                     <input
@@ -1599,7 +1599,7 @@ exports[`SearchBarPluginFilters should render with null initialValues 1`] = `
                   </span>
                 </label>
                 <label
-                  class="flex items-center block px-2 pb-1 cursor-pointer space-x-2 text-theme-neutral-dark hover:bg-theme-neutral-contrast rounded-md"
+                  class="flex items-center block px-2 pb-1 space-x-2 rounded-md cursor-pointer text-theme-neutral-dark hover:bg-theme-neutral-contrast"
                 >
                   <span>
                     <input
@@ -1757,7 +1757,7 @@ exports[`SearchBarPluginFilters should render with selected values 1`] = `
               class="w-64 px-6 py-4"
             >
               <label
-                class="flex items-center block px-2 pb-1 cursor-pointer space-x-3 text-theme-neutral-dark hover:bg-theme-neutral-contrast rounded-md"
+                class="flex items-center block px-2 pb-1 space-x-3 rounded-md cursor-pointer text-theme-neutral-dark hover:bg-theme-neutral-contrast"
               >
                 <span>
                   <input
@@ -1785,7 +1785,7 @@ exports[`SearchBarPluginFilters should render with selected values 1`] = `
               </div>
               <fieldset>
                 <label
-                  class="flex items-center block px-2 pb-1 mb-1 cursor-pointer space-x-2 text-theme-neutral-dark hover:bg-theme-neutral-contrast rounded-md"
+                  class="flex items-center block px-2 pb-1 mb-1 space-x-2 rounded-md cursor-pointer text-theme-neutral-dark hover:bg-theme-neutral-contrast"
                 >
                   <span>
                     <input
@@ -1814,7 +1814,7 @@ exports[`SearchBarPluginFilters should render with selected values 1`] = `
               </div>
               <fieldset>
                 <label
-                  class="flex items-center block px-2 pb-1 cursor-pointer space-x-2 text-theme-neutral-dark hover:bg-theme-neutral-contrast rounded-md"
+                  class="flex items-center block px-2 pb-1 space-x-2 rounded-md cursor-pointer text-theme-neutral-dark hover:bg-theme-neutral-contrast"
                 >
                   <span>
                     <input
@@ -1903,7 +1903,7 @@ exports[`SearchBarPluginFilters should render with selected values 1`] = `
                   </span>
                 </label>
                 <label
-                  class="flex items-center block px-2 pb-1 cursor-pointer space-x-2 text-theme-neutral-dark hover:bg-theme-neutral-contrast rounded-md"
+                  class="flex items-center block px-2 pb-1 space-x-2 rounded-md cursor-pointer text-theme-neutral-dark hover:bg-theme-neutral-contrast"
                 >
                   <span>
                     <input
@@ -1992,7 +1992,7 @@ exports[`SearchBarPluginFilters should render with selected values 1`] = `
                   </span>
                 </label>
                 <label
-                  class="flex items-center block px-2 pb-1 cursor-pointer space-x-2 text-theme-neutral-dark hover:bg-theme-neutral-contrast rounded-md"
+                  class="flex items-center block px-2 pb-1 space-x-2 rounded-md cursor-pointer text-theme-neutral-dark hover:bg-theme-neutral-contrast"
                 >
                   <span>
                     <input
@@ -2081,7 +2081,7 @@ exports[`SearchBarPluginFilters should render with selected values 1`] = `
                   </span>
                 </label>
                 <label
-                  class="flex items-center block px-2 pb-1 cursor-pointer space-x-2 text-theme-neutral-dark hover:bg-theme-neutral-contrast rounded-md"
+                  class="flex items-center block px-2 pb-1 space-x-2 rounded-md cursor-pointer text-theme-neutral-dark hover:bg-theme-neutral-contrast"
                 >
                   <span>
                     <input

--- a/src/app/components/SelectionBar/SelectionBar.tsx
+++ b/src/app/components/SelectionBar/SelectionBar.tsx
@@ -46,7 +46,7 @@ export const SelectionBarOption = ({ value, isValueChecked, setCheckedValue, chi
 			role="radio"
 			aria-checked={isChecked}
 			onClick={() => setCheckedValue(value)}
-			className="relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+			className="relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
 		>
 			{children}
 		</SelectionBarOptionStyled>

--- a/src/app/components/SelectionBar/__snapshots__/SelectionBar.test.tsx.snap
+++ b/src/app/components/SelectionBar/__snapshots__/SelectionBar.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`SelectionBarOption should render 1`] = `
 <DocumentFragment>
   <button
     aria-checked="true"
-    class="sc-AxjAm htsBtC relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+    class="sc-AxjAm htsBtC relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
     data-testid="SelectionBarOption"
     role="radio"
     type="button"
@@ -23,7 +23,7 @@ exports[`SelectionBarOption should render 1`] = `
   </button>
   <button
     aria-checked="false"
-    class="sc-AxjAm htsBtC relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+    class="sc-AxjAm htsBtC relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
     data-testid="SelectionBarOption"
     role="radio"
     type="button"

--- a/src/app/components/Slider/Slider.tsx
+++ b/src/app/components/Slider/Slider.tsx
@@ -56,7 +56,7 @@ export const Slider = ({ children, data, options, className, paginationPosition 
 	return (
 		<div className="relative">
 			{paginationPosition === "top-right" && (
-				<div className="absolute right-0 w-auto -top-12 swiper-pagination space-x-2" />
+				<div className="absolute right-0 w-auto space-x-2 -top-12 swiper-pagination" />
 			)}
 
 			<div className="swiper-container" style={{ height: `${getContainerHeight()}px` }}>

--- a/src/domains/contact/components/ContactForm/__snapshots__/ContactForm.test.tsx.snap
+++ b/src/domains/contact/components/ContactForm/__snapshots__/ContactForm.test.tsx.snap
@@ -82,7 +82,7 @@ exports[`ContactForm should select 1`] = `
         </div>
         <ul
           aria-labelledby="ContactForm__network-label"
-          class="mt-6 grid grid-cols-6 gap-6"
+          class="grid grid-cols-6 gap-6 mt-6"
           id="ContactForm__network-menu"
           role="listbox"
         >
@@ -672,7 +672,7 @@ exports[`ContactForm should select with errors 1`] = `
         </div>
         <ul
           aria-labelledby="ContactForm__network-label"
-          class="mt-6 grid grid-cols-6 gap-6"
+          class="grid grid-cols-6 gap-6 mt-6"
           id="ContactForm__network-menu"
           role="listbox"
         >
@@ -1256,7 +1256,7 @@ exports[`ContactForm when creating a new contact should render the form 1`] = `
         </div>
         <ul
           aria-labelledby="ContactForm__network-label"
-          class="mt-6 grid grid-cols-6 gap-6"
+          class="grid grid-cols-6 gap-6 mt-6"
           id="ContactForm__network-menu"
           role="listbox"
         />
@@ -1431,7 +1431,7 @@ exports[`ContactForm when editing an existing contact should render the form 1`]
         </div>
         <ul
           aria-labelledby="ContactForm__network-label"
-          class="mt-6 grid grid-cols-6 gap-6"
+          class="grid grid-cols-6 gap-6 mt-6"
           id="ContactForm__network-menu"
           role="listbox"
         />

--- a/src/domains/contact/components/ContactListItem/ContactListItem.tsx
+++ b/src/domains/contact/components/ContactListItem/ContactListItem.tsx
@@ -69,7 +69,7 @@ export const ContactListItem = ({ contact, variant, onAction, options }: Contact
 							</div>
 						</td>
 						{!isCondensed() && (
-							<td className="text-sm font-bold text-center border-b border-dashed space-x-2 border-theme-neutral-200">
+							<td className="space-x-2 text-sm font-bold text-center border-b border-dashed border-theme-neutral-200">
 								{address.hasSyncedWithNetwork() &&
 									walletTypes.map((type: string) =>
 										// @ts-ignore

--- a/src/domains/contact/components/ContactListItem/__snapshots__/ContactListItem.test.tsx.snap
+++ b/src/domains/contact/components/ContactListItem/__snapshots__/ContactListItem.test.tsx.snap
@@ -87,7 +87,7 @@ exports[`ContactListItem should render 1`] = `
           </div>
         </td>
         <td
-          class="text-sm font-bold text-center border-b border-dashed space-x-2 border-theme-neutral-200"
+          class="space-x-2 text-sm font-bold text-center border-b border-dashed border-theme-neutral-200"
         >
           <div
             class="sc-AxiKw eHzXqc border-black"
@@ -228,7 +228,7 @@ exports[`ContactListItem should render with multiple addresses 1`] = `
           </div>
         </td>
         <td
-          class="text-sm font-bold text-center border-b border-dashed space-x-2 border-theme-neutral-200"
+          class="space-x-2 text-sm font-bold text-center border-b border-dashed border-theme-neutral-200"
         >
           <div
             class="sc-AxiKw eHzXqc border-black"
@@ -334,7 +334,7 @@ exports[`ContactListItem should render with multiple addresses 1`] = `
           </div>
         </td>
         <td
-          class="text-sm font-bold text-center border-b border-dashed space-x-2 border-theme-neutral-200"
+          class="space-x-2 text-sm font-bold text-center border-b border-dashed border-theme-neutral-200"
         >
           <div
             class="sc-AxiKw eHzXqc border-black"
@@ -446,7 +446,7 @@ exports[`ContactListItem should render with multiple options 1`] = `
           </div>
         </td>
         <td
-          class="text-sm font-bold text-center border-b border-dashed space-x-2 border-theme-neutral-200"
+          class="space-x-2 text-sm font-bold text-center border-b border-dashed border-theme-neutral-200"
         >
           <div
             class="sc-AxiKw eHzXqc border-black"
@@ -552,7 +552,7 @@ exports[`ContactListItem should render with multiple options 1`] = `
           </div>
         </td>
         <td
-          class="text-sm font-bold text-center border-b border-dashed space-x-2 border-theme-neutral-200"
+          class="space-x-2 text-sm font-bold text-center border-b border-dashed border-theme-neutral-200"
         >
           <div
             class="sc-AxiKw eHzXqc border-black"
@@ -664,7 +664,7 @@ exports[`ContactListItem should render with one option 1`] = `
           </div>
         </td>
         <td
-          class="text-sm font-bold text-center border-b border-dashed space-x-2 border-theme-neutral-200"
+          class="space-x-2 text-sm font-bold text-center border-b border-dashed border-theme-neutral-200"
         >
           <div
             class="sc-AxiKw eHzXqc border-black"
@@ -750,7 +750,7 @@ exports[`ContactListItem should render with one option 1`] = `
           </div>
         </td>
         <td
-          class="text-sm font-bold text-center border-b border-dashed space-x-2 border-theme-neutral-200"
+          class="space-x-2 text-sm font-bold text-center border-b border-dashed border-theme-neutral-200"
         >
           <div
             class="sc-AxiKw eHzXqc border-black"

--- a/src/domains/contact/components/CreateContact/__snapshots__/CreateContact.test.tsx.snap
+++ b/src/domains/contact/components/CreateContact/__snapshots__/CreateContact.test.tsx.snap
@@ -134,7 +134,7 @@ exports[`CreateContact should render create contact modal 1`] = `
                   </div>
                   <ul
                     aria-labelledby="ContactForm__network-label"
-                    class="mt-6 grid grid-cols-6 gap-6"
+                    class="grid grid-cols-6 gap-6 mt-6"
                     id="ContactForm__network-menu"
                     role="listbox"
                   >

--- a/src/domains/contact/components/UpdateContact/__snapshots__/UpdateContact.test.tsx.snap
+++ b/src/domains/contact/components/UpdateContact/__snapshots__/UpdateContact.test.tsx.snap
@@ -129,7 +129,7 @@ exports[`UpdateContact should render a modal 1`] = `
                   </div>
                   <ul
                     aria-labelledby="ContactForm__network-label"
-                    class="mt-6 grid grid-cols-6 gap-6"
+                    class="grid grid-cols-6 gap-6 mt-6"
                     id="ContactForm__network-menu"
                     role="listbox"
                   />

--- a/src/domains/contact/pages/Contacts/__snapshots__/Contacts.test.tsx.snap
+++ b/src/domains/contact/pages/Contacts/__snapshots__/Contacts.test.tsx.snap
@@ -516,7 +516,7 @@ exports[`Contacts with contacts should render with contacts 1`] = `
                       </div>
                     </td>
                     <td
-                      class="text-sm font-bold text-center border-b border-dashed space-x-2 border-theme-neutral-200"
+                      class="space-x-2 text-sm font-bold text-center border-b border-dashed border-theme-neutral-200"
                     >
                       <div
                         class="sc-fznyAO gQONjx border-black"
@@ -648,7 +648,7 @@ exports[`Contacts with contacts should render with contacts 1`] = `
                       </div>
                     </td>
                     <td
-                      class="text-sm font-bold text-center border-b border-dashed space-x-2 border-theme-neutral-200"
+                      class="space-x-2 text-sm font-bold text-center border-b border-dashed border-theme-neutral-200"
                     />
                     <td
                       class="border-b border-dashed border-theme-neutral-200"

--- a/src/domains/dashboard/components/Transactions/__snapshots__/Transactions.test.tsx.snap
+++ b/src/domains/dashboard/components/Transactions/__snapshots__/Transactions.test.tsx.snap
@@ -348,7 +348,7 @@ exports[`Transactions should render with with transactions 1`] = `
                     class="inline-block align-middle"
                   >
                     <a
-                      class="sc-AxheI bALhgA inline-flex items-center font-semibold cursor-pointer transition-colors duration-200 text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+                      class="sc-AxheI bALhgA inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
                       data-testid="TransactionRow__ID"
                       rel="noopener noreferrer"
                       to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
@@ -428,7 +428,7 @@ exports[`Transactions should render with with transactions 1`] = `
                   class="text-center"
                 >
                   <div
-                    class="inline-flex align-middle space-x-1"
+                    class="inline-flex space-x-1 align-middle"
                     data-testid="TransactionRowInfo"
                   >
                     <span
@@ -493,7 +493,7 @@ exports[`Transactions should render with with transactions 1`] = `
                     class="inline-block align-middle"
                   >
                     <a
-                      class="sc-AxheI bALhgA inline-flex items-center font-semibold cursor-pointer transition-colors duration-200 text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+                      class="sc-AxheI bALhgA inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
                       data-testid="TransactionRow__ID"
                       rel="noopener noreferrer"
                       to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
@@ -573,7 +573,7 @@ exports[`Transactions should render with with transactions 1`] = `
                   class="text-center"
                 >
                   <div
-                    class="inline-flex align-middle space-x-1"
+                    class="inline-flex space-x-1 align-middle"
                     data-testid="TransactionRowInfo"
                   >
                     <span
@@ -638,7 +638,7 @@ exports[`Transactions should render with with transactions 1`] = `
                     class="inline-block align-middle"
                   >
                     <a
-                      class="sc-AxheI bALhgA inline-flex items-center font-semibold cursor-pointer transition-colors duration-200 text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+                      class="sc-AxheI bALhgA inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
                       data-testid="TransactionRow__ID"
                       rel="noopener noreferrer"
                       to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
@@ -714,7 +714,7 @@ exports[`Transactions should render with with transactions 1`] = `
                   class="text-center"
                 >
                   <div
-                    class="inline-flex align-middle space-x-1"
+                    class="inline-flex space-x-1 align-middle"
                     data-testid="TransactionRowInfo"
                   >
                     <span
@@ -779,7 +779,7 @@ exports[`Transactions should render with with transactions 1`] = `
                     class="inline-block align-middle"
                   >
                     <a
-                      class="sc-AxheI bALhgA inline-flex items-center font-semibold cursor-pointer transition-colors duration-200 text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+                      class="sc-AxheI bALhgA inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
                       data-testid="TransactionRow__ID"
                       rel="noopener noreferrer"
                       to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
@@ -855,7 +855,7 @@ exports[`Transactions should render with with transactions 1`] = `
                   class="text-center"
                 >
                   <div
-                    class="inline-flex align-middle space-x-1"
+                    class="inline-flex space-x-1 align-middle"
                     data-testid="TransactionRowInfo"
                   >
                     <span

--- a/src/domains/dashboard/pages/Dashboard/__snapshots__/Dashboard.test.tsx.snap
+++ b/src/domains/dashboard/pages/Dashboard/__snapshots__/Dashboard.test.tsx.snap
@@ -1067,7 +1067,7 @@ exports[`Dashboard should fetch more transactions 1`] = `
                             class="inline-block align-middle"
                           >
                             <a
-                              class="sc-fzozJi fCisHH inline-flex items-center font-semibold cursor-pointer transition-colors duration-200 text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+                              class="sc-fzozJi fCisHH inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
                               data-testid="TransactionRow__ID"
                               rel="noopener noreferrer"
                               to="https://dexplorer.ark.io/transaction/8f913b6b719e7767d49861c0aec79ced212767645cb793d75d2f1b89abb49877"
@@ -1147,7 +1147,7 @@ exports[`Dashboard should fetch more transactions 1`] = `
                           class="text-center"
                         >
                           <div
-                            class="inline-flex align-middle space-x-1"
+                            class="inline-flex space-x-1 align-middle"
                             data-testid="TransactionRowInfo"
                           />
                         </td>
@@ -1208,7 +1208,7 @@ exports[`Dashboard should fetch more transactions 1`] = `
                             class="inline-block align-middle"
                           >
                             <a
-                              class="sc-fzozJi fCisHH inline-flex items-center font-semibold cursor-pointer transition-colors duration-200 text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+                              class="sc-fzozJi fCisHH inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
                               data-testid="TransactionRow__ID"
                               rel="noopener noreferrer"
                               to="https://dexplorer.ark.io/transaction/0d8d12d7980bf0183ef015e5938e56c44c3db4d3695cefd16ccec4a7bfd8a2cf"
@@ -1288,7 +1288,7 @@ exports[`Dashboard should fetch more transactions 1`] = `
                           class="text-center"
                         >
                           <div
-                            class="inline-flex align-middle space-x-1"
+                            class="inline-flex space-x-1 align-middle"
                             data-testid="TransactionRowInfo"
                           />
                         </td>
@@ -1349,7 +1349,7 @@ exports[`Dashboard should fetch more transactions 1`] = `
                             class="inline-block align-middle"
                           >
                             <a
-                              class="sc-fzozJi fCisHH inline-flex items-center font-semibold cursor-pointer transition-colors duration-200 text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+                              class="sc-fzozJi fCisHH inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
                               data-testid="TransactionRow__ID"
                               rel="noopener noreferrer"
                               to="https://dexplorer.ark.io/transaction/8f913b6b719e7767d49861c0aec79ced212767645cb793d75d2f1b89abb49877"
@@ -1429,7 +1429,7 @@ exports[`Dashboard should fetch more transactions 1`] = `
                           class="text-center"
                         >
                           <div
-                            class="inline-flex align-middle space-x-1"
+                            class="inline-flex space-x-1 align-middle"
                             data-testid="TransactionRowInfo"
                           />
                         </td>
@@ -1490,7 +1490,7 @@ exports[`Dashboard should fetch more transactions 1`] = `
                             class="inline-block align-middle"
                           >
                             <a
-                              class="sc-fzozJi fCisHH inline-flex items-center font-semibold cursor-pointer transition-colors duration-200 text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+                              class="sc-fzozJi fCisHH inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
                               data-testid="TransactionRow__ID"
                               rel="noopener noreferrer"
                               to="https://dexplorer.ark.io/transaction/0d8d12d7980bf0183ef015e5938e56c44c3db4d3695cefd16ccec4a7bfd8a2cf"
@@ -1570,7 +1570,7 @@ exports[`Dashboard should fetch more transactions 1`] = `
                           class="text-center"
                         >
                           <div
-                            class="inline-flex align-middle space-x-1"
+                            class="inline-flex space-x-1 align-middle"
                             data-testid="TransactionRowInfo"
                           />
                         </td>
@@ -1631,7 +1631,7 @@ exports[`Dashboard should fetch more transactions 1`] = `
                             class="inline-block align-middle"
                           >
                             <a
-                              class="sc-fzozJi fCisHH inline-flex items-center font-semibold cursor-pointer transition-colors duration-200 text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+                              class="sc-fzozJi fCisHH inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
                               data-testid="TransactionRow__ID"
                               rel="noopener noreferrer"
                               to="https://dexplorer.ark.io/transaction/8f913b6b719e7767d49861c0aec79ced212767645cb793d75d2f1b89abb49877"
@@ -1711,7 +1711,7 @@ exports[`Dashboard should fetch more transactions 1`] = `
                           class="text-center"
                         >
                           <div
-                            class="inline-flex align-middle space-x-1"
+                            class="inline-flex space-x-1 align-middle"
                             data-testid="TransactionRowInfo"
                           />
                         </td>
@@ -1772,7 +1772,7 @@ exports[`Dashboard should fetch more transactions 1`] = `
                             class="inline-block align-middle"
                           >
                             <a
-                              class="sc-fzozJi fCisHH inline-flex items-center font-semibold cursor-pointer transition-colors duration-200 text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+                              class="sc-fzozJi fCisHH inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
                               data-testid="TransactionRow__ID"
                               rel="noopener noreferrer"
                               to="https://dexplorer.ark.io/transaction/0d8d12d7980bf0183ef015e5938e56c44c3db4d3695cefd16ccec4a7bfd8a2cf"
@@ -1852,7 +1852,7 @@ exports[`Dashboard should fetch more transactions 1`] = `
                           class="text-center"
                         >
                           <div
-                            class="inline-flex align-middle space-x-1"
+                            class="inline-flex space-x-1 align-middle"
                             data-testid="TransactionRowInfo"
                           />
                         </td>
@@ -1913,7 +1913,7 @@ exports[`Dashboard should fetch more transactions 1`] = `
                             class="inline-block align-middle"
                           >
                             <a
-                              class="sc-fzozJi fCisHH inline-flex items-center font-semibold cursor-pointer transition-colors duration-200 text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+                              class="sc-fzozJi fCisHH inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
                               data-testid="TransactionRow__ID"
                               rel="noopener noreferrer"
                               to="https://dexplorer.ark.io/transaction/8f913b6b719e7767d49861c0aec79ced212767645cb793d75d2f1b89abb49877"
@@ -1993,7 +1993,7 @@ exports[`Dashboard should fetch more transactions 1`] = `
                           class="text-center"
                         >
                           <div
-                            class="inline-flex align-middle space-x-1"
+                            class="inline-flex space-x-1 align-middle"
                             data-testid="TransactionRowInfo"
                           />
                         </td>
@@ -2054,7 +2054,7 @@ exports[`Dashboard should fetch more transactions 1`] = `
                             class="inline-block align-middle"
                           >
                             <a
-                              class="sc-fzozJi fCisHH inline-flex items-center font-semibold cursor-pointer transition-colors duration-200 text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+                              class="sc-fzozJi fCisHH inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
                               data-testid="TransactionRow__ID"
                               rel="noopener noreferrer"
                               to="https://dexplorer.ark.io/transaction/0d8d12d7980bf0183ef015e5938e56c44c3db4d3695cefd16ccec4a7bfd8a2cf"
@@ -2134,7 +2134,7 @@ exports[`Dashboard should fetch more transactions 1`] = `
                           class="text-center"
                         >
                           <div
-                            class="inline-flex align-middle space-x-1"
+                            class="inline-flex space-x-1 align-middle"
                             data-testid="TransactionRowInfo"
                           />
                         </td>
@@ -3251,7 +3251,7 @@ exports[`Dashboard should hide portfolio view 1`] = `
                             class="inline-block align-middle"
                           >
                             <a
-                              class="sc-fzozJi fCisHH inline-flex items-center font-semibold cursor-pointer transition-colors duration-200 text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+                              class="sc-fzozJi fCisHH inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
                               data-testid="TransactionRow__ID"
                               rel="noopener noreferrer"
                               to="https://dexplorer.ark.io/transaction/8f913b6b719e7767d49861c0aec79ced212767645cb793d75d2f1b89abb49877"
@@ -3331,7 +3331,7 @@ exports[`Dashboard should hide portfolio view 1`] = `
                           class="text-center"
                         >
                           <div
-                            class="inline-flex align-middle space-x-1"
+                            class="inline-flex space-x-1 align-middle"
                             data-testid="TransactionRowInfo"
                           />
                         </td>
@@ -3392,7 +3392,7 @@ exports[`Dashboard should hide portfolio view 1`] = `
                             class="inline-block align-middle"
                           >
                             <a
-                              class="sc-fzozJi fCisHH inline-flex items-center font-semibold cursor-pointer transition-colors duration-200 text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+                              class="sc-fzozJi fCisHH inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
                               data-testid="TransactionRow__ID"
                               rel="noopener noreferrer"
                               to="https://dexplorer.ark.io/transaction/0d8d12d7980bf0183ef015e5938e56c44c3db4d3695cefd16ccec4a7bfd8a2cf"
@@ -3472,7 +3472,7 @@ exports[`Dashboard should hide portfolio view 1`] = `
                           class="text-center"
                         >
                           <div
-                            class="inline-flex align-middle space-x-1"
+                            class="inline-flex space-x-1 align-middle"
                             data-testid="TransactionRowInfo"
                           />
                         </td>
@@ -3533,7 +3533,7 @@ exports[`Dashboard should hide portfolio view 1`] = `
                             class="inline-block align-middle"
                           >
                             <a
-                              class="sc-fzozJi fCisHH inline-flex items-center font-semibold cursor-pointer transition-colors duration-200 text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+                              class="sc-fzozJi fCisHH inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
                               data-testid="TransactionRow__ID"
                               rel="noopener noreferrer"
                               to="https://dexplorer.ark.io/transaction/8f913b6b719e7767d49861c0aec79ced212767645cb793d75d2f1b89abb49877"
@@ -3613,7 +3613,7 @@ exports[`Dashboard should hide portfolio view 1`] = `
                           class="text-center"
                         >
                           <div
-                            class="inline-flex align-middle space-x-1"
+                            class="inline-flex space-x-1 align-middle"
                             data-testid="TransactionRowInfo"
                           />
                         </td>
@@ -3674,7 +3674,7 @@ exports[`Dashboard should hide portfolio view 1`] = `
                             class="inline-block align-middle"
                           >
                             <a
-                              class="sc-fzozJi fCisHH inline-flex items-center font-semibold cursor-pointer transition-colors duration-200 text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+                              class="sc-fzozJi fCisHH inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
                               data-testid="TransactionRow__ID"
                               rel="noopener noreferrer"
                               to="https://dexplorer.ark.io/transaction/0d8d12d7980bf0183ef015e5938e56c44c3db4d3695cefd16ccec4a7bfd8a2cf"
@@ -3754,7 +3754,7 @@ exports[`Dashboard should hide portfolio view 1`] = `
                           class="text-center"
                         >
                           <div
-                            class="inline-flex align-middle space-x-1"
+                            class="inline-flex space-x-1 align-middle"
                             data-testid="TransactionRowInfo"
                           />
                         </td>
@@ -5961,7 +5961,7 @@ exports[`Dashboard should open detail modal on transaction row click 1`] = `
                             class="inline-block align-middle"
                           >
                             <a
-                              class="sc-fzozJi fCisHH inline-flex items-center font-semibold cursor-pointer transition-colors duration-200 text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+                              class="sc-fzozJi fCisHH inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
                               data-testid="TransactionRow__ID"
                               rel="noopener noreferrer"
                               to="https://dexplorer.ark.io/transaction/8f913b6b719e7767d49861c0aec79ced212767645cb793d75d2f1b89abb49877"
@@ -6041,7 +6041,7 @@ exports[`Dashboard should open detail modal on transaction row click 1`] = `
                           class="text-center"
                         >
                           <div
-                            class="inline-flex align-middle space-x-1"
+                            class="inline-flex space-x-1 align-middle"
                             data-testid="TransactionRowInfo"
                           />
                         </td>
@@ -6102,7 +6102,7 @@ exports[`Dashboard should open detail modal on transaction row click 1`] = `
                             class="inline-block align-middle"
                           >
                             <a
-                              class="sc-fzozJi fCisHH inline-flex items-center font-semibold cursor-pointer transition-colors duration-200 text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+                              class="sc-fzozJi fCisHH inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
                               data-testid="TransactionRow__ID"
                               rel="noopener noreferrer"
                               to="https://dexplorer.ark.io/transaction/0d8d12d7980bf0183ef015e5938e56c44c3db4d3695cefd16ccec4a7bfd8a2cf"
@@ -6182,7 +6182,7 @@ exports[`Dashboard should open detail modal on transaction row click 1`] = `
                           class="text-center"
                         >
                           <div
-                            class="inline-flex align-middle space-x-1"
+                            class="inline-flex space-x-1 align-middle"
                             data-testid="TransactionRowInfo"
                           />
                         </td>
@@ -6243,7 +6243,7 @@ exports[`Dashboard should open detail modal on transaction row click 1`] = `
                             class="inline-block align-middle"
                           >
                             <a
-                              class="sc-fzozJi fCisHH inline-flex items-center font-semibold cursor-pointer transition-colors duration-200 text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+                              class="sc-fzozJi fCisHH inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
                               data-testid="TransactionRow__ID"
                               rel="noopener noreferrer"
                               to="https://dexplorer.ark.io/transaction/8f913b6b719e7767d49861c0aec79ced212767645cb793d75d2f1b89abb49877"
@@ -6323,7 +6323,7 @@ exports[`Dashboard should open detail modal on transaction row click 1`] = `
                           class="text-center"
                         >
                           <div
-                            class="inline-flex align-middle space-x-1"
+                            class="inline-flex space-x-1 align-middle"
                             data-testid="TransactionRowInfo"
                           />
                         </td>
@@ -6384,7 +6384,7 @@ exports[`Dashboard should open detail modal on transaction row click 1`] = `
                             class="inline-block align-middle"
                           >
                             <a
-                              class="sc-fzozJi fCisHH inline-flex items-center font-semibold cursor-pointer transition-colors duration-200 text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+                              class="sc-fzozJi fCisHH inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
                               data-testid="TransactionRow__ID"
                               rel="noopener noreferrer"
                               to="https://dexplorer.ark.io/transaction/0d8d12d7980bf0183ef015e5938e56c44c3db4d3695cefd16ccec4a7bfd8a2cf"
@@ -6464,7 +6464,7 @@ exports[`Dashboard should open detail modal on transaction row click 1`] = `
                           class="text-center"
                         >
                           <div
-                            class="inline-flex align-middle space-x-1"
+                            class="inline-flex space-x-1 align-middle"
                             data-testid="TransactionRowInfo"
                           />
                         </td>
@@ -7602,7 +7602,7 @@ exports[`Dashboard should render 1`] = `
                             class="inline-block align-middle"
                           >
                             <a
-                              class="sc-fzozJi fCisHH inline-flex items-center font-semibold cursor-pointer transition-colors duration-200 text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+                              class="sc-fzozJi fCisHH inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
                               data-testid="TransactionRow__ID"
                               rel="noopener noreferrer"
                               to="https://dexplorer.ark.io/transaction/8f913b6b719e7767d49861c0aec79ced212767645cb793d75d2f1b89abb49877"
@@ -7682,7 +7682,7 @@ exports[`Dashboard should render 1`] = `
                           class="text-center"
                         >
                           <div
-                            class="inline-flex align-middle space-x-1"
+                            class="inline-flex space-x-1 align-middle"
                             data-testid="TransactionRowInfo"
                           />
                         </td>
@@ -7743,7 +7743,7 @@ exports[`Dashboard should render 1`] = `
                             class="inline-block align-middle"
                           >
                             <a
-                              class="sc-fzozJi fCisHH inline-flex items-center font-semibold cursor-pointer transition-colors duration-200 text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+                              class="sc-fzozJi fCisHH inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
                               data-testid="TransactionRow__ID"
                               rel="noopener noreferrer"
                               to="https://dexplorer.ark.io/transaction/0d8d12d7980bf0183ef015e5938e56c44c3db4d3695cefd16ccec4a7bfd8a2cf"
@@ -7823,7 +7823,7 @@ exports[`Dashboard should render 1`] = `
                           class="text-center"
                         >
                           <div
-                            class="inline-flex align-middle space-x-1"
+                            class="inline-flex space-x-1 align-middle"
                             data-testid="TransactionRowInfo"
                           />
                         </td>
@@ -7884,7 +7884,7 @@ exports[`Dashboard should render 1`] = `
                             class="inline-block align-middle"
                           >
                             <a
-                              class="sc-fzozJi fCisHH inline-flex items-center font-semibold cursor-pointer transition-colors duration-200 text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+                              class="sc-fzozJi fCisHH inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
                               data-testid="TransactionRow__ID"
                               rel="noopener noreferrer"
                               to="https://dexplorer.ark.io/transaction/8f913b6b719e7767d49861c0aec79ced212767645cb793d75d2f1b89abb49877"
@@ -7964,7 +7964,7 @@ exports[`Dashboard should render 1`] = `
                           class="text-center"
                         >
                           <div
-                            class="inline-flex align-middle space-x-1"
+                            class="inline-flex space-x-1 align-middle"
                             data-testid="TransactionRowInfo"
                           />
                         </td>
@@ -8025,7 +8025,7 @@ exports[`Dashboard should render 1`] = `
                             class="inline-block align-middle"
                           >
                             <a
-                              class="sc-fzozJi fCisHH inline-flex items-center font-semibold cursor-pointer transition-colors duration-200 text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+                              class="sc-fzozJi fCisHH inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
                               data-testid="TransactionRow__ID"
                               rel="noopener noreferrer"
                               to="https://dexplorer.ark.io/transaction/0d8d12d7980bf0183ef015e5938e56c44c3db4d3695cefd16ccec4a7bfd8a2cf"
@@ -8105,7 +8105,7 @@ exports[`Dashboard should render 1`] = `
                           class="text-center"
                         >
                           <div
-                            class="inline-flex align-middle space-x-1"
+                            class="inline-flex space-x-1 align-middle"
                             data-testid="TransactionRowInfo"
                           />
                         </td>
@@ -9243,7 +9243,7 @@ exports[`Dashboard should render portfolio chart 1`] = `
                             class="inline-block align-middle"
                           >
                             <a
-                              class="sc-fzozJi fCisHH inline-flex items-center font-semibold cursor-pointer transition-colors duration-200 text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+                              class="sc-fzozJi fCisHH inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
                               data-testid="TransactionRow__ID"
                               rel="noopener noreferrer"
                               to="https://dexplorer.ark.io/transaction/8f913b6b719e7767d49861c0aec79ced212767645cb793d75d2f1b89abb49877"
@@ -9323,7 +9323,7 @@ exports[`Dashboard should render portfolio chart 1`] = `
                           class="text-center"
                         >
                           <div
-                            class="inline-flex align-middle space-x-1"
+                            class="inline-flex space-x-1 align-middle"
                             data-testid="TransactionRowInfo"
                           />
                         </td>
@@ -9384,7 +9384,7 @@ exports[`Dashboard should render portfolio chart 1`] = `
                             class="inline-block align-middle"
                           >
                             <a
-                              class="sc-fzozJi fCisHH inline-flex items-center font-semibold cursor-pointer transition-colors duration-200 text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+                              class="sc-fzozJi fCisHH inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
                               data-testid="TransactionRow__ID"
                               rel="noopener noreferrer"
                               to="https://dexplorer.ark.io/transaction/0d8d12d7980bf0183ef015e5938e56c44c3db4d3695cefd16ccec4a7bfd8a2cf"
@@ -9464,7 +9464,7 @@ exports[`Dashboard should render portfolio chart 1`] = `
                           class="text-center"
                         >
                           <div
-                            class="inline-flex align-middle space-x-1"
+                            class="inline-flex space-x-1 align-middle"
                             data-testid="TransactionRowInfo"
                           />
                         </td>
@@ -9525,7 +9525,7 @@ exports[`Dashboard should render portfolio chart 1`] = `
                             class="inline-block align-middle"
                           >
                             <a
-                              class="sc-fzozJi fCisHH inline-flex items-center font-semibold cursor-pointer transition-colors duration-200 text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+                              class="sc-fzozJi fCisHH inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
                               data-testid="TransactionRow__ID"
                               rel="noopener noreferrer"
                               to="https://dexplorer.ark.io/transaction/8f913b6b719e7767d49861c0aec79ced212767645cb793d75d2f1b89abb49877"
@@ -9605,7 +9605,7 @@ exports[`Dashboard should render portfolio chart 1`] = `
                           class="text-center"
                         >
                           <div
-                            class="inline-flex align-middle space-x-1"
+                            class="inline-flex space-x-1 align-middle"
                             data-testid="TransactionRowInfo"
                           />
                         </td>
@@ -9666,7 +9666,7 @@ exports[`Dashboard should render portfolio chart 1`] = `
                             class="inline-block align-middle"
                           >
                             <a
-                              class="sc-fzozJi fCisHH inline-flex items-center font-semibold cursor-pointer transition-colors duration-200 text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+                              class="sc-fzozJi fCisHH inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
                               data-testid="TransactionRow__ID"
                               rel="noopener noreferrer"
                               to="https://dexplorer.ark.io/transaction/0d8d12d7980bf0183ef015e5938e56c44c3db4d3695cefd16ccec4a7bfd8a2cf"
@@ -9746,7 +9746,7 @@ exports[`Dashboard should render portfolio chart 1`] = `
                           class="text-center"
                         >
                           <div
-                            class="inline-flex align-middle space-x-1"
+                            class="inline-flex space-x-1 align-middle"
                             data-testid="TransactionRowInfo"
                           />
                         </td>
@@ -10884,7 +10884,7 @@ exports[`Dashboard should render portfolio percentage bar 1`] = `
                             class="inline-block align-middle"
                           >
                             <a
-                              class="sc-fzozJi fCisHH inline-flex items-center font-semibold cursor-pointer transition-colors duration-200 text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+                              class="sc-fzozJi fCisHH inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
                               data-testid="TransactionRow__ID"
                               rel="noopener noreferrer"
                               to="https://dexplorer.ark.io/transaction/8f913b6b719e7767d49861c0aec79ced212767645cb793d75d2f1b89abb49877"
@@ -10964,7 +10964,7 @@ exports[`Dashboard should render portfolio percentage bar 1`] = `
                           class="text-center"
                         >
                           <div
-                            class="inline-flex align-middle space-x-1"
+                            class="inline-flex space-x-1 align-middle"
                             data-testid="TransactionRowInfo"
                           />
                         </td>
@@ -11025,7 +11025,7 @@ exports[`Dashboard should render portfolio percentage bar 1`] = `
                             class="inline-block align-middle"
                           >
                             <a
-                              class="sc-fzozJi fCisHH inline-flex items-center font-semibold cursor-pointer transition-colors duration-200 text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+                              class="sc-fzozJi fCisHH inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
                               data-testid="TransactionRow__ID"
                               rel="noopener noreferrer"
                               to="https://dexplorer.ark.io/transaction/0d8d12d7980bf0183ef015e5938e56c44c3db4d3695cefd16ccec4a7bfd8a2cf"
@@ -11105,7 +11105,7 @@ exports[`Dashboard should render portfolio percentage bar 1`] = `
                           class="text-center"
                         >
                           <div
-                            class="inline-flex align-middle space-x-1"
+                            class="inline-flex space-x-1 align-middle"
                             data-testid="TransactionRowInfo"
                           />
                         </td>
@@ -11166,7 +11166,7 @@ exports[`Dashboard should render portfolio percentage bar 1`] = `
                             class="inline-block align-middle"
                           >
                             <a
-                              class="sc-fzozJi fCisHH inline-flex items-center font-semibold cursor-pointer transition-colors duration-200 text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+                              class="sc-fzozJi fCisHH inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
                               data-testid="TransactionRow__ID"
                               rel="noopener noreferrer"
                               to="https://dexplorer.ark.io/transaction/8f913b6b719e7767d49861c0aec79ced212767645cb793d75d2f1b89abb49877"
@@ -11246,7 +11246,7 @@ exports[`Dashboard should render portfolio percentage bar 1`] = `
                           class="text-center"
                         >
                           <div
-                            class="inline-flex align-middle space-x-1"
+                            class="inline-flex space-x-1 align-middle"
                             data-testid="TransactionRowInfo"
                           />
                         </td>
@@ -11307,7 +11307,7 @@ exports[`Dashboard should render portfolio percentage bar 1`] = `
                             class="inline-block align-middle"
                           >
                             <a
-                              class="sc-fzozJi fCisHH inline-flex items-center font-semibold cursor-pointer transition-colors duration-200 text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+                              class="sc-fzozJi fCisHH inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
                               data-testid="TransactionRow__ID"
                               rel="noopener noreferrer"
                               to="https://dexplorer.ark.io/transaction/0d8d12d7980bf0183ef015e5938e56c44c3db4d3695cefd16ccec4a7bfd8a2cf"
@@ -11387,7 +11387,7 @@ exports[`Dashboard should render portfolio percentage bar 1`] = `
                           class="text-center"
                         >
                           <div
-                            class="inline-flex align-middle space-x-1"
+                            class="inline-flex space-x-1 align-middle"
                             data-testid="TransactionRowInfo"
                           />
                         </td>
@@ -12525,7 +12525,7 @@ exports[`Dashboard should render wallets 1`] = `
                             class="inline-block align-middle"
                           >
                             <a
-                              class="sc-fzozJi fCisHH inline-flex items-center font-semibold cursor-pointer transition-colors duration-200 text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+                              class="sc-fzozJi fCisHH inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
                               data-testid="TransactionRow__ID"
                               rel="noopener noreferrer"
                               to="https://dexplorer.ark.io/transaction/8f913b6b719e7767d49861c0aec79ced212767645cb793d75d2f1b89abb49877"
@@ -12605,7 +12605,7 @@ exports[`Dashboard should render wallets 1`] = `
                           class="text-center"
                         >
                           <div
-                            class="inline-flex align-middle space-x-1"
+                            class="inline-flex space-x-1 align-middle"
                             data-testid="TransactionRowInfo"
                           />
                         </td>
@@ -12666,7 +12666,7 @@ exports[`Dashboard should render wallets 1`] = `
                             class="inline-block align-middle"
                           >
                             <a
-                              class="sc-fzozJi fCisHH inline-flex items-center font-semibold cursor-pointer transition-colors duration-200 text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+                              class="sc-fzozJi fCisHH inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
                               data-testid="TransactionRow__ID"
                               rel="noopener noreferrer"
                               to="https://dexplorer.ark.io/transaction/0d8d12d7980bf0183ef015e5938e56c44c3db4d3695cefd16ccec4a7bfd8a2cf"
@@ -12746,7 +12746,7 @@ exports[`Dashboard should render wallets 1`] = `
                           class="text-center"
                         >
                           <div
-                            class="inline-flex align-middle space-x-1"
+                            class="inline-flex space-x-1 align-middle"
                             data-testid="TransactionRowInfo"
                           />
                         </td>
@@ -12807,7 +12807,7 @@ exports[`Dashboard should render wallets 1`] = `
                             class="inline-block align-middle"
                           >
                             <a
-                              class="sc-fzozJi fCisHH inline-flex items-center font-semibold cursor-pointer transition-colors duration-200 text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+                              class="sc-fzozJi fCisHH inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
                               data-testid="TransactionRow__ID"
                               rel="noopener noreferrer"
                               to="https://dexplorer.ark.io/transaction/8f913b6b719e7767d49861c0aec79ced212767645cb793d75d2f1b89abb49877"
@@ -12887,7 +12887,7 @@ exports[`Dashboard should render wallets 1`] = `
                           class="text-center"
                         >
                           <div
-                            class="inline-flex align-middle space-x-1"
+                            class="inline-flex space-x-1 align-middle"
                             data-testid="TransactionRowInfo"
                           />
                         </td>
@@ -12948,7 +12948,7 @@ exports[`Dashboard should render wallets 1`] = `
                             class="inline-block align-middle"
                           >
                             <a
-                              class="sc-fzozJi fCisHH inline-flex items-center font-semibold cursor-pointer transition-colors duration-200 text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+                              class="sc-fzozJi fCisHH inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
                               data-testid="TransactionRow__ID"
                               rel="noopener noreferrer"
                               to="https://dexplorer.ark.io/transaction/0d8d12d7980bf0183ef015e5938e56c44c3db4d3695cefd16ccec4a7bfd8a2cf"
@@ -13028,7 +13028,7 @@ exports[`Dashboard should render wallets 1`] = `
                           class="text-center"
                         >
                           <div
-                            class="inline-flex align-middle space-x-1"
+                            class="inline-flex space-x-1 align-middle"
                             data-testid="TransactionRowInfo"
                           />
                         </td>

--- a/src/domains/exchange/pages/Exchange/Exchange.tsx
+++ b/src/domains/exchange/pages/Exchange/Exchange.tsx
@@ -19,8 +19,8 @@ const NoExchangesList = ({ onAddExchange }: { onAddExchange: any }) => {
 	const { t } = useTranslation();
 
 	return (
-		<div className="mt-8 grid grid-cols-8">
-			<div className="flex flex-col h-32 mr-5 border-2 rounded-lg border-theme-primary-contrast col-span-6">
+		<div className="grid grid-cols-8 mt-8">
+			<div className="flex flex-col h-32 col-span-6 mr-5 border-2 rounded-lg border-theme-primary-contrast">
 				<div className="flex flex-col m-auto text-center">
 					<span className="font-semibold">{t("EXCHANGE.YOUR_EXCHANGE_LIST")}</span>
 

--- a/src/domains/exchange/pages/Exchange/__snapshots__/Exchange.test.tsx.snap
+++ b/src/domains/exchange/pages/Exchange/__snapshots__/Exchange.test.tsx.snap
@@ -273,7 +273,7 @@ exports[`Exchange should not render filler exchange cards 1`] = `
               class="relative"
             >
               <div
-                class="absolute right-0 w-auto -top-12 swiper-pagination space-x-2 swiper-pagination-clickable swiper-pagination-bullets"
+                class="absolute right-0 w-auto space-x-2 -top-12 swiper-pagination swiper-pagination-clickable swiper-pagination-bullets"
               />
               <div
                 class="swiper-container swiper-container-initialized swiper-container-horizontal"
@@ -754,7 +754,7 @@ exports[`Exchange should open & close add exchange modal 1`] = `
               class="relative"
             >
               <div
-                class="absolute right-0 w-auto -top-12 swiper-pagination space-x-2 swiper-pagination-clickable swiper-pagination-bullets"
+                class="absolute right-0 w-auto space-x-2 -top-12 swiper-pagination swiper-pagination-clickable swiper-pagination-bullets"
               />
               <div
                 class="swiper-container swiper-container-initialized swiper-container-horizontal"
@@ -1229,10 +1229,10 @@ exports[`Exchange should open & close add exchange modal when no existing exchan
             </div>
           </div>
           <div
-            class="mt-8 grid grid-cols-8"
+            class="grid grid-cols-8 mt-8"
           >
             <div
-              class="flex flex-col h-32 mr-5 border-2 rounded-lg border-theme-primary-contrast col-span-6"
+              class="flex flex-col h-32 col-span-6 mr-5 border-2 rounded-lg border-theme-primary-contrast"
             >
               <div
                 class="flex flex-col m-auto text-center"
@@ -1559,10 +1559,10 @@ exports[`Exchange should render 1`] = `
             </div>
           </div>
           <div
-            class="mt-8 grid grid-cols-8"
+            class="grid grid-cols-8 mt-8"
           >
             <div
-              class="flex flex-col h-32 mr-5 border-2 rounded-lg border-theme-primary-contrast col-span-6"
+              class="flex flex-col h-32 col-span-6 mr-5 border-2 rounded-lg border-theme-primary-contrast"
             >
               <div
                 class="flex flex-col m-auto text-center"
@@ -1895,7 +1895,7 @@ exports[`Exchange should render filler exchange cards 1`] = `
               class="relative"
             >
               <div
-                class="absolute right-0 w-auto -top-12 swiper-pagination space-x-2 swiper-pagination-clickable swiper-pagination-bullets"
+                class="absolute right-0 w-auto space-x-2 -top-12 swiper-pagination swiper-pagination-clickable swiper-pagination-bullets"
               />
               <div
                 class="swiper-container swiper-container-initialized swiper-container-horizontal"
@@ -2485,7 +2485,7 @@ exports[`Exchange should render with exchanges 1`] = `
               class="relative"
             >
               <div
-                class="absolute right-0 w-auto -top-12 swiper-pagination space-x-2 swiper-pagination-clickable swiper-pagination-bullets"
+                class="absolute right-0 w-auto space-x-2 -top-12 swiper-pagination swiper-pagination-clickable swiper-pagination-bullets"
               />
               <div
                 class="swiper-container swiper-container-initialized swiper-container-horizontal"
@@ -2966,7 +2966,7 @@ exports[`Exchange should select exchange 1`] = `
               class="relative"
             >
               <div
-                class="absolute right-0 w-auto -top-12 swiper-pagination space-x-2 swiper-pagination-clickable swiper-pagination-bullets"
+                class="absolute right-0 w-auto space-x-2 -top-12 swiper-pagination swiper-pagination-clickable swiper-pagination-bullets"
               />
               <div
                 class="swiper-container swiper-container-initialized swiper-container-horizontal"

--- a/src/domains/network/components/SelectNetwork/SelectNetwork.tsx
+++ b/src/domains/network/components/SelectNetwork/SelectNetwork.tsx
@@ -126,7 +126,7 @@ export const SelectNetwork = ({
 					})}
 				/>
 			</div>
-			<ul {...getMenuProps()} className="mt-6 grid grid-cols-6 gap-6">
+			<ul {...getMenuProps()} className="grid grid-cols-6 gap-6 mt-6">
 				{items.map((item, index) => (
 					<li
 						data-testid="SelectNetwork__NetworkIcon--container"

--- a/src/domains/network/components/SelectNetwork/__snapshots__/SelectNetwork.test.tsx.snap
+++ b/src/domains/network/components/SelectNetwork/__snapshots__/SelectNetwork.test.tsx.snap
@@ -40,7 +40,7 @@ exports[`SelectNetwork should render 1`] = `
   </div>
   <ul
     aria-labelledby="downshift-1-label"
-    class="mt-6 grid grid-cols-6 gap-6"
+    class="grid grid-cols-6 gap-6 mt-6"
     id="downshift-1-menu"
     role="listbox"
   />
@@ -87,7 +87,7 @@ exports[`SelectNetwork should render with networks 1`] = `
   </div>
   <ul
     aria-labelledby="downshift-5-label"
-    class="mt-6 grid grid-cols-6 gap-6"
+    class="grid grid-cols-6 gap-6 mt-6"
     id="downshift-5-menu"
     role="listbox"
   >

--- a/src/domains/news/components/AddAssets/__snapshots__/AddAssets.test.tsx.snap
+++ b/src/domains/news/components/AddAssets/__snapshots__/AddAssets.test.tsx.snap
@@ -107,7 +107,7 @@ exports[`AddAssets should render a modal 1`] = `
               </div>
               <ul
                 aria-labelledby="AddAssets__network-label"
-                class="mt-6 grid grid-cols-6 gap-6"
+                class="grid grid-cols-6 gap-6 mt-6"
                 id="AddAssets__network-menu"
                 role="listbox"
               />

--- a/src/domains/news/components/NewsCard/NewsCardSkeleton.tsx
+++ b/src/domains/news/components/NewsCard/NewsCardSkeleton.tsx
@@ -15,7 +15,7 @@ export const NewsCardSkeleton = () => (
 						<div>
 							<Skeleton height={6} width={100} style={{ verticalAlign: "middle" }} />
 						</div>
-						<div className="flex items-center align-middle space-x-4">
+						<div className="flex items-center space-x-4 align-middle">
 							<p className="text-theme-neutral" data-testid="NewsCard__author">
 								<Skeleton height={6} width={100} style={{ verticalAlign: "middle" }} />
 								<Skeleton height={6} width={100} style={{ verticalAlign: "middle" }} className="ml-2" />

--- a/src/domains/news/components/NewsCard/__snapshots__/NewsCard.test.tsx.snap
+++ b/src/domains/news/components/NewsCard/__snapshots__/NewsCard.test.tsx.snap
@@ -79,7 +79,7 @@ exports[`NewsCard should render 1`] = `
         >
           Recently we released our all-in-one toolkit the ARK Platform SDK, along with an overview and what blockchain projects it will initially support. Today we are going into more details on a technical level. 
           <a
-            class="sc-AxgMl fZdMHS inline-flex items-center font-semibold cursor-pointer transition-colors duration-200 text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+            class="sc-AxgMl fZdMHS inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
             data-testid="Link"
             rel="noopener noreferrer"
             to="https://blog.ark.io/ark-platform-sdk-modernization-of-blockchain-network-interactions-b5a7d70c2461"
@@ -175,7 +175,7 @@ exports[`NewsCard should render with cover image 1`] = `
         >
           June is over and it's time for the Monthly Update. This blog post will cover last month’s highlights, activities, development, partner activities, news and updates of our upcoming releases. 
           <a
-            class="sc-AxgMl fZdMHS inline-flex items-center font-semibold cursor-pointer transition-colors duration-200 text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+            class="sc-AxgMl fZdMHS inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
             data-testid="Link"
             rel="noopener noreferrer"
             to="https://blog.ark.io/ark-monthly-update-june-2020-edition-279a3dd47a36"

--- a/src/domains/news/components/NewsOptions/NewsOptions.tsx
+++ b/src/domains/news/components/NewsOptions/NewsOptions.tsx
@@ -69,7 +69,7 @@ export const NewsOptions = ({
 			data-testid="NewsOptions"
 		>
 			<div className="flex flex-col space-y-8">
-				<div className="flex items-center justify-between px-2 py-4 shadow-xl rounded-md">
+				<div className="flex items-center justify-between px-2 py-4 rounded-md shadow-xl">
 					<Input
 						data-testid="NewsOptions__search"
 						maxLength={32}

--- a/src/domains/news/components/NewsOptions/__snapshots__/NewsOptions.test.tsx.snap
+++ b/src/domains/news/components/NewsOptions/__snapshots__/NewsOptions.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`NewsOptions should render 1`] = `
       class="flex flex-col space-y-8"
     >
       <div
-        class="flex items-center justify-between px-2 py-4 shadow-xl rounded-md"
+        class="flex items-center justify-between px-2 py-4 rounded-md shadow-xl"
       >
         <input
           class="sc-AxgMl jRvGoE overflow-hidden w-full bg-theme-background appearance-none rounded border border-theme-neutral-300 text-theme-neutral-900 transition-colors duration-200 px-4 py-3 border-none shadow-none NewsOptions__search"

--- a/src/domains/news/pages/News/__snapshots__/News.test.tsx.snap
+++ b/src/domains/news/pages/News/__snapshots__/News.test.tsx.snap
@@ -415,7 +415,7 @@ exports[`News should filter results based on category query and asset 1`] = `
                         Major League Hacking is having another virtual workshop showcasing ARK technology on August 19th 2020. Anyone can join at 5PM EDT to Build a Blockchain Taco Shop with ARK!
 
                         <a
-                          class="sc-fzozJi fCisHH inline-flex items-center font-semibold cursor-pointer transition-colors duration-200 text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+                          class="sc-fzozJi fCisHH inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
                           data-testid="Link"
                           rel="noopener noreferrer"
                           to="https://organize.mlh.io/participants/events/3858-build-a-blockchain-taco-shop-with-ark-io"
@@ -534,7 +534,7 @@ exports[`News should filter results based on category query and asset 1`] = `
                   class="flex flex-col space-y-8"
                 >
                   <div
-                    class="flex items-center justify-between px-2 py-4 shadow-xl rounded-md"
+                    class="flex items-center justify-between px-2 py-4 rounded-md shadow-xl"
                   >
                     <input
                       class="sc-fzpans jVpASP overflow-hidden w-full bg-theme-background appearance-none rounded border border-theme-neutral-300 text-theme-neutral-900 transition-colors duration-200 px-4 py-3 border-none shadow-none NewsOptions__search"

--- a/src/domains/plugin/components/Comments/Comments.tsx
+++ b/src/domains/plugin/components/Comments/Comments.tsx
@@ -32,7 +32,7 @@ const Votes = ({ votes }: any) => {
 	}
 
 	return (
-		<div className="flex items-center font-semibold space-x-2">
+		<div className="flex items-center space-x-2 font-semibold">
 			<span className={voteDiffColor}>{voteDiff > 0 ? `+${voteDiff}` : voteDiff}</span>
 			<Icon className="text-theme-primary-light" name="ChevronUp" width={15} height={15} />
 			<Icon className="text-theme-primary-light" name="ChevronDown" width={15} height={15} />
@@ -51,11 +51,11 @@ export const Comments = ({ comments, sortOptions }: CommentsProps) => {
 		<div className="w-full">
 			<div className="flex items-center mt-5 text-sm font-semibold text-theme-neutral">
 				<span className="text-theme-neutral-900">{t("COMMON.SORT_BY")}:</span>
-				<div className="flex items-center ml-2 divide-x divide-theme-neutral-light space-x-3">
+				<div className="flex items-center ml-2 space-x-3 divide-x divide-theme-neutral-light">
 					{["Best", "Date", "Most Popular"].map((sortType: string, index: number) => (
 						<span className={`cursor-pointer ${index > 0 ? "pl-3" : null}`} key={index}>
 							{sortBy.type === sortType ? (
-								<span className="flex items-center text-theme-neutral-900 space-x-1">
+								<span className="flex items-center space-x-1 text-theme-neutral-900">
 									<span>{t(`COMMON.${transformType(sortType)}`)}</span>
 									<Icon
 										name={sortBy.direction === "asc" ? "ArrowUp" : "ArrowDown"}

--- a/src/domains/plugin/components/Comments/__snapshots__/Comments.test.tsx.snap
+++ b/src/domains/plugin/components/Comments/__snapshots__/Comments.test.tsx.snap
@@ -14,13 +14,13 @@ exports[`Comments should render properly 1`] = `
         Sort by:
       </span>
       <div
-        class="flex items-center ml-2 divide-x divide-theme-neutral-light space-x-3"
+        class="flex items-center ml-2 space-x-3 divide-x divide-theme-neutral-light"
       >
         <span
           class="cursor-pointer null"
         >
           <span
-            class="flex items-center text-theme-neutral-900 space-x-1"
+            class="flex items-center space-x-1 text-theme-neutral-900"
           >
             <span>
               Best
@@ -96,7 +96,7 @@ exports[`Comments should render properly 1`] = `
             </span>
           </div>
           <div
-            class="flex items-center font-semibold space-x-2"
+            class="flex items-center space-x-2 font-semibold"
           >
             <span
               class="text-theme-neutral-light"
@@ -176,7 +176,7 @@ exports[`Comments should render properly 1`] = `
             </span>
           </div>
           <div
-            class="flex items-center font-semibold space-x-2"
+            class="flex items-center space-x-2 font-semibold"
           >
             <span
               class="text-theme-success"
@@ -231,7 +231,7 @@ exports[`Comments should render properly 1`] = `
                 </div>
               </div>
               <div
-                class="flex items-center divide-x divide-theme-neutral-light space-x-3"
+                class="flex items-center space-x-3 divide-x divide-theme-neutral-light"
               >
                 <span
                   class="text-lg font-semibold text-theme-neutral-900"
@@ -305,7 +305,7 @@ exports[`Comments should render properly 1`] = `
             </span>
           </div>
           <div
-            class="flex items-center font-semibold space-x-2"
+            class="flex items-center space-x-2 font-semibold"
           >
             <span
               class="text-theme-neutral-light"
@@ -385,7 +385,7 @@ exports[`Comments should render properly 1`] = `
             </span>
           </div>
           <div
-            class="flex items-center font-semibold space-x-2"
+            class="flex items-center space-x-2 font-semibold"
           >
             <span
               class="text-theme-danger-dark"

--- a/src/domains/plugin/components/Comments/components/Reply/Reply.tsx
+++ b/src/domains/plugin/components/Comments/components/Reply/Reply.tsx
@@ -25,7 +25,7 @@ export const Reply = ({ date, content }: ReplyProps) => {
 					<Icon className="mx-auto -mt-2" name="ReplyArrow" width={15} height={18} />
 				</div>
 
-				<div className="flex items-center divide-x divide-theme-neutral-light space-x-3">
+				<div className="flex items-center space-x-3 divide-x divide-theme-neutral-light">
 					<span className="text-lg font-semibold text-theme-neutral-900">
 						{t("PLUGINS.DEVELOPER_RESPONSE")}
 					</span>

--- a/src/domains/plugin/components/Comments/components/Reply/__snapshots__/Reply.test.tsx.snap
+++ b/src/domains/plugin/components/Comments/components/Reply/__snapshots__/Reply.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`Reply should render properly 1`] = `
         </div>
       </div>
       <div
-        class="flex items-center divide-x divide-theme-neutral-light space-x-3"
+        class="flex items-center space-x-3 divide-x divide-theme-neutral-light"
       >
         <span
           class="text-lg font-semibold text-theme-neutral-900"

--- a/src/domains/plugin/components/InstallPlugin/Step1.tsx
+++ b/src/domains/plugin/components/InstallPlugin/Step1.tsx
@@ -10,7 +10,7 @@ export const FirstStep = () => {
 				{t("PLUGINS.MODAL_INSTALL_PLUGIN.DESCRIPTION")}
 			</p>
 			<div className="max-w-sm">
-				<ul className="mt-2 ml-5 list-outside leading-8 list-circle text-theme-neutral-dark">
+				<ul className="mt-2 ml-5 leading-8 list-outside list-circle text-theme-neutral-dark">
 					<li>{t("PLUGINS.MODAL_INSTALL_PLUGIN.ITEM_1")}</li>
 					<li>{t("PLUGINS.MODAL_INSTALL_PLUGIN.ITEM_2")}</li>
 					<li>{t("PLUGINS.MODAL_INSTALL_PLUGIN.ITEM_3")}</li>

--- a/src/domains/plugin/components/InstallPlugin/__snapshots__/InstallPlugin.test.tsx.snap
+++ b/src/domains/plugin/components/InstallPlugin/__snapshots__/InstallPlugin.test.tsx.snap
@@ -62,7 +62,7 @@ exports[`InstallPlugin should render 1`] = `
                   class="max-w-sm"
                 >
                   <ul
-                    class="mt-2 ml-5 list-outside leading-8 list-circle text-theme-neutral-dark"
+                    class="mt-2 ml-5 leading-8 list-outside list-circle text-theme-neutral-dark"
                   >
                     <li>
                       Allows access to the Desktop Wallet alerts
@@ -119,7 +119,7 @@ exports[`InstallPlugin should render 1st step 1`] = `
       class="max-w-sm"
     >
       <ul
-        class="mt-2 ml-5 list-outside leading-8 list-circle text-theme-neutral-dark"
+        class="mt-2 ml-5 leading-8 list-outside list-circle text-theme-neutral-dark"
       >
         <li>
           Allows access to the Desktop Wallet alerts

--- a/src/domains/plugin/components/PluginCard/PluginCard.tsx
+++ b/src/domains/plugin/components/PluginCard/PluginCard.tsx
@@ -53,7 +53,7 @@ export const PluginCard = ({ isOwner, plugin, onClick, onDelete }: PluginCardPro
 						<ChangeNowLogo />
 					</PluginImageContainer>
 
-					<div className="flex items-center mb-2 text-lg space-x-2 text-theme-primary">
+					<div className="flex items-center mb-2 space-x-2 text-lg text-theme-primary">
 						<div>{plugin.name}</div>
 
 						<div>
@@ -62,7 +62,7 @@ export const PluginCard = ({ isOwner, plugin, onClick, onDelete }: PluginCardPro
 						</div>
 					</div>
 
-					<div className="flex text-sm text-theme-neutral-light space-x-4">
+					<div className="flex space-x-4 text-sm text-theme-neutral-light">
 						<div className="pr-4 border-r border-theme-neutral-300">{plugin.author}</div>
 
 						<div>

--- a/src/domains/plugin/components/PluginCard/__snapshots__/PluginCard.test.tsx.snap
+++ b/src/domains/plugin/components/PluginCard/__snapshots__/PluginCard.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`PluginCard should render 1`] = `
           </svg>
         </div>
         <div
-          class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+          class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
         >
           <div>
             ARK Explorer
@@ -28,7 +28,7 @@ exports[`PluginCard should render 1`] = `
           <div />
         </div>
         <div
-          class="flex text-sm text-theme-neutral-light space-x-4"
+          class="flex space-x-4 text-sm text-theme-neutral-light"
         >
           <div
             class="pr-4 border-r border-theme-neutral-300"
@@ -96,7 +96,7 @@ exports[`PluginCard should render grant icon 1`] = `
           </svg>
         </div>
         <div
-          class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+          class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
         >
           <div>
             ARK Explorer
@@ -114,7 +114,7 @@ exports[`PluginCard should render grant icon 1`] = `
           </div>
         </div>
         <div
-          class="flex text-sm text-theme-neutral-light space-x-4"
+          class="flex space-x-4 text-sm text-theme-neutral-light"
         >
           <div
             class="pr-4 border-r border-theme-neutral-300"
@@ -182,7 +182,7 @@ exports[`PluginCard should render official icon 1`] = `
           </svg>
         </div>
         <div
-          class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+          class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
         >
           <div>
             ARK Explorer
@@ -200,7 +200,7 @@ exports[`PluginCard should render official icon 1`] = `
           </div>
         </div>
         <div
-          class="flex text-sm text-theme-neutral-light space-x-4"
+          class="flex space-x-4 text-sm text-theme-neutral-light"
         >
           <div
             class="pr-4 border-r border-theme-neutral-300"
@@ -268,7 +268,7 @@ exports[`PluginCard should trigger delete 1`] = `
           </svg>
         </div>
         <div
-          class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+          class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
         >
           <div>
             ARK Explorer
@@ -276,7 +276,7 @@ exports[`PluginCard should trigger delete 1`] = `
           <div />
         </div>
         <div
-          class="flex text-sm text-theme-neutral-light space-x-4"
+          class="flex space-x-4 text-sm text-theme-neutral-light"
         >
           <div
             class="pr-4 border-r border-theme-neutral-300"
@@ -359,7 +359,7 @@ exports[`PluginCard should trigger view 1`] = `
           </svg>
         </div>
         <div
-          class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+          class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
         >
           <div>
             ARK Explorer
@@ -367,7 +367,7 @@ exports[`PluginCard should trigger view 1`] = `
           <div />
         </div>
         <div
-          class="flex text-sm text-theme-neutral-light space-x-4"
+          class="flex space-x-4 text-sm text-theme-neutral-light"
         >
           <div
             class="pr-4 border-r border-theme-neutral-300"

--- a/src/domains/plugin/components/PluginGrid/__snapshots__/PluginGrid.test.tsx.snap
+++ b/src/domains/plugin/components/PluginGrid/__snapshots__/PluginGrid.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`PluginGrid should render 1`] = `
               </svg>
             </div>
             <div
-              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
             >
               <div>
                 ARK Explorer
@@ -44,7 +44,7 @@ exports[`PluginGrid should render 1`] = `
               </div>
             </div>
             <div
-              class="flex text-sm text-theme-neutral-light space-x-4"
+              class="flex space-x-4 text-sm text-theme-neutral-light"
             >
               <div
                 class="pr-4 border-r border-theme-neutral-300"
@@ -107,7 +107,7 @@ exports[`PluginGrid should render 1`] = `
               </svg>
             </div>
             <div
-              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
             >
               <div>
                 ARK Avatars
@@ -125,7 +125,7 @@ exports[`PluginGrid should render 1`] = `
               </div>
             </div>
             <div
-              class="flex text-sm text-theme-neutral-light space-x-4"
+              class="flex space-x-4 text-sm text-theme-neutral-light"
             >
               <div
                 class="pr-4 border-r border-theme-neutral-300"
@@ -234,7 +234,7 @@ exports[`PluginGrid should render without pagination 1`] = `
               </svg>
             </div>
             <div
-              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
             >
               <div>
                 ARK Explorer
@@ -252,7 +252,7 @@ exports[`PluginGrid should render without pagination 1`] = `
               </div>
             </div>
             <div
-              class="flex text-sm text-theme-neutral-light space-x-4"
+              class="flex space-x-4 text-sm text-theme-neutral-light"
             >
               <div
                 class="pr-4 border-r border-theme-neutral-300"
@@ -315,7 +315,7 @@ exports[`PluginGrid should render without pagination 1`] = `
               </svg>
             </div>
             <div
-              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
             >
               <div>
                 ARK Avatars
@@ -333,7 +333,7 @@ exports[`PluginGrid should render without pagination 1`] = `
               </div>
             </div>
             <div
-              class="flex text-sm text-theme-neutral-light space-x-4"
+              class="flex space-x-4 text-sm text-theme-neutral-light"
             >
               <div
                 class="pr-4 border-r border-theme-neutral-300"
@@ -427,7 +427,7 @@ exports[`PluginGrid should split by page 1`] = `
               </svg>
             </div>
             <div
-              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
             >
               <div>
                 ARK Avatars
@@ -445,7 +445,7 @@ exports[`PluginGrid should split by page 1`] = `
               </div>
             </div>
             <div
-              class="flex text-sm text-theme-neutral-light space-x-4"
+              class="flex space-x-4 text-sm text-theme-neutral-light"
             >
               <div
                 class="pr-4 border-r border-theme-neutral-300"
@@ -576,7 +576,7 @@ exports[`PluginGrid should trigger delete 1`] = `
               </svg>
             </div>
             <div
-              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
             >
               <div>
                 ARK Explorer
@@ -594,7 +594,7 @@ exports[`PluginGrid should trigger delete 1`] = `
               </div>
             </div>
             <div
-              class="flex text-sm text-theme-neutral-light space-x-4"
+              class="flex space-x-4 text-sm text-theme-neutral-light"
             >
               <div
                 class="pr-4 border-r border-theme-neutral-300"
@@ -657,7 +657,7 @@ exports[`PluginGrid should trigger delete 1`] = `
               </svg>
             </div>
             <div
-              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
             >
               <div>
                 ARK Avatars
@@ -675,7 +675,7 @@ exports[`PluginGrid should trigger delete 1`] = `
               </div>
             </div>
             <div
-              class="flex text-sm text-theme-neutral-light space-x-4"
+              class="flex space-x-4 text-sm text-theme-neutral-light"
             >
               <div
                 class="pr-4 border-r border-theme-neutral-300"
@@ -784,7 +784,7 @@ exports[`PluginGrid should trigger select 1`] = `
               </svg>
             </div>
             <div
-              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
             >
               <div>
                 ARK Explorer
@@ -802,7 +802,7 @@ exports[`PluginGrid should trigger select 1`] = `
               </div>
             </div>
             <div
-              class="flex text-sm text-theme-neutral-light space-x-4"
+              class="flex space-x-4 text-sm text-theme-neutral-light"
             >
               <div
                 class="pr-4 border-r border-theme-neutral-300"
@@ -865,7 +865,7 @@ exports[`PluginGrid should trigger select 1`] = `
               </svg>
             </div>
             <div
-              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
             >
               <div>
                 ARK Avatars
@@ -883,7 +883,7 @@ exports[`PluginGrid should trigger select 1`] = `
               </div>
             </div>
             <div
-              class="flex text-sm text-theme-neutral-light space-x-4"
+              class="flex space-x-4 text-sm text-theme-neutral-light"
             >
               <div
                 class="pr-4 border-r border-theme-neutral-300"

--- a/src/domains/plugin/components/PluginHeader/__snapshots__/PluginHeader.test.tsx.snap
+++ b/src/domains/plugin/components/PluginHeader/__snapshots__/PluginHeader.test.tsx.snap
@@ -96,7 +96,7 @@ exports[`PluginHeader should render as installed 1`] = `
           </div>
         </div>
         <div
-          class="pt-8 mt-8 text-sm border-t border-dashed grid grid-cols-5 divide-x divide-theme-neutral-300 grid-flow-col border-theme-neutral-300"
+          class="grid grid-flow-col grid-cols-5 pt-8 mt-8 text-sm border-t border-dashed divide-x divide-theme-neutral-300 border-theme-neutral-300"
         >
           <div
             class="flex"
@@ -307,7 +307,7 @@ exports[`PluginHeader should render properly 1`] = `
           </div>
         </div>
         <div
-          class="pt-8 mt-8 text-sm border-t border-dashed grid grid-cols-5 divide-x divide-theme-neutral-300 grid-flow-col border-theme-neutral-300"
+          class="grid grid-flow-col grid-cols-5 pt-8 mt-8 text-sm border-t border-dashed divide-x divide-theme-neutral-300 border-theme-neutral-300"
         >
           <div
             class="flex"

--- a/src/domains/plugin/components/PluginHeader/components/PluginSpecs/PluginSpecs.tsx
+++ b/src/domains/plugin/components/PluginHeader/components/PluginSpecs/PluginSpecs.tsx
@@ -50,7 +50,7 @@ export const PluginSpecs = ({ author, category, url, rating, version, size }: Pr
 	const { t } = useTranslation();
 
 	return (
-		<div className="pt-8 mt-8 text-sm border-t border-dashed grid grid-cols-5 divide-x divide-theme-neutral-300 grid-flow-col border-theme-neutral-300">
+		<div className="grid grid-flow-col grid-cols-5 pt-8 mt-8 text-sm border-t border-dashed divide-x divide-theme-neutral-300 border-theme-neutral-300">
 			<GridCol>
 				<div className="flex flex-col">
 					<span className="font-bold text-theme-neutral-light">{t("COMMON.AUTHOR")}</span>

--- a/src/domains/plugin/components/PluginHeader/components/PluginSpecs/__snapshots__/PluginSpecs.test.tsx.snap
+++ b/src/domains/plugin/components/PluginHeader/components/PluginSpecs/__snapshots__/PluginSpecs.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`PluginSpecs should render properly 1`] = `
 <DocumentFragment>
   <div
-    class="pt-8 mt-8 text-sm border-t border-dashed grid grid-cols-5 divide-x divide-theme-neutral-300 grid-flow-col border-theme-neutral-300"
+    class="grid grid-flow-col grid-cols-5 pt-8 mt-8 text-sm border-t border-dashed divide-x divide-theme-neutral-300 border-theme-neutral-300"
   >
     <div
       class="flex"

--- a/src/domains/plugin/pages/PluginDetails/__snapshots__/PluginDetails.test.tsx.snap
+++ b/src/domains/plugin/pages/PluginDetails/__snapshots__/PluginDetails.test.tsx.snap
@@ -337,7 +337,7 @@ exports[`PluginDetails should render properly 1`] = `
                   </div>
                 </div>
                 <div
-                  class="pt-8 mt-8 text-sm border-t border-dashed grid grid-cols-5 divide-x divide-theme-neutral-300 grid-flow-col border-theme-neutral-300"
+                  class="grid grid-flow-col grid-cols-5 pt-8 mt-8 text-sm border-t border-dashed divide-x divide-theme-neutral-300 border-theme-neutral-300"
                 >
                   <div
                     class="flex"
@@ -689,13 +689,13 @@ exports[`PluginDetails should render properly 1`] = `
                       Sort by:
                     </span>
                     <div
-                      class="flex items-center ml-2 divide-x divide-theme-neutral-light space-x-3"
+                      class="flex items-center ml-2 space-x-3 divide-x divide-theme-neutral-light"
                     >
                       <span
                         class="cursor-pointer null"
                       >
                         <span
-                          class="flex items-center text-theme-neutral-900 space-x-1"
+                          class="flex items-center space-x-1 text-theme-neutral-900"
                         >
                           <span>
                             Best
@@ -771,7 +771,7 @@ exports[`PluginDetails should render properly 1`] = `
                           </span>
                         </div>
                         <div
-                          class="flex items-center font-semibold space-x-2"
+                          class="flex items-center space-x-2 font-semibold"
                         >
                           <span
                             class="text-theme-neutral-light"
@@ -851,7 +851,7 @@ exports[`PluginDetails should render properly 1`] = `
                           </span>
                         </div>
                         <div
-                          class="flex items-center font-semibold space-x-2"
+                          class="flex items-center space-x-2 font-semibold"
                         >
                           <span
                             class="text-theme-success"
@@ -906,7 +906,7 @@ exports[`PluginDetails should render properly 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex items-center divide-x divide-theme-neutral-light space-x-3"
+                              class="flex items-center space-x-3 divide-x divide-theme-neutral-light"
                             >
                               <span
                                 class="text-lg font-semibold text-theme-neutral-900"
@@ -980,7 +980,7 @@ exports[`PluginDetails should render properly 1`] = `
                           </span>
                         </div>
                         <div
-                          class="flex items-center font-semibold space-x-2"
+                          class="flex items-center space-x-2 font-semibold"
                         >
                           <span
                             class="text-theme-neutral-light"
@@ -1060,7 +1060,7 @@ exports[`PluginDetails should render properly 1`] = `
                           </span>
                         </div>
                         <div
-                          class="flex items-center font-semibold space-x-2"
+                          class="flex items-center space-x-2 font-semibold"
                         >
                           <span
                             class="text-theme-danger-dark"
@@ -1838,7 +1838,7 @@ exports[`PluginDetails should render properly as installed 1`] = `
                   </div>
                 </div>
                 <div
-                  class="pt-8 mt-8 text-sm border-t border-dashed grid grid-cols-5 divide-x divide-theme-neutral-300 grid-flow-col border-theme-neutral-300"
+                  class="grid grid-flow-col grid-cols-5 pt-8 mt-8 text-sm border-t border-dashed divide-x divide-theme-neutral-300 border-theme-neutral-300"
                 >
                   <div
                     class="flex"
@@ -2190,13 +2190,13 @@ exports[`PluginDetails should render properly as installed 1`] = `
                       Sort by:
                     </span>
                     <div
-                      class="flex items-center ml-2 divide-x divide-theme-neutral-light space-x-3"
+                      class="flex items-center ml-2 space-x-3 divide-x divide-theme-neutral-light"
                     >
                       <span
                         class="cursor-pointer null"
                       >
                         <span
-                          class="flex items-center text-theme-neutral-900 space-x-1"
+                          class="flex items-center space-x-1 text-theme-neutral-900"
                         >
                           <span>
                             Best
@@ -2272,7 +2272,7 @@ exports[`PluginDetails should render properly as installed 1`] = `
                           </span>
                         </div>
                         <div
-                          class="flex items-center font-semibold space-x-2"
+                          class="flex items-center space-x-2 font-semibold"
                         >
                           <span
                             class="text-theme-neutral-light"
@@ -2352,7 +2352,7 @@ exports[`PluginDetails should render properly as installed 1`] = `
                           </span>
                         </div>
                         <div
-                          class="flex items-center font-semibold space-x-2"
+                          class="flex items-center space-x-2 font-semibold"
                         >
                           <span
                             class="text-theme-success"
@@ -2407,7 +2407,7 @@ exports[`PluginDetails should render properly as installed 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex items-center divide-x divide-theme-neutral-light space-x-3"
+                              class="flex items-center space-x-3 divide-x divide-theme-neutral-light"
                             >
                               <span
                                 class="text-lg font-semibold text-theme-neutral-900"
@@ -2481,7 +2481,7 @@ exports[`PluginDetails should render properly as installed 1`] = `
                           </span>
                         </div>
                         <div
-                          class="flex items-center font-semibold space-x-2"
+                          class="flex items-center space-x-2 font-semibold"
                         >
                           <span
                             class="text-theme-neutral-light"
@@ -2561,7 +2561,7 @@ exports[`PluginDetails should render properly as installed 1`] = `
                           </span>
                         </div>
                         <div
-                          class="flex items-center font-semibold space-x-2"
+                          class="flex items-center space-x-2 font-semibold"
                         >
                           <span
                             class="text-theme-danger-dark"

--- a/src/domains/plugin/pages/PluginManager/PluginManager.tsx
+++ b/src/domains/plugin/pages/PluginManager/PluginManager.tsx
@@ -208,7 +208,7 @@ export const PluginManager = ({ paths }: PluginManagerProps) => {
 									data-testid="PluginManager_header--install"
 									onClick={() => setInstallPlugin(true)}
 								>
-									<div className="flex items-center whitespace-no-wrap space-x-2">
+									<div className="flex items-center space-x-2 whitespace-no-wrap">
 										<Icon name="File" width={15} height={15} />
 										<span>Install File</span>
 									</div>

--- a/src/domains/plugin/pages/PluginManager/__snapshots__/PluginManager.test.tsx.snap
+++ b/src/domains/plugin/pages/PluginManager/__snapshots__/PluginManager.test.tsx.snap
@@ -302,7 +302,7 @@ exports[`PluginManager should cancel install plugin 1`] = `
                   type="button"
                 >
                   <div
-                    class="flex items-center whitespace-no-wrap space-x-2"
+                    class="flex items-center space-x-2 whitespace-no-wrap"
                   >
                     <div
                       class="sc-AxirZ fkjLBb"
@@ -4729,7 +4729,7 @@ exports[`PluginManager should close install plugin modal 1`] = `
                   type="button"
                 >
                   <div
-                    class="flex items-center whitespace-no-wrap space-x-2"
+                    class="flex items-center space-x-2 whitespace-no-wrap"
                   >
                     <div
                       class="sc-AxirZ fkjLBb"
@@ -9156,7 +9156,7 @@ exports[`PluginManager should delete plugin on game 1`] = `
                   type="button"
                 >
                   <div
-                    class="flex items-center whitespace-no-wrap space-x-2"
+                    class="flex items-center space-x-2 whitespace-no-wrap"
                   >
                     <div
                       class="sc-AxirZ fkjLBb"
@@ -11256,7 +11256,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                   type="button"
                 >
                   <div
-                    class="flex items-center whitespace-no-wrap space-x-2"
+                    class="flex items-center space-x-2 whitespace-no-wrap"
                   >
                     <div
                       class="sc-AxirZ fkjLBb"
@@ -11522,7 +11522,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Explorer
@@ -11540,7 +11540,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -11603,7 +11603,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Avatars
@@ -11621,7 +11621,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -11699,7 +11699,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Explorer
@@ -11717,7 +11717,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -11780,7 +11780,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Avatars
@@ -11798,7 +11798,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -11876,7 +11876,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Explorer
@@ -11894,7 +11894,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -11957,7 +11957,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Avatars
@@ -11975,7 +11975,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -12053,7 +12053,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Explorer
@@ -12071,7 +12071,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -12134,7 +12134,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Avatars
@@ -12152,7 +12152,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -12262,7 +12262,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Explorer
@@ -12280,7 +12280,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -12343,7 +12343,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Avatars
@@ -12361,7 +12361,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -12439,7 +12439,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Explorer
@@ -12457,7 +12457,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -12520,7 +12520,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Avatars
@@ -12538,7 +12538,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -12616,7 +12616,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Explorer
@@ -12634,7 +12634,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -12697,7 +12697,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Avatars
@@ -12715,7 +12715,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -12793,7 +12793,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Explorer
@@ -12811,7 +12811,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -12874,7 +12874,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Avatars
@@ -12892,7 +12892,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -13001,7 +13001,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Explorer
@@ -13019,7 +13019,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -13082,7 +13082,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Avatars
@@ -13100,7 +13100,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -13178,7 +13178,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Explorer
@@ -13196,7 +13196,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -13259,7 +13259,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Avatars
@@ -13277,7 +13277,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -13355,7 +13355,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Explorer
@@ -13373,7 +13373,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -13436,7 +13436,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Avatars
@@ -13454,7 +13454,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -13532,7 +13532,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Explorer
@@ -13550,7 +13550,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -13613,7 +13613,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Avatars
@@ -13631,7 +13631,7 @@ exports[`PluginManager should delete plugin on home 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -14009,7 +14009,7 @@ exports[`PluginManager should download & install plugin on game 1`] = `
                   type="button"
                 >
                   <div
-                    class="flex items-center whitespace-no-wrap space-x-2"
+                    class="flex items-center space-x-2 whitespace-no-wrap"
                   >
                     <div
                       class="sc-AxirZ fkjLBb"
@@ -16264,7 +16264,7 @@ exports[`PluginManager should download & install plugin on home 1`] = `
                   type="button"
                 >
                   <div
-                    class="flex items-center whitespace-no-wrap space-x-2"
+                    class="flex items-center space-x-2 whitespace-no-wrap"
                   >
                     <div
                       class="sc-AxirZ fkjLBb"
@@ -20846,7 +20846,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
                   type="button"
                 >
                   <div
-                    class="flex items-center whitespace-no-wrap space-x-2"
+                    class="flex items-center space-x-2 whitespace-no-wrap"
                   >
                     <div
                       class="sc-AxirZ fkjLBb"
@@ -21112,7 +21112,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Explorer
@@ -21130,7 +21130,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -21193,7 +21193,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Avatars
@@ -21211,7 +21211,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -21289,7 +21289,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Explorer
@@ -21307,7 +21307,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -21370,7 +21370,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Avatars
@@ -21388,7 +21388,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -21466,7 +21466,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Explorer
@@ -21484,7 +21484,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -21547,7 +21547,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Avatars
@@ -21565,7 +21565,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -21643,7 +21643,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Explorer
@@ -21661,7 +21661,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -21724,7 +21724,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Avatars
@@ -21742,7 +21742,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -21852,7 +21852,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Explorer
@@ -21870,7 +21870,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -21933,7 +21933,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Avatars
@@ -21951,7 +21951,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -22029,7 +22029,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Explorer
@@ -22047,7 +22047,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -22110,7 +22110,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Avatars
@@ -22128,7 +22128,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -22206,7 +22206,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Explorer
@@ -22224,7 +22224,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -22287,7 +22287,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Avatars
@@ -22305,7 +22305,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -22383,7 +22383,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Explorer
@@ -22401,7 +22401,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -22464,7 +22464,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Avatars
@@ -22482,7 +22482,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -22591,7 +22591,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Explorer
@@ -22609,7 +22609,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -22672,7 +22672,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Avatars
@@ -22690,7 +22690,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -22768,7 +22768,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Explorer
@@ -22786,7 +22786,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -22849,7 +22849,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Avatars
@@ -22867,7 +22867,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -22945,7 +22945,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Explorer
@@ -22963,7 +22963,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -23026,7 +23026,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Avatars
@@ -23044,7 +23044,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -23122,7 +23122,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Explorer
@@ -23140,7 +23140,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -23203,7 +23203,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Avatars
@@ -23221,7 +23221,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -23754,7 +23754,7 @@ exports[`PluginManager should render 1`] = `
                   type="button"
                 >
                   <div
-                    class="flex items-center whitespace-no-wrap space-x-2"
+                    class="flex items-center space-x-2 whitespace-no-wrap"
                   >
                     <div
                       class="sc-AxirZ fkjLBb"
@@ -24020,7 +24020,7 @@ exports[`PluginManager should render 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Explorer
@@ -24038,7 +24038,7 @@ exports[`PluginManager should render 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -24101,7 +24101,7 @@ exports[`PluginManager should render 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Avatars
@@ -24119,7 +24119,7 @@ exports[`PluginManager should render 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -24197,7 +24197,7 @@ exports[`PluginManager should render 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Explorer
@@ -24215,7 +24215,7 @@ exports[`PluginManager should render 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -24278,7 +24278,7 @@ exports[`PluginManager should render 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Avatars
@@ -24296,7 +24296,7 @@ exports[`PluginManager should render 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -24374,7 +24374,7 @@ exports[`PluginManager should render 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Explorer
@@ -24392,7 +24392,7 @@ exports[`PluginManager should render 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -24455,7 +24455,7 @@ exports[`PluginManager should render 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Avatars
@@ -24473,7 +24473,7 @@ exports[`PluginManager should render 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -24551,7 +24551,7 @@ exports[`PluginManager should render 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Explorer
@@ -24569,7 +24569,7 @@ exports[`PluginManager should render 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -24632,7 +24632,7 @@ exports[`PluginManager should render 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Avatars
@@ -24650,7 +24650,7 @@ exports[`PluginManager should render 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -24760,7 +24760,7 @@ exports[`PluginManager should render 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Explorer
@@ -24778,7 +24778,7 @@ exports[`PluginManager should render 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -24841,7 +24841,7 @@ exports[`PluginManager should render 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Avatars
@@ -24859,7 +24859,7 @@ exports[`PluginManager should render 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -24937,7 +24937,7 @@ exports[`PluginManager should render 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Explorer
@@ -24955,7 +24955,7 @@ exports[`PluginManager should render 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -25018,7 +25018,7 @@ exports[`PluginManager should render 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Avatars
@@ -25036,7 +25036,7 @@ exports[`PluginManager should render 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -25114,7 +25114,7 @@ exports[`PluginManager should render 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Explorer
@@ -25132,7 +25132,7 @@ exports[`PluginManager should render 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -25195,7 +25195,7 @@ exports[`PluginManager should render 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Avatars
@@ -25213,7 +25213,7 @@ exports[`PluginManager should render 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -25291,7 +25291,7 @@ exports[`PluginManager should render 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Explorer
@@ -25309,7 +25309,7 @@ exports[`PluginManager should render 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -25372,7 +25372,7 @@ exports[`PluginManager should render 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Avatars
@@ -25390,7 +25390,7 @@ exports[`PluginManager should render 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -25499,7 +25499,7 @@ exports[`PluginManager should render 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Explorer
@@ -25517,7 +25517,7 @@ exports[`PluginManager should render 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -25580,7 +25580,7 @@ exports[`PluginManager should render 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Avatars
@@ -25598,7 +25598,7 @@ exports[`PluginManager should render 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -25676,7 +25676,7 @@ exports[`PluginManager should render 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Explorer
@@ -25694,7 +25694,7 @@ exports[`PluginManager should render 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -25757,7 +25757,7 @@ exports[`PluginManager should render 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Avatars
@@ -25775,7 +25775,7 @@ exports[`PluginManager should render 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -25853,7 +25853,7 @@ exports[`PluginManager should render 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Explorer
@@ -25871,7 +25871,7 @@ exports[`PluginManager should render 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -25934,7 +25934,7 @@ exports[`PluginManager should render 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Avatars
@@ -25952,7 +25952,7 @@ exports[`PluginManager should render 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -26030,7 +26030,7 @@ exports[`PluginManager should render 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Explorer
@@ -26048,7 +26048,7 @@ exports[`PluginManager should render 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -26111,7 +26111,7 @@ exports[`PluginManager should render 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Avatars
@@ -26129,7 +26129,7 @@ exports[`PluginManager should render 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -26478,7 +26478,7 @@ exports[`PluginManager should search for plugin 1`] = `
                   class="relative"
                 >
                   <div
-                    class="sc-fzoLsD gNnXoT absolute flex items-center px-6 py-4 bg-white shadow-xl rounded-md -bottom-4 -right-6"
+                    class="sc-fzoLsD gNnXoT absolute flex items-center px-6 py-4 bg-white rounded-md shadow-xl -bottom-4 -right-6"
                     data-testid="header-search-bar__input"
                   >
                     <div
@@ -26559,7 +26559,7 @@ exports[`PluginManager should search for plugin 1`] = `
                   type="button"
                 >
                   <div
-                    class="flex items-center whitespace-no-wrap space-x-2"
+                    class="flex items-center space-x-2 whitespace-no-wrap"
                   >
                     <div
                       class="sc-AxirZ fkjLBb"
@@ -26825,7 +26825,7 @@ exports[`PluginManager should search for plugin 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Explorer
@@ -26843,7 +26843,7 @@ exports[`PluginManager should search for plugin 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -26906,7 +26906,7 @@ exports[`PluginManager should search for plugin 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Avatars
@@ -26924,7 +26924,7 @@ exports[`PluginManager should search for plugin 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -27002,7 +27002,7 @@ exports[`PluginManager should search for plugin 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Explorer
@@ -27020,7 +27020,7 @@ exports[`PluginManager should search for plugin 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -27083,7 +27083,7 @@ exports[`PluginManager should search for plugin 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Avatars
@@ -27101,7 +27101,7 @@ exports[`PluginManager should search for plugin 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -27179,7 +27179,7 @@ exports[`PluginManager should search for plugin 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Explorer
@@ -27197,7 +27197,7 @@ exports[`PluginManager should search for plugin 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -27260,7 +27260,7 @@ exports[`PluginManager should search for plugin 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Avatars
@@ -27278,7 +27278,7 @@ exports[`PluginManager should search for plugin 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -27356,7 +27356,7 @@ exports[`PluginManager should search for plugin 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Explorer
@@ -27374,7 +27374,7 @@ exports[`PluginManager should search for plugin 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -27437,7 +27437,7 @@ exports[`PluginManager should search for plugin 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Avatars
@@ -27455,7 +27455,7 @@ exports[`PluginManager should search for plugin 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -27565,7 +27565,7 @@ exports[`PluginManager should search for plugin 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Explorer
@@ -27583,7 +27583,7 @@ exports[`PluginManager should search for plugin 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -27646,7 +27646,7 @@ exports[`PluginManager should search for plugin 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Avatars
@@ -27664,7 +27664,7 @@ exports[`PluginManager should search for plugin 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -27742,7 +27742,7 @@ exports[`PluginManager should search for plugin 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Explorer
@@ -27760,7 +27760,7 @@ exports[`PluginManager should search for plugin 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -27823,7 +27823,7 @@ exports[`PluginManager should search for plugin 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Avatars
@@ -27841,7 +27841,7 @@ exports[`PluginManager should search for plugin 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -27919,7 +27919,7 @@ exports[`PluginManager should search for plugin 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Explorer
@@ -27937,7 +27937,7 @@ exports[`PluginManager should search for plugin 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -28000,7 +28000,7 @@ exports[`PluginManager should search for plugin 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Avatars
@@ -28018,7 +28018,7 @@ exports[`PluginManager should search for plugin 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -28096,7 +28096,7 @@ exports[`PluginManager should search for plugin 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Explorer
@@ -28114,7 +28114,7 @@ exports[`PluginManager should search for plugin 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -28177,7 +28177,7 @@ exports[`PluginManager should search for plugin 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Avatars
@@ -28195,7 +28195,7 @@ exports[`PluginManager should search for plugin 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -28304,7 +28304,7 @@ exports[`PluginManager should search for plugin 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Explorer
@@ -28322,7 +28322,7 @@ exports[`PluginManager should search for plugin 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -28385,7 +28385,7 @@ exports[`PluginManager should search for plugin 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Avatars
@@ -28403,7 +28403,7 @@ exports[`PluginManager should search for plugin 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -28481,7 +28481,7 @@ exports[`PluginManager should search for plugin 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Explorer
@@ -28499,7 +28499,7 @@ exports[`PluginManager should search for plugin 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -28562,7 +28562,7 @@ exports[`PluginManager should search for plugin 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Avatars
@@ -28580,7 +28580,7 @@ exports[`PluginManager should search for plugin 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -28658,7 +28658,7 @@ exports[`PluginManager should search for plugin 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Explorer
@@ -28676,7 +28676,7 @@ exports[`PluginManager should search for plugin 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -28739,7 +28739,7 @@ exports[`PluginManager should search for plugin 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Avatars
@@ -28757,7 +28757,7 @@ exports[`PluginManager should search for plugin 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -28835,7 +28835,7 @@ exports[`PluginManager should search for plugin 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Explorer
@@ -28853,7 +28853,7 @@ exports[`PluginManager should search for plugin 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -28916,7 +28916,7 @@ exports[`PluginManager should search for plugin 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Avatars
@@ -28934,7 +28934,7 @@ exports[`PluginManager should search for plugin 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -29314,7 +29314,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
                   type="button"
                 >
                   <div
-                    class="flex items-center whitespace-no-wrap space-x-2"
+                    class="flex items-center space-x-2 whitespace-no-wrap"
                   >
                     <div
                       class="sc-AxirZ fkjLBb"
@@ -29558,7 +29558,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
                           </svg>
                         </div>
                         <div
-                          class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                          class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                         >
                           <div>
                             ARK Explorer
@@ -29576,7 +29576,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
                           </div>
                         </div>
                         <div
-                          class="flex text-sm text-theme-neutral-light space-x-4"
+                          class="flex space-x-4 text-sm text-theme-neutral-light"
                         >
                           <div
                             class="pr-4 border-r border-theme-neutral-300"
@@ -29639,7 +29639,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
                           </svg>
                         </div>
                         <div
-                          class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                          class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                         >
                           <div>
                             ARK Avatars
@@ -29657,7 +29657,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
                           </div>
                         </div>
                         <div
-                          class="flex text-sm text-theme-neutral-light space-x-4"
+                          class="flex space-x-4 text-sm text-theme-neutral-light"
                         >
                           <div
                             class="pr-4 border-r border-theme-neutral-300"
@@ -29735,7 +29735,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
                           </svg>
                         </div>
                         <div
-                          class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                          class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                         >
                           <div>
                             ARK Explorer
@@ -29753,7 +29753,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
                           </div>
                         </div>
                         <div
-                          class="flex text-sm text-theme-neutral-light space-x-4"
+                          class="flex space-x-4 text-sm text-theme-neutral-light"
                         >
                           <div
                             class="pr-4 border-r border-theme-neutral-300"
@@ -29816,7 +29816,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
                           </svg>
                         </div>
                         <div
-                          class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                          class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                         >
                           <div>
                             ARK Avatars
@@ -29834,7 +29834,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
                           </div>
                         </div>
                         <div
-                          class="flex text-sm text-theme-neutral-light space-x-4"
+                          class="flex space-x-4 text-sm text-theme-neutral-light"
                         >
                           <div
                             class="pr-4 border-r border-theme-neutral-300"
@@ -29912,7 +29912,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
                           </svg>
                         </div>
                         <div
-                          class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                          class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                         >
                           <div>
                             ARK Explorer
@@ -29930,7 +29930,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
                           </div>
                         </div>
                         <div
-                          class="flex text-sm text-theme-neutral-light space-x-4"
+                          class="flex space-x-4 text-sm text-theme-neutral-light"
                         >
                           <div
                             class="pr-4 border-r border-theme-neutral-300"
@@ -29993,7 +29993,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
                           </svg>
                         </div>
                         <div
-                          class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                          class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                         >
                           <div>
                             ARK Avatars
@@ -30011,7 +30011,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
                           </div>
                         </div>
                         <div
-                          class="flex text-sm text-theme-neutral-light space-x-4"
+                          class="flex space-x-4 text-sm text-theme-neutral-light"
                         >
                           <div
                             class="pr-4 border-r border-theme-neutral-300"
@@ -30089,7 +30089,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
                           </svg>
                         </div>
                         <div
-                          class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                          class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                         >
                           <div>
                             ARK Explorer
@@ -30107,7 +30107,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
                           </div>
                         </div>
                         <div
-                          class="flex text-sm text-theme-neutral-light space-x-4"
+                          class="flex space-x-4 text-sm text-theme-neutral-light"
                         >
                           <div
                             class="pr-4 border-r border-theme-neutral-300"
@@ -30170,7 +30170,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
                           </svg>
                         </div>
                         <div
-                          class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                          class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                         >
                           <div>
                             ARK Avatars
@@ -30188,7 +30188,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
                           </div>
                         </div>
                         <div
-                          class="flex text-sm text-theme-neutral-light space-x-4"
+                          class="flex space-x-4 text-sm text-theme-neutral-light"
                         >
                           <div
                             class="pr-4 border-r border-theme-neutral-300"
@@ -30266,7 +30266,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
                           </svg>
                         </div>
                         <div
-                          class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                          class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                         >
                           <div>
                             ARK Explorer
@@ -30284,7 +30284,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
                           </div>
                         </div>
                         <div
-                          class="flex text-sm text-theme-neutral-light space-x-4"
+                          class="flex space-x-4 text-sm text-theme-neutral-light"
                         >
                           <div
                             class="pr-4 border-r border-theme-neutral-300"
@@ -30347,7 +30347,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
                           </svg>
                         </div>
                         <div
-                          class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                          class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                         >
                           <div>
                             ARK Avatars
@@ -30365,7 +30365,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
                           </div>
                         </div>
                         <div
-                          class="flex text-sm text-theme-neutral-light space-x-4"
+                          class="flex space-x-4 text-sm text-theme-neutral-light"
                         >
                           <div
                             class="pr-4 border-r border-theme-neutral-300"
@@ -30443,7 +30443,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
                           </svg>
                         </div>
                         <div
-                          class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                          class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                         >
                           <div>
                             ARK Explorer
@@ -30461,7 +30461,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
                           </div>
                         </div>
                         <div
-                          class="flex text-sm text-theme-neutral-light space-x-4"
+                          class="flex space-x-4 text-sm text-theme-neutral-light"
                         >
                           <div
                             class="pr-4 border-r border-theme-neutral-300"
@@ -30524,7 +30524,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
                           </svg>
                         </div>
                         <div
-                          class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                          class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                         >
                           <div>
                             ARK Avatars
@@ -30542,7 +30542,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
                           </div>
                         </div>
                         <div
-                          class="flex text-sm text-theme-neutral-light space-x-4"
+                          class="flex space-x-4 text-sm text-theme-neutral-light"
                         >
                           <div
                             class="pr-4 border-r border-theme-neutral-300"
@@ -30620,7 +30620,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
                           </svg>
                         </div>
                         <div
-                          class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                          class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                         >
                           <div>
                             ARK Explorer
@@ -30638,7 +30638,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
                           </div>
                         </div>
                         <div
-                          class="flex text-sm text-theme-neutral-light space-x-4"
+                          class="flex space-x-4 text-sm text-theme-neutral-light"
                         >
                           <div
                             class="pr-4 border-r border-theme-neutral-300"
@@ -30701,7 +30701,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
                           </svg>
                         </div>
                         <div
-                          class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                          class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                         >
                           <div>
                             ARK Avatars
@@ -30719,7 +30719,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
                           </div>
                         </div>
                         <div
-                          class="flex text-sm text-theme-neutral-light space-x-4"
+                          class="flex space-x-4 text-sm text-theme-neutral-light"
                         >
                           <div
                             class="pr-4 border-r border-theme-neutral-300"
@@ -30797,7 +30797,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
                           </svg>
                         </div>
                         <div
-                          class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                          class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                         >
                           <div>
                             ARK Explorer
@@ -30815,7 +30815,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
                           </div>
                         </div>
                         <div
-                          class="flex text-sm text-theme-neutral-light space-x-4"
+                          class="flex space-x-4 text-sm text-theme-neutral-light"
                         >
                           <div
                             class="pr-4 border-r border-theme-neutral-300"
@@ -30878,7 +30878,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
                           </svg>
                         </div>
                         <div
-                          class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                          class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                         >
                           <div>
                             ARK Avatars
@@ -30896,7 +30896,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
                           </div>
                         </div>
                         <div
-                          class="flex text-sm text-theme-neutral-light space-x-4"
+                          class="flex space-x-4 text-sm text-theme-neutral-light"
                         >
                           <div
                             class="pr-4 border-r border-theme-neutral-300"
@@ -30974,7 +30974,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
                           </svg>
                         </div>
                         <div
-                          class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                          class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                         >
                           <div>
                             ARK Explorer
@@ -30992,7 +30992,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
                           </div>
                         </div>
                         <div
-                          class="flex text-sm text-theme-neutral-light space-x-4"
+                          class="flex space-x-4 text-sm text-theme-neutral-light"
                         >
                           <div
                             class="pr-4 border-r border-theme-neutral-300"
@@ -31055,7 +31055,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
                           </svg>
                         </div>
                         <div
-                          class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                          class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                         >
                           <div>
                             ARK Avatars
@@ -31073,7 +31073,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
                           </div>
                         </div>
                         <div
-                          class="flex text-sm text-theme-neutral-light space-x-4"
+                          class="flex space-x-4 text-sm text-theme-neutral-light"
                         >
                           <div
                             class="pr-4 border-r border-theme-neutral-300"
@@ -31151,7 +31151,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
                           </svg>
                         </div>
                         <div
-                          class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                          class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                         >
                           <div>
                             ARK Explorer
@@ -31169,7 +31169,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
                           </div>
                         </div>
                         <div
-                          class="flex text-sm text-theme-neutral-light space-x-4"
+                          class="flex space-x-4 text-sm text-theme-neutral-light"
                         >
                           <div
                             class="pr-4 border-r border-theme-neutral-300"
@@ -31232,7 +31232,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
                           </svg>
                         </div>
                         <div
-                          class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                          class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                         >
                           <div>
                             ARK Avatars
@@ -31250,7 +31250,7 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
                           </div>
                         </div>
                         <div
-                          class="flex text-sm text-theme-neutral-light space-x-4"
+                          class="flex space-x-4 text-sm text-theme-neutral-light"
                         >
                           <div
                             class="pr-4 border-r border-theme-neutral-300"
@@ -31641,7 +31641,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                   type="button"
                 >
                   <div
-                    class="flex items-center whitespace-no-wrap space-x-2"
+                    class="flex items-center space-x-2 whitespace-no-wrap"
                   >
                     <div
                       class="sc-AxirZ fkjLBb"
@@ -31907,7 +31907,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Explorer
@@ -31925,7 +31925,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -31988,7 +31988,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Avatars
@@ -32006,7 +32006,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -32084,7 +32084,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Explorer
@@ -32102,7 +32102,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -32165,7 +32165,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Avatars
@@ -32183,7 +32183,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -32261,7 +32261,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Explorer
@@ -32279,7 +32279,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -32342,7 +32342,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Avatars
@@ -32360,7 +32360,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -32438,7 +32438,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Explorer
@@ -32456,7 +32456,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -32519,7 +32519,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Avatars
@@ -32537,7 +32537,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -32647,7 +32647,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Explorer
@@ -32665,7 +32665,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -32728,7 +32728,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Avatars
@@ -32746,7 +32746,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -32824,7 +32824,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Explorer
@@ -32842,7 +32842,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -32905,7 +32905,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Avatars
@@ -32923,7 +32923,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -33001,7 +33001,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Explorer
@@ -33019,7 +33019,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -33082,7 +33082,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Avatars
@@ -33100,7 +33100,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -33178,7 +33178,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Explorer
@@ -33196,7 +33196,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -33259,7 +33259,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Avatars
@@ -33277,7 +33277,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -33386,7 +33386,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Explorer
@@ -33404,7 +33404,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -33467,7 +33467,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Avatars
@@ -33485,7 +33485,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -33563,7 +33563,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Explorer
@@ -33581,7 +33581,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -33644,7 +33644,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Avatars
@@ -33662,7 +33662,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -33740,7 +33740,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Explorer
@@ -33758,7 +33758,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -33821,7 +33821,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Avatars
@@ -33839,7 +33839,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -33917,7 +33917,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Explorer
@@ -33935,7 +33935,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"
@@ -33998,7 +33998,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                              class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                             >
                               <div>
                                 ARK Avatars
@@ -34016,7 +34016,7 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
                               </div>
                             </div>
                             <div
-                              class="flex text-sm text-theme-neutral-light space-x-4"
+                              class="flex space-x-4 text-sm text-theme-neutral-light"
                             >
                               <div
                                 class="pr-4 border-r border-theme-neutral-300"

--- a/src/domains/plugin/pages/PluginsCategory/PluginsCategory.tsx
+++ b/src/domains/plugin/pages/PluginsCategory/PluginsCategory.tsx
@@ -135,7 +135,7 @@ export const PluginsCategory = ({ title, description, initialViewType }: Plugins
 									onClick={() => setInstallPlugin(true)}
 									data-testid="PluginsCategory_header--install"
 								>
-									<div className="flex items-center whitespace-no-wrap space-x-2">
+									<div className="flex items-center space-x-2 whitespace-no-wrap">
 										<Icon name="File" width={15} height={15} />
 										<span>Install File</span>
 									</div>

--- a/src/domains/plugin/pages/PluginsCategory/__snapshots__/PluginsCategory.test.tsx.snap
+++ b/src/domains/plugin/pages/PluginsCategory/__snapshots__/PluginsCategory.test.tsx.snap
@@ -331,7 +331,7 @@ exports[`PluginsCategory should cancel install plugin 1`] = `
                   type="button"
                 >
                   <div
-                    class="flex items-center whitespace-no-wrap space-x-2"
+                    class="flex items-center space-x-2 whitespace-no-wrap"
                   >
                     <div
                       class="sc-AxirZ fkjLBb"
@@ -2052,7 +2052,7 @@ exports[`PluginsCategory should close install plugin modal 1`] = `
                   type="button"
                 >
                   <div
-                    class="flex items-center whitespace-no-wrap space-x-2"
+                    class="flex items-center space-x-2 whitespace-no-wrap"
                   >
                     <div
                       class="sc-AxirZ fkjLBb"
@@ -3773,7 +3773,7 @@ exports[`PluginsCategory should delete plugin 1`] = `
                   type="button"
                 >
                   <div
-                    class="flex items-center whitespace-no-wrap space-x-2"
+                    class="flex items-center space-x-2 whitespace-no-wrap"
                   >
                     <div
                       class="sc-AxirZ fkjLBb"
@@ -3883,7 +3883,7 @@ exports[`PluginsCategory should delete plugin 1`] = `
                           </svg>
                         </div>
                         <div
-                          class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                          class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                         >
                           <div>
                             ARK Explorer
@@ -3901,7 +3901,7 @@ exports[`PluginsCategory should delete plugin 1`] = `
                           </div>
                         </div>
                         <div
-                          class="flex text-sm text-theme-neutral-light space-x-4"
+                          class="flex space-x-4 text-sm text-theme-neutral-light"
                         >
                           <div
                             class="pr-4 border-r border-theme-neutral-300"
@@ -3964,7 +3964,7 @@ exports[`PluginsCategory should delete plugin 1`] = `
                           </svg>
                         </div>
                         <div
-                          class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                          class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                         >
                           <div>
                             ARK Avatars
@@ -3982,7 +3982,7 @@ exports[`PluginsCategory should delete plugin 1`] = `
                           </div>
                         </div>
                         <div
-                          class="flex text-sm text-theme-neutral-light space-x-4"
+                          class="flex space-x-4 text-sm text-theme-neutral-light"
                         >
                           <div
                             class="pr-4 border-r border-theme-neutral-300"
@@ -4060,7 +4060,7 @@ exports[`PluginsCategory should delete plugin 1`] = `
                           </svg>
                         </div>
                         <div
-                          class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                          class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                         >
                           <div>
                             ARK Explorer
@@ -4078,7 +4078,7 @@ exports[`PluginsCategory should delete plugin 1`] = `
                           </div>
                         </div>
                         <div
-                          class="flex text-sm text-theme-neutral-light space-x-4"
+                          class="flex space-x-4 text-sm text-theme-neutral-light"
                         >
                           <div
                             class="pr-4 border-r border-theme-neutral-300"
@@ -4141,7 +4141,7 @@ exports[`PluginsCategory should delete plugin 1`] = `
                           </svg>
                         </div>
                         <div
-                          class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                          class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                         >
                           <div>
                             ARK Avatars
@@ -4159,7 +4159,7 @@ exports[`PluginsCategory should delete plugin 1`] = `
                           </div>
                         </div>
                         <div
-                          class="flex text-sm text-theme-neutral-light space-x-4"
+                          class="flex space-x-4 text-sm text-theme-neutral-light"
                         >
                           <div
                             class="pr-4 border-r border-theme-neutral-300"
@@ -4237,7 +4237,7 @@ exports[`PluginsCategory should delete plugin 1`] = `
                           </svg>
                         </div>
                         <div
-                          class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                          class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                         >
                           <div>
                             ARK Explorer
@@ -4255,7 +4255,7 @@ exports[`PluginsCategory should delete plugin 1`] = `
                           </div>
                         </div>
                         <div
-                          class="flex text-sm text-theme-neutral-light space-x-4"
+                          class="flex space-x-4 text-sm text-theme-neutral-light"
                         >
                           <div
                             class="pr-4 border-r border-theme-neutral-300"
@@ -4318,7 +4318,7 @@ exports[`PluginsCategory should delete plugin 1`] = `
                           </svg>
                         </div>
                         <div
-                          class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                          class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                         >
                           <div>
                             ARK Avatars
@@ -4336,7 +4336,7 @@ exports[`PluginsCategory should delete plugin 1`] = `
                           </div>
                         </div>
                         <div
-                          class="flex text-sm text-theme-neutral-light space-x-4"
+                          class="flex space-x-4 text-sm text-theme-neutral-light"
                         >
                           <div
                             class="pr-4 border-r border-theme-neutral-300"
@@ -4414,7 +4414,7 @@ exports[`PluginsCategory should delete plugin 1`] = `
                           </svg>
                         </div>
                         <div
-                          class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                          class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                         >
                           <div>
                             ARK Explorer
@@ -4432,7 +4432,7 @@ exports[`PluginsCategory should delete plugin 1`] = `
                           </div>
                         </div>
                         <div
-                          class="flex text-sm text-theme-neutral-light space-x-4"
+                          class="flex space-x-4 text-sm text-theme-neutral-light"
                         >
                           <div
                             class="pr-4 border-r border-theme-neutral-300"
@@ -4495,7 +4495,7 @@ exports[`PluginsCategory should delete plugin 1`] = `
                           </svg>
                         </div>
                         <div
-                          class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                          class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                         >
                           <div>
                             ARK Avatars
@@ -4513,7 +4513,7 @@ exports[`PluginsCategory should delete plugin 1`] = `
                           </div>
                         </div>
                         <div
-                          class="flex text-sm text-theme-neutral-light space-x-4"
+                          class="flex space-x-4 text-sm text-theme-neutral-light"
                         >
                           <div
                             class="pr-4 border-r border-theme-neutral-300"
@@ -4918,7 +4918,7 @@ exports[`PluginsCategory should download & install plugin 1`] = `
                   type="button"
                 >
                   <div
-                    class="flex items-center whitespace-no-wrap space-x-2"
+                    class="flex items-center space-x-2 whitespace-no-wrap"
                   >
                     <div
                       class="sc-AxirZ fkjLBb"
@@ -6794,7 +6794,7 @@ exports[`PluginsCategory should install plugin from header install button 1`] = 
                   type="button"
                 >
                   <div
-                    class="flex items-center whitespace-no-wrap space-x-2"
+                    class="flex items-center space-x-2 whitespace-no-wrap"
                   >
                     <div
                       class="sc-AxirZ fkjLBb"
@@ -6904,7 +6904,7 @@ exports[`PluginsCategory should install plugin from header install button 1`] = 
                           </svg>
                         </div>
                         <div
-                          class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                          class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                         >
                           <div>
                             ARK Explorer
@@ -6922,7 +6922,7 @@ exports[`PluginsCategory should install plugin from header install button 1`] = 
                           </div>
                         </div>
                         <div
-                          class="flex text-sm text-theme-neutral-light space-x-4"
+                          class="flex space-x-4 text-sm text-theme-neutral-light"
                         >
                           <div
                             class="pr-4 border-r border-theme-neutral-300"
@@ -6985,7 +6985,7 @@ exports[`PluginsCategory should install plugin from header install button 1`] = 
                           </svg>
                         </div>
                         <div
-                          class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                          class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                         >
                           <div>
                             ARK Avatars
@@ -7003,7 +7003,7 @@ exports[`PluginsCategory should install plugin from header install button 1`] = 
                           </div>
                         </div>
                         <div
-                          class="flex text-sm text-theme-neutral-light space-x-4"
+                          class="flex space-x-4 text-sm text-theme-neutral-light"
                         >
                           <div
                             class="pr-4 border-r border-theme-neutral-300"
@@ -7081,7 +7081,7 @@ exports[`PluginsCategory should install plugin from header install button 1`] = 
                           </svg>
                         </div>
                         <div
-                          class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                          class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                         >
                           <div>
                             ARK Explorer
@@ -7099,7 +7099,7 @@ exports[`PluginsCategory should install plugin from header install button 1`] = 
                           </div>
                         </div>
                         <div
-                          class="flex text-sm text-theme-neutral-light space-x-4"
+                          class="flex space-x-4 text-sm text-theme-neutral-light"
                         >
                           <div
                             class="pr-4 border-r border-theme-neutral-300"
@@ -7162,7 +7162,7 @@ exports[`PluginsCategory should install plugin from header install button 1`] = 
                           </svg>
                         </div>
                         <div
-                          class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                          class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                         >
                           <div>
                             ARK Avatars
@@ -7180,7 +7180,7 @@ exports[`PluginsCategory should install plugin from header install button 1`] = 
                           </div>
                         </div>
                         <div
-                          class="flex text-sm text-theme-neutral-light space-x-4"
+                          class="flex space-x-4 text-sm text-theme-neutral-light"
                         >
                           <div
                             class="pr-4 border-r border-theme-neutral-300"
@@ -7258,7 +7258,7 @@ exports[`PluginsCategory should install plugin from header install button 1`] = 
                           </svg>
                         </div>
                         <div
-                          class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                          class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                         >
                           <div>
                             ARK Explorer
@@ -7276,7 +7276,7 @@ exports[`PluginsCategory should install plugin from header install button 1`] = 
                           </div>
                         </div>
                         <div
-                          class="flex text-sm text-theme-neutral-light space-x-4"
+                          class="flex space-x-4 text-sm text-theme-neutral-light"
                         >
                           <div
                             class="pr-4 border-r border-theme-neutral-300"
@@ -7339,7 +7339,7 @@ exports[`PluginsCategory should install plugin from header install button 1`] = 
                           </svg>
                         </div>
                         <div
-                          class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                          class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                         >
                           <div>
                             ARK Avatars
@@ -7357,7 +7357,7 @@ exports[`PluginsCategory should install plugin from header install button 1`] = 
                           </div>
                         </div>
                         <div
-                          class="flex text-sm text-theme-neutral-light space-x-4"
+                          class="flex space-x-4 text-sm text-theme-neutral-light"
                         >
                           <div
                             class="pr-4 border-r border-theme-neutral-300"
@@ -7435,7 +7435,7 @@ exports[`PluginsCategory should install plugin from header install button 1`] = 
                           </svg>
                         </div>
                         <div
-                          class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                          class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                         >
                           <div>
                             ARK Explorer
@@ -7453,7 +7453,7 @@ exports[`PluginsCategory should install plugin from header install button 1`] = 
                           </div>
                         </div>
                         <div
-                          class="flex text-sm text-theme-neutral-light space-x-4"
+                          class="flex space-x-4 text-sm text-theme-neutral-light"
                         >
                           <div
                             class="pr-4 border-r border-theme-neutral-300"
@@ -7516,7 +7516,7 @@ exports[`PluginsCategory should install plugin from header install button 1`] = 
                           </svg>
                         </div>
                         <div
-                          class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                          class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                         >
                           <div>
                             ARK Avatars
@@ -7534,7 +7534,7 @@ exports[`PluginsCategory should install plugin from header install button 1`] = 
                           </div>
                         </div>
                         <div
-                          class="flex text-sm text-theme-neutral-light space-x-4"
+                          class="flex space-x-4 text-sm text-theme-neutral-light"
                         >
                           <div
                             class="pr-4 border-r border-theme-neutral-300"
@@ -8094,7 +8094,7 @@ exports[`PluginsCategory should render 1`] = `
                   type="button"
                 >
                   <div
-                    class="flex items-center whitespace-no-wrap space-x-2"
+                    class="flex items-center space-x-2 whitespace-no-wrap"
                   >
                     <div
                       class="sc-AxirZ fkjLBb"
@@ -8204,7 +8204,7 @@ exports[`PluginsCategory should render 1`] = `
                           </svg>
                         </div>
                         <div
-                          class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                          class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                         >
                           <div>
                             ARK Explorer
@@ -8222,7 +8222,7 @@ exports[`PluginsCategory should render 1`] = `
                           </div>
                         </div>
                         <div
-                          class="flex text-sm text-theme-neutral-light space-x-4"
+                          class="flex space-x-4 text-sm text-theme-neutral-light"
                         >
                           <div
                             class="pr-4 border-r border-theme-neutral-300"
@@ -8285,7 +8285,7 @@ exports[`PluginsCategory should render 1`] = `
                           </svg>
                         </div>
                         <div
-                          class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                          class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                         >
                           <div>
                             ARK Avatars
@@ -8303,7 +8303,7 @@ exports[`PluginsCategory should render 1`] = `
                           </div>
                         </div>
                         <div
-                          class="flex text-sm text-theme-neutral-light space-x-4"
+                          class="flex space-x-4 text-sm text-theme-neutral-light"
                         >
                           <div
                             class="pr-4 border-r border-theme-neutral-300"
@@ -8381,7 +8381,7 @@ exports[`PluginsCategory should render 1`] = `
                           </svg>
                         </div>
                         <div
-                          class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                          class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                         >
                           <div>
                             ARK Explorer
@@ -8399,7 +8399,7 @@ exports[`PluginsCategory should render 1`] = `
                           </div>
                         </div>
                         <div
-                          class="flex text-sm text-theme-neutral-light space-x-4"
+                          class="flex space-x-4 text-sm text-theme-neutral-light"
                         >
                           <div
                             class="pr-4 border-r border-theme-neutral-300"
@@ -8462,7 +8462,7 @@ exports[`PluginsCategory should render 1`] = `
                           </svg>
                         </div>
                         <div
-                          class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                          class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                         >
                           <div>
                             ARK Avatars
@@ -8480,7 +8480,7 @@ exports[`PluginsCategory should render 1`] = `
                           </div>
                         </div>
                         <div
-                          class="flex text-sm text-theme-neutral-light space-x-4"
+                          class="flex space-x-4 text-sm text-theme-neutral-light"
                         >
                           <div
                             class="pr-4 border-r border-theme-neutral-300"
@@ -8558,7 +8558,7 @@ exports[`PluginsCategory should render 1`] = `
                           </svg>
                         </div>
                         <div
-                          class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                          class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                         >
                           <div>
                             ARK Explorer
@@ -8576,7 +8576,7 @@ exports[`PluginsCategory should render 1`] = `
                           </div>
                         </div>
                         <div
-                          class="flex text-sm text-theme-neutral-light space-x-4"
+                          class="flex space-x-4 text-sm text-theme-neutral-light"
                         >
                           <div
                             class="pr-4 border-r border-theme-neutral-300"
@@ -8639,7 +8639,7 @@ exports[`PluginsCategory should render 1`] = `
                           </svg>
                         </div>
                         <div
-                          class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                          class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                         >
                           <div>
                             ARK Avatars
@@ -8657,7 +8657,7 @@ exports[`PluginsCategory should render 1`] = `
                           </div>
                         </div>
                         <div
-                          class="flex text-sm text-theme-neutral-light space-x-4"
+                          class="flex space-x-4 text-sm text-theme-neutral-light"
                         >
                           <div
                             class="pr-4 border-r border-theme-neutral-300"
@@ -8735,7 +8735,7 @@ exports[`PluginsCategory should render 1`] = `
                           </svg>
                         </div>
                         <div
-                          class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                          class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                         >
                           <div>
                             ARK Explorer
@@ -8753,7 +8753,7 @@ exports[`PluginsCategory should render 1`] = `
                           </div>
                         </div>
                         <div
-                          class="flex text-sm text-theme-neutral-light space-x-4"
+                          class="flex space-x-4 text-sm text-theme-neutral-light"
                         >
                           <div
                             class="pr-4 border-r border-theme-neutral-300"
@@ -8816,7 +8816,7 @@ exports[`PluginsCategory should render 1`] = `
                           </svg>
                         </div>
                         <div
-                          class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                          class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                         >
                           <div>
                             ARK Avatars
@@ -8834,7 +8834,7 @@ exports[`PluginsCategory should render 1`] = `
                           </div>
                         </div>
                         <div
-                          class="flex text-sm text-theme-neutral-light space-x-4"
+                          class="flex space-x-4 text-sm text-theme-neutral-light"
                         >
                           <div
                             class="pr-4 border-r border-theme-neutral-300"
@@ -9208,7 +9208,7 @@ exports[`PluginsCategory should search for plugin 1`] = `
                   class="relative"
                 >
                   <div
-                    class="sc-fzoLsD gNnXoT absolute flex items-center px-6 py-4 bg-white shadow-xl rounded-md -bottom-4 -right-6"
+                    class="sc-fzoLsD gNnXoT absolute flex items-center px-6 py-4 bg-white rounded-md shadow-xl -bottom-4 -right-6"
                     data-testid="header-search-bar__input"
                   >
                     <div
@@ -9289,7 +9289,7 @@ exports[`PluginsCategory should search for plugin 1`] = `
                   type="button"
                 >
                   <div
-                    class="flex items-center whitespace-no-wrap space-x-2"
+                    class="flex items-center space-x-2 whitespace-no-wrap"
                   >
                     <div
                       class="sc-AxirZ fkjLBb"
@@ -9399,7 +9399,7 @@ exports[`PluginsCategory should search for plugin 1`] = `
                           </svg>
                         </div>
                         <div
-                          class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                          class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                         >
                           <div>
                             ARK Explorer
@@ -9417,7 +9417,7 @@ exports[`PluginsCategory should search for plugin 1`] = `
                           </div>
                         </div>
                         <div
-                          class="flex text-sm text-theme-neutral-light space-x-4"
+                          class="flex space-x-4 text-sm text-theme-neutral-light"
                         >
                           <div
                             class="pr-4 border-r border-theme-neutral-300"
@@ -9480,7 +9480,7 @@ exports[`PluginsCategory should search for plugin 1`] = `
                           </svg>
                         </div>
                         <div
-                          class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                          class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                         >
                           <div>
                             ARK Avatars
@@ -9498,7 +9498,7 @@ exports[`PluginsCategory should search for plugin 1`] = `
                           </div>
                         </div>
                         <div
-                          class="flex text-sm text-theme-neutral-light space-x-4"
+                          class="flex space-x-4 text-sm text-theme-neutral-light"
                         >
                           <div
                             class="pr-4 border-r border-theme-neutral-300"
@@ -9576,7 +9576,7 @@ exports[`PluginsCategory should search for plugin 1`] = `
                           </svg>
                         </div>
                         <div
-                          class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                          class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                         >
                           <div>
                             ARK Explorer
@@ -9594,7 +9594,7 @@ exports[`PluginsCategory should search for plugin 1`] = `
                           </div>
                         </div>
                         <div
-                          class="flex text-sm text-theme-neutral-light space-x-4"
+                          class="flex space-x-4 text-sm text-theme-neutral-light"
                         >
                           <div
                             class="pr-4 border-r border-theme-neutral-300"
@@ -9657,7 +9657,7 @@ exports[`PluginsCategory should search for plugin 1`] = `
                           </svg>
                         </div>
                         <div
-                          class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                          class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                         >
                           <div>
                             ARK Avatars
@@ -9675,7 +9675,7 @@ exports[`PluginsCategory should search for plugin 1`] = `
                           </div>
                         </div>
                         <div
-                          class="flex text-sm text-theme-neutral-light space-x-4"
+                          class="flex space-x-4 text-sm text-theme-neutral-light"
                         >
                           <div
                             class="pr-4 border-r border-theme-neutral-300"
@@ -9753,7 +9753,7 @@ exports[`PluginsCategory should search for plugin 1`] = `
                           </svg>
                         </div>
                         <div
-                          class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                          class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                         >
                           <div>
                             ARK Explorer
@@ -9771,7 +9771,7 @@ exports[`PluginsCategory should search for plugin 1`] = `
                           </div>
                         </div>
                         <div
-                          class="flex text-sm text-theme-neutral-light space-x-4"
+                          class="flex space-x-4 text-sm text-theme-neutral-light"
                         >
                           <div
                             class="pr-4 border-r border-theme-neutral-300"
@@ -9834,7 +9834,7 @@ exports[`PluginsCategory should search for plugin 1`] = `
                           </svg>
                         </div>
                         <div
-                          class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                          class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                         >
                           <div>
                             ARK Avatars
@@ -9852,7 +9852,7 @@ exports[`PluginsCategory should search for plugin 1`] = `
                           </div>
                         </div>
                         <div
-                          class="flex text-sm text-theme-neutral-light space-x-4"
+                          class="flex space-x-4 text-sm text-theme-neutral-light"
                         >
                           <div
                             class="pr-4 border-r border-theme-neutral-300"
@@ -9930,7 +9930,7 @@ exports[`PluginsCategory should search for plugin 1`] = `
                           </svg>
                         </div>
                         <div
-                          class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                          class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                         >
                           <div>
                             ARK Explorer
@@ -9948,7 +9948,7 @@ exports[`PluginsCategory should search for plugin 1`] = `
                           </div>
                         </div>
                         <div
-                          class="flex text-sm text-theme-neutral-light space-x-4"
+                          class="flex space-x-4 text-sm text-theme-neutral-light"
                         >
                           <div
                             class="pr-4 border-r border-theme-neutral-300"
@@ -10011,7 +10011,7 @@ exports[`PluginsCategory should search for plugin 1`] = `
                           </svg>
                         </div>
                         <div
-                          class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                          class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                         >
                           <div>
                             ARK Avatars
@@ -10029,7 +10029,7 @@ exports[`PluginsCategory should search for plugin 1`] = `
                           </div>
                         </div>
                         <div
-                          class="flex text-sm text-theme-neutral-light space-x-4"
+                          class="flex space-x-4 text-sm text-theme-neutral-light"
                         >
                           <div
                             class="pr-4 border-r border-theme-neutral-300"
@@ -10434,7 +10434,7 @@ exports[`PluginsCategory should select plugin on grid 1`] = `
                   type="button"
                 >
                   <div
-                    class="flex items-center whitespace-no-wrap space-x-2"
+                    class="flex items-center space-x-2 whitespace-no-wrap"
                   >
                     <div
                       class="sc-AxirZ fkjLBb"
@@ -10544,7 +10544,7 @@ exports[`PluginsCategory should select plugin on grid 1`] = `
                           </svg>
                         </div>
                         <div
-                          class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                          class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                         >
                           <div>
                             ARK Explorer
@@ -10562,7 +10562,7 @@ exports[`PluginsCategory should select plugin on grid 1`] = `
                           </div>
                         </div>
                         <div
-                          class="flex text-sm text-theme-neutral-light space-x-4"
+                          class="flex space-x-4 text-sm text-theme-neutral-light"
                         >
                           <div
                             class="pr-4 border-r border-theme-neutral-300"
@@ -10625,7 +10625,7 @@ exports[`PluginsCategory should select plugin on grid 1`] = `
                           </svg>
                         </div>
                         <div
-                          class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                          class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                         >
                           <div>
                             ARK Avatars
@@ -10643,7 +10643,7 @@ exports[`PluginsCategory should select plugin on grid 1`] = `
                           </div>
                         </div>
                         <div
-                          class="flex text-sm text-theme-neutral-light space-x-4"
+                          class="flex space-x-4 text-sm text-theme-neutral-light"
                         >
                           <div
                             class="pr-4 border-r border-theme-neutral-300"
@@ -10721,7 +10721,7 @@ exports[`PluginsCategory should select plugin on grid 1`] = `
                           </svg>
                         </div>
                         <div
-                          class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                          class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                         >
                           <div>
                             ARK Explorer
@@ -10739,7 +10739,7 @@ exports[`PluginsCategory should select plugin on grid 1`] = `
                           </div>
                         </div>
                         <div
-                          class="flex text-sm text-theme-neutral-light space-x-4"
+                          class="flex space-x-4 text-sm text-theme-neutral-light"
                         >
                           <div
                             class="pr-4 border-r border-theme-neutral-300"
@@ -10802,7 +10802,7 @@ exports[`PluginsCategory should select plugin on grid 1`] = `
                           </svg>
                         </div>
                         <div
-                          class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                          class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                         >
                           <div>
                             ARK Avatars
@@ -10820,7 +10820,7 @@ exports[`PluginsCategory should select plugin on grid 1`] = `
                           </div>
                         </div>
                         <div
-                          class="flex text-sm text-theme-neutral-light space-x-4"
+                          class="flex space-x-4 text-sm text-theme-neutral-light"
                         >
                           <div
                             class="pr-4 border-r border-theme-neutral-300"
@@ -10898,7 +10898,7 @@ exports[`PluginsCategory should select plugin on grid 1`] = `
                           </svg>
                         </div>
                         <div
-                          class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                          class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                         >
                           <div>
                             ARK Explorer
@@ -10916,7 +10916,7 @@ exports[`PluginsCategory should select plugin on grid 1`] = `
                           </div>
                         </div>
                         <div
-                          class="flex text-sm text-theme-neutral-light space-x-4"
+                          class="flex space-x-4 text-sm text-theme-neutral-light"
                         >
                           <div
                             class="pr-4 border-r border-theme-neutral-300"
@@ -10979,7 +10979,7 @@ exports[`PluginsCategory should select plugin on grid 1`] = `
                           </svg>
                         </div>
                         <div
-                          class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                          class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                         >
                           <div>
                             ARK Avatars
@@ -10997,7 +10997,7 @@ exports[`PluginsCategory should select plugin on grid 1`] = `
                           </div>
                         </div>
                         <div
-                          class="flex text-sm text-theme-neutral-light space-x-4"
+                          class="flex space-x-4 text-sm text-theme-neutral-light"
                         >
                           <div
                             class="pr-4 border-r border-theme-neutral-300"
@@ -11075,7 +11075,7 @@ exports[`PluginsCategory should select plugin on grid 1`] = `
                           </svg>
                         </div>
                         <div
-                          class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                          class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                         >
                           <div>
                             ARK Explorer
@@ -11093,7 +11093,7 @@ exports[`PluginsCategory should select plugin on grid 1`] = `
                           </div>
                         </div>
                         <div
-                          class="flex text-sm text-theme-neutral-light space-x-4"
+                          class="flex space-x-4 text-sm text-theme-neutral-light"
                         >
                           <div
                             class="pr-4 border-r border-theme-neutral-300"
@@ -11156,7 +11156,7 @@ exports[`PluginsCategory should select plugin on grid 1`] = `
                           </svg>
                         </div>
                         <div
-                          class="flex items-center mb-2 text-lg space-x-2 text-theme-primary"
+                          class="flex items-center mb-2 space-x-2 text-lg text-theme-primary"
                         >
                           <div>
                             ARK Avatars
@@ -11174,7 +11174,7 @@ exports[`PluginsCategory should select plugin on grid 1`] = `
                           </div>
                         </div>
                         <div
-                          class="flex text-sm text-theme-neutral-light space-x-4"
+                          class="flex space-x-4 text-sm text-theme-neutral-light"
                         >
                           <div
                             class="pr-4 border-r border-theme-neutral-300"
@@ -11579,7 +11579,7 @@ exports[`PluginsCategory should toggle between grid and list 1`] = `
                   type="button"
                 >
                   <div
-                    class="flex items-center whitespace-no-wrap space-x-2"
+                    class="flex items-center space-x-2 whitespace-no-wrap"
                   >
                     <div
                       class="sc-AxirZ fkjLBb"

--- a/src/domains/profile/components/SelectRecipient/SelectRecipient.tsx
+++ b/src/domains/profile/components/SelectRecipient/SelectRecipient.tsx
@@ -84,7 +84,7 @@ export const SelectRecipient = React.forwardRef<HTMLInputElement, SelectRecipien
 
 					<div
 						data-testid="SelectRecipient__select-contact"
-						className="absolute flex items-center cursor-pointer right-4 space-x-3"
+						className="absolute flex items-center space-x-3 cursor-pointer right-4"
 						onClick={openContacts}
 					>
 						<Icon name="User" width={20} height={20} />

--- a/src/domains/profile/components/SelectRecipient/__snapshots__/SelectRecipient.test.tsx.snap
+++ b/src/domains/profile/components/SelectRecipient/__snapshots__/SelectRecipient.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`SelectRecipient should render disabled 1`] = `
         value=""
       />
       <div
-        class="absolute flex items-center cursor-pointer right-4 space-x-3"
+        class="absolute flex items-center space-x-3 cursor-pointer right-4"
         data-testid="SelectRecipient__select-contact"
       >
         <div
@@ -61,7 +61,7 @@ exports[`SelectRecipient should render empty 1`] = `
         value=""
       />
       <div
-        class="absolute flex items-center cursor-pointer right-4 space-x-3"
+        class="absolute flex items-center space-x-3 cursor-pointer right-4"
         data-testid="SelectRecipient__select-contact"
       >
         <div
@@ -101,7 +101,7 @@ exports[`SelectRecipient should render invalid 1`] = `
         value=""
       />
       <div
-        class="absolute flex items-center cursor-pointer right-4 space-x-3"
+        class="absolute flex items-center space-x-3 cursor-pointer right-4"
         data-testid="SelectRecipient__select-contact"
       >
         <div
@@ -151,7 +151,7 @@ exports[`SelectRecipient should render with preselected address 1`] = `
         value="bP6T9GQ3kqP6T9GQ3kqP6T9GQ3kqTTTP6T9GQ3kqT"
       />
       <div
-        class="absolute flex items-center cursor-pointer right-4 space-x-3"
+        class="absolute flex items-center space-x-3 cursor-pointer right-4"
         data-testid="SelectRecipient__select-contact"
       >
         <div

--- a/src/domains/profile/pages/MyRegistrations/components/RepositoryModal/__snapshots__/RepositoryModal.test.tsx.snap
+++ b/src/domains/profile/pages/MyRegistrations/components/RepositoryModal/__snapshots__/RepositoryModal.test.tsx.snap
@@ -65,7 +65,7 @@ exports[`RepositoryModal should render empty state 1`] = `
                 </div>
               </div>
               <div
-                class="flex flex-col font-semibold space-y-1"
+                class="flex flex-col space-y-1 font-semibold"
               >
                 <span
                   class="text-sm text-theme-neutral-light"
@@ -99,7 +99,7 @@ exports[`RepositoryModal should render empty state 1`] = `
                 </div>
               </div>
               <div
-                class="flex flex-col font-semibold space-y-1"
+                class="flex flex-col space-y-1 font-semibold"
               >
                 <span
                   class="text-sm text-theme-neutral-light"
@@ -133,7 +133,7 @@ exports[`RepositoryModal should render empty state 1`] = `
                 </div>
               </div>
               <div
-                class="flex flex-col font-semibold space-y-1"
+                class="flex flex-col space-y-1 font-semibold"
               >
                 <span
                   class="text-sm text-theme-neutral-light"
@@ -167,7 +167,7 @@ exports[`RepositoryModal should render empty state 1`] = `
                 </div>
               </div>
               <div
-                class="flex flex-col font-semibold space-y-1"
+                class="flex flex-col space-y-1 font-semibold"
               >
                 <span
                   class="text-sm text-theme-neutral-light"

--- a/src/domains/profile/pages/MyRegistrations/components/RepositoryModal/components/RepositoryLink/RepositoryLink.tsx
+++ b/src/domains/profile/pages/MyRegistrations/components/RepositoryModal/components/RepositoryLink/RepositoryLink.tsx
@@ -17,7 +17,7 @@ export const RepositoryLink = ({ provider, url }: RepositoryLinkProps) => {
 			<Circle className="border-theme-neutral-800" size="lg">
 				<Icon name={provider} width={22} height={22} data-testid="repository-link__icon" />
 			</Circle>
-			<div className="flex flex-col font-semibold space-y-1">
+			<div className="flex flex-col space-y-1 font-semibold">
 				<span className="text-sm text-theme-neutral-light">{t(`PROFILE.MODAL_REPOSITORIES.${provider}`)}</span>
 				<Link className="text-theme-primary" to={{ pathname: url }} target="_blank">
 					{url}

--- a/src/domains/profile/pages/MyRegistrations/components/RepositoryModal/components/RepositoryLink/__snapshots__/RepositoryLink.test.tsx.snap
+++ b/src/domains/profile/pages/MyRegistrations/components/RepositoryModal/components/RepositoryLink/__snapshots__/RepositoryLink.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`RepositoryLink should render properly 1`] = `
       </div>
     </div>
     <div
-      class="flex flex-col font-semibold space-y-1"
+      class="flex flex-col space-y-1 font-semibold"
     >
       <span
         class="text-sm text-theme-neutral-light"

--- a/src/domains/setting/components/CustomPeers/__snapshots__/CustomPeers.test.tsx.snap
+++ b/src/domains/setting/components/CustomPeers/__snapshots__/CustomPeers.test.tsx.snap
@@ -102,7 +102,7 @@ exports[`CustomPeers should render a modal 1`] = `
               </div>
               <ul
                 aria-labelledby="CustomPeers__network-label"
-                class="mt-6 grid grid-cols-6 gap-6"
+                class="grid grid-cols-6 gap-6 mt-6"
                 id="CustomPeers__network-menu"
                 role="listbox"
               />

--- a/src/domains/setting/components/PeerList/__snapshots__/PeerList.test.tsx.snap
+++ b/src/domains/setting/components/PeerList/__snapshots__/PeerList.test.tsx.snap
@@ -101,7 +101,7 @@ exports[`PeerList should add peer 1`] = `
                 </div>
                 <ul
                   aria-labelledby="CustomPeers__network-label"
-                  class="mt-6 grid grid-cols-6 gap-6"
+                  class="grid grid-cols-6 gap-6 mt-6"
                   id="CustomPeers__network-menu"
                   role="listbox"
                 />

--- a/src/domains/transaction/components/AddRecipient/__snapshots__/AddRecipient.test.tsx.snap
+++ b/src/domains/transaction/components/AddRecipient/__snapshots__/AddRecipient.test.tsx.snap
@@ -97,7 +97,7 @@ exports[`AddRecipient should render 1`] = `
                 value=""
               />
               <div
-                class="absolute flex items-center cursor-pointer right-4 space-x-3"
+                class="absolute flex items-center space-x-3 cursor-pointer right-4"
                 data-testid="SelectRecipient__select-contact"
               >
                 <div
@@ -258,7 +258,7 @@ exports[`AddRecipient should render with multiple recipients tab 1`] = `
                 value=""
               />
               <div
-                class="absolute flex items-center cursor-pointer right-4 space-x-3"
+                class="absolute flex items-center space-x-3 cursor-pointer right-4"
                 data-testid="SelectRecipient__select-contact"
               >
                 <div
@@ -430,7 +430,7 @@ exports[`AddRecipient should render with single recipient data 1`] = `
                 value="D6Z26L69gdk9qYmTv5uzk3uGepigtHY4ax"
               />
               <div
-                class="absolute flex items-center cursor-pointer right-4 space-x-3"
+                class="absolute flex items-center space-x-3 cursor-pointer right-4"
                 data-testid="SelectRecipient__select-contact"
               >
                 <div
@@ -591,7 +591,7 @@ exports[`AddRecipient should render without recipients 1`] = `
                 value=""
               />
               <div
-                class="absolute flex items-center cursor-pointer right-4 space-x-3"
+                class="absolute flex items-center space-x-3 cursor-pointer right-4"
                 data-testid="SelectRecipient__select-contact"
               >
                 <div
@@ -752,7 +752,7 @@ exports[`AddRecipient should set available amount 1`] = `
                 value=""
               />
               <div
-                class="absolute flex items-center cursor-pointer right-4 space-x-3"
+                class="absolute flex items-center space-x-3 cursor-pointer right-4"
                 data-testid="SelectRecipient__select-contact"
               >
                 <div

--- a/src/domains/transaction/components/BusinessRegistrationForm/__snapshots__/BusinessRegistrationForm.test.tsx.snap
+++ b/src/domains/transaction/components/BusinessRegistrationForm/__snapshots__/BusinessRegistrationForm.test.tsx.snap
@@ -300,7 +300,7 @@ exports[`BusinessRegistrationForm should render step 2 1`] = `
                       >
                         <button
                           aria-checked="false"
-                          class="sc-fznZeY vTGiJ relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+                          class="sc-fznZeY vTGiJ relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
                           data-testid="SelectionBarOption"
                           role="radio"
                           type="button"
@@ -309,7 +309,7 @@ exports[`BusinessRegistrationForm should render step 2 1`] = `
                         </button>
                         <button
                           aria-checked="false"
-                          class="sc-fznZeY vTGiJ relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+                          class="sc-fznZeY vTGiJ relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
                           data-testid="SelectionBarOption"
                           role="radio"
                           type="button"
@@ -318,7 +318,7 @@ exports[`BusinessRegistrationForm should render step 2 1`] = `
                         </button>
                         <button
                           aria-checked="false"
-                          class="sc-fznZeY vTGiJ relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+                          class="sc-fznZeY vTGiJ relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
                           data-testid="SelectionBarOption"
                           role="radio"
                           type="button"

--- a/src/domains/transaction/components/DelegateRegistrationForm/DelegateRegistrationForm.tsx
+++ b/src/domains/transaction/components/DelegateRegistrationForm/DelegateRegistrationForm.tsx
@@ -135,7 +135,7 @@ const ThirdStep = ({ wallet }: { wallet: ReadWriteWallet }) => {
 				{t("TRANSACTION.PAGE_DELEGATE_REGISTRATION.SECOND_STEP.DESCRIPTION")}
 			</div>
 
-			<div className="mt-4 grid grid-flow-row gap-2">
+			<div className="grid grid-flow-row gap-2 mt-4">
 				<TransactionDetail
 					border={false}
 					label={t("TRANSACTION.NETWORK")}

--- a/src/domains/transaction/components/DelegateRegistrationForm/__snapshots__/DelegateRegistrationForm.test.tsx.snap
+++ b/src/domains/transaction/components/DelegateRegistrationForm/__snapshots__/DelegateRegistrationForm.test.tsx.snap
@@ -215,7 +215,7 @@ exports[`DelegateRegistrationForm should error for invalid username 1`] = `
                 >
                   <button
                     aria-checked="false"
-                    class="sc-fzqBZW dJUDOf relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+                    class="sc-fzqBZW dJUDOf relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
                     data-testid="SelectionBarOption"
                     role="radio"
                     type="button"
@@ -224,7 +224,7 @@ exports[`DelegateRegistrationForm should error for invalid username 1`] = `
                   </button>
                   <button
                     aria-checked="false"
-                    class="sc-fzqBZW dJUDOf relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+                    class="sc-fzqBZW dJUDOf relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
                     data-testid="SelectionBarOption"
                     role="radio"
                     type="button"
@@ -233,7 +233,7 @@ exports[`DelegateRegistrationForm should error for invalid username 1`] = `
                   </button>
                   <button
                     aria-checked="false"
-                    class="sc-fzqBZW dJUDOf relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+                    class="sc-fzqBZW dJUDOf relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
                     data-testid="SelectionBarOption"
                     role="radio"
                     type="button"
@@ -466,7 +466,7 @@ exports[`DelegateRegistrationForm should error for long username 1`] = `
                 >
                   <button
                     aria-checked="false"
-                    class="sc-fzqBZW dJUDOf relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+                    class="sc-fzqBZW dJUDOf relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
                     data-testid="SelectionBarOption"
                     role="radio"
                     type="button"
@@ -475,7 +475,7 @@ exports[`DelegateRegistrationForm should error for long username 1`] = `
                   </button>
                   <button
                     aria-checked="false"
-                    class="sc-fzqBZW dJUDOf relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+                    class="sc-fzqBZW dJUDOf relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
                     data-testid="SelectionBarOption"
                     role="radio"
                     type="button"
@@ -484,7 +484,7 @@ exports[`DelegateRegistrationForm should error for long username 1`] = `
                   </button>
                   <button
                     aria-checked="false"
-                    class="sc-fzqBZW dJUDOf relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+                    class="sc-fzqBZW dJUDOf relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
                     data-testid="SelectionBarOption"
                     role="radio"
                     type="button"
@@ -717,7 +717,7 @@ exports[`DelegateRegistrationForm should error if username already exists 1`] = 
                 >
                   <button
                     aria-checked="false"
-                    class="sc-fzqBZW dJUDOf relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+                    class="sc-fzqBZW dJUDOf relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
                     data-testid="SelectionBarOption"
                     role="radio"
                     type="button"
@@ -726,7 +726,7 @@ exports[`DelegateRegistrationForm should error if username already exists 1`] = 
                   </button>
                   <button
                     aria-checked="false"
-                    class="sc-fzqBZW dJUDOf relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+                    class="sc-fzqBZW dJUDOf relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
                     data-testid="SelectionBarOption"
                     role="radio"
                     type="button"
@@ -735,7 +735,7 @@ exports[`DelegateRegistrationForm should error if username already exists 1`] = 
                   </button>
                   <button
                     aria-checked="false"
-                    class="sc-fzqBZW dJUDOf relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+                    class="sc-fzqBZW dJUDOf relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
                     data-testid="SelectionBarOption"
                     role="radio"
                     type="button"
@@ -962,7 +962,7 @@ exports[`DelegateRegistrationForm should render step 2 1`] = `
                 >
                   <button
                     aria-checked="false"
-                    class="sc-fzqBZW dJUDOf relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+                    class="sc-fzqBZW dJUDOf relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
                     data-testid="SelectionBarOption"
                     role="radio"
                     type="button"
@@ -971,7 +971,7 @@ exports[`DelegateRegistrationForm should render step 2 1`] = `
                   </button>
                   <button
                     aria-checked="false"
-                    class="sc-fzqBZW dJUDOf relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+                    class="sc-fzqBZW dJUDOf relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
                     data-testid="SelectionBarOption"
                     role="radio"
                     type="button"
@@ -980,7 +980,7 @@ exports[`DelegateRegistrationForm should render step 2 1`] = `
                   </button>
                   <button
                     aria-checked="false"
-                    class="sc-fzqBZW dJUDOf relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+                    class="sc-fzqBZW dJUDOf relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
                     data-testid="SelectionBarOption"
                     role="radio"
                     type="button"
@@ -1018,7 +1018,7 @@ exports[`DelegateRegistrationForm should render step 3 1`] = `
           Make up a name and register your delegate online.
         </div>
         <div
-          class="mt-4 grid grid-flow-row gap-2"
+          class="grid grid-flow-row gap-2 mt-4"
         >
           <div
             class="flex items-center py-6 true "
@@ -1446,7 +1446,7 @@ exports[`DelegateRegistrationForm should set fee 1`] = `
                 >
                   <button
                     aria-checked="false"
-                    class="sc-fzqBZW dJUDOf relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+                    class="sc-fzqBZW dJUDOf relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
                     data-testid="SelectionBarOption"
                     role="radio"
                     type="button"
@@ -1455,7 +1455,7 @@ exports[`DelegateRegistrationForm should set fee 1`] = `
                   </button>
                   <button
                     aria-checked="false"
-                    class="sc-fzqBZW dJUDOf relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+                    class="sc-fzqBZW dJUDOf relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
                     data-testid="SelectionBarOption"
                     role="radio"
                     type="button"
@@ -1464,7 +1464,7 @@ exports[`DelegateRegistrationForm should set fee 1`] = `
                   </button>
                   <button
                     aria-checked="true"
-                    class="sc-fzqBZW dJUDOf relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+                    class="sc-fzqBZW dJUDOf relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
                     data-testid="SelectionBarOption"
                     role="radio"
                     type="button"
@@ -1691,7 +1691,7 @@ exports[`DelegateRegistrationForm should set username 1`] = `
                 >
                   <button
                     aria-checked="false"
-                    class="sc-fzqBZW dJUDOf relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+                    class="sc-fzqBZW dJUDOf relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
                     data-testid="SelectionBarOption"
                     role="radio"
                     type="button"
@@ -1700,7 +1700,7 @@ exports[`DelegateRegistrationForm should set username 1`] = `
                   </button>
                   <button
                     aria-checked="false"
-                    class="sc-fzqBZW dJUDOf relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+                    class="sc-fzqBZW dJUDOf relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
                     data-testid="SelectionBarOption"
                     role="radio"
                     type="button"
@@ -1709,7 +1709,7 @@ exports[`DelegateRegistrationForm should set username 1`] = `
                   </button>
                   <button
                     aria-checked="false"
-                    class="sc-fzqBZW dJUDOf relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+                    class="sc-fzqBZW dJUDOf relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
                     data-testid="SelectionBarOption"
                     role="radio"
                     type="button"

--- a/src/domains/transaction/components/InputFee/__snapshots__/InputFee.test.tsx.snap
+++ b/src/domains/transaction/components/InputFee/__snapshots__/InputFee.test.tsx.snap
@@ -59,7 +59,7 @@ exports[`InputFee should render 1`] = `
       >
         <button
           aria-checked="false"
-          class="sc-fzozJi cqpCRb relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+          class="sc-fzozJi cqpCRb relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
           data-testid="SelectionBarOption"
           role="radio"
           type="button"
@@ -68,7 +68,7 @@ exports[`InputFee should render 1`] = `
         </button>
         <button
           aria-checked="false"
-          class="sc-fzozJi cqpCRb relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+          class="sc-fzozJi cqpCRb relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
           data-testid="SelectionBarOption"
           role="radio"
           type="button"
@@ -77,7 +77,7 @@ exports[`InputFee should render 1`] = `
         </button>
         <button
           aria-checked="false"
-          class="sc-fzozJi cqpCRb relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+          class="sc-fzozJi cqpCRb relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
           data-testid="SelectionBarOption"
           role="radio"
           type="button"
@@ -149,7 +149,7 @@ exports[`InputFee should update fee if value property changes 1`] = `
       >
         <button
           aria-checked="true"
-          class="sc-fzozJi cqpCRb relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+          class="sc-fzozJi cqpCRb relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
           data-testid="SelectionBarOption"
           role="radio"
           type="button"
@@ -158,7 +158,7 @@ exports[`InputFee should update fee if value property changes 1`] = `
         </button>
         <button
           aria-checked="false"
-          class="sc-fzozJi cqpCRb relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+          class="sc-fzozJi cqpCRb relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
           data-testid="SelectionBarOption"
           role="radio"
           type="button"
@@ -167,7 +167,7 @@ exports[`InputFee should update fee if value property changes 1`] = `
         </button>
         <button
           aria-checked="false"
-          class="sc-fzozJi cqpCRb relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+          class="sc-fzozJi cqpCRb relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
           data-testid="SelectionBarOption"
           role="radio"
           type="button"
@@ -239,7 +239,7 @@ exports[`InputFee should update fee when clicking on avg 1`] = `
       >
         <button
           aria-checked="false"
-          class="sc-fzozJi cqpCRb relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+          class="sc-fzozJi cqpCRb relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
           data-testid="SelectionBarOption"
           role="radio"
           type="button"
@@ -248,7 +248,7 @@ exports[`InputFee should update fee when clicking on avg 1`] = `
         </button>
         <button
           aria-checked="true"
-          class="sc-fzozJi cqpCRb relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+          class="sc-fzozJi cqpCRb relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
           data-testid="SelectionBarOption"
           role="radio"
           type="button"
@@ -257,7 +257,7 @@ exports[`InputFee should update fee when clicking on avg 1`] = `
         </button>
         <button
           aria-checked="false"
-          class="sc-fzozJi cqpCRb relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+          class="sc-fzozJi cqpCRb relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
           data-testid="SelectionBarOption"
           role="radio"
           type="button"
@@ -329,7 +329,7 @@ exports[`InputFee should update fee when clicking on max 1`] = `
       >
         <button
           aria-checked="false"
-          class="sc-fzozJi cqpCRb relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+          class="sc-fzozJi cqpCRb relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
           data-testid="SelectionBarOption"
           role="radio"
           type="button"
@@ -338,7 +338,7 @@ exports[`InputFee should update fee when clicking on max 1`] = `
         </button>
         <button
           aria-checked="false"
-          class="sc-fzozJi cqpCRb relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+          class="sc-fzozJi cqpCRb relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
           data-testid="SelectionBarOption"
           role="radio"
           type="button"
@@ -347,7 +347,7 @@ exports[`InputFee should update fee when clicking on max 1`] = `
         </button>
         <button
           aria-checked="true"
-          class="sc-fzozJi cqpCRb relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+          class="sc-fzozJi cqpCRb relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
           data-testid="SelectionBarOption"
           role="radio"
           type="button"
@@ -419,7 +419,7 @@ exports[`InputFee should update fee when clicking on min 1`] = `
       >
         <button
           aria-checked="true"
-          class="sc-fzozJi cqpCRb relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+          class="sc-fzozJi cqpCRb relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
           data-testid="SelectionBarOption"
           role="radio"
           type="button"
@@ -428,7 +428,7 @@ exports[`InputFee should update fee when clicking on min 1`] = `
         </button>
         <button
           aria-checked="false"
-          class="sc-fzozJi cqpCRb relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+          class="sc-fzozJi cqpCRb relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
           data-testid="SelectionBarOption"
           role="radio"
           type="button"
@@ -437,7 +437,7 @@ exports[`InputFee should update fee when clicking on min 1`] = `
         </button>
         <button
           aria-checked="false"
-          class="sc-fzozJi cqpCRb relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+          class="sc-fzozJi cqpCRb relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
           data-testid="SelectionBarOption"
           role="radio"
           type="button"

--- a/src/domains/transaction/components/SecondSignatureRegistrationForm/Step4.tsx
+++ b/src/domains/transaction/components/SecondSignatureRegistrationForm/Step4.tsx
@@ -28,7 +28,7 @@ export const ReviewStep = ({ wallet }: { wallet: ReadWriteWallet }) => {
 				{t("TRANSACTION.PAGE_SECOND_SIGNATURE.REVIEW_STEP.DESCRIPTION")}
 			</div>
 
-			<div className="mt-4 grid grid-flow-row gap-2">
+			<div className="grid grid-flow-row gap-2 mt-4">
 				<TransactionDetail
 					border={false}
 					label={t("TRANSACTION.NETWORK")}

--- a/src/domains/transaction/components/SecondSignatureRegistrationForm/__snapshots__/SecondSignatureRegistrationForm.test.tsx.snap
+++ b/src/domains/transaction/components/SecondSignatureRegistrationForm/__snapshots__/SecondSignatureRegistrationForm.test.tsx.snap
@@ -55,7 +55,7 @@ exports[`SecondSignatureRegistrationForm should render backup step 1`] = `
               </div>
             </div>
             <ul
-              class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 row-gap-5 col-gap-3"
+              class="grid grid-cols-2 row-gap-5 col-gap-3 md:grid-cols-3 lg:grid-cols-4"
             >
               <li
                 class="relative px-3 py-3 border rounded border-theme-neutral-light"
@@ -378,7 +378,7 @@ exports[`SecondSignatureRegistrationForm should render generation step 1`] = `
                   >
                     <button
                       aria-checked="false"
-                      class="sc-fzqBZW dJUDOf relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+                      class="sc-fzqBZW dJUDOf relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
                       data-testid="SelectionBarOption"
                       role="radio"
                       type="button"
@@ -387,7 +387,7 @@ exports[`SecondSignatureRegistrationForm should render generation step 1`] = `
                     </button>
                     <button
                       aria-checked="false"
-                      class="sc-fzqBZW dJUDOf relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+                      class="sc-fzqBZW dJUDOf relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
                       data-testid="SelectionBarOption"
                       role="radio"
                       type="button"
@@ -396,7 +396,7 @@ exports[`SecondSignatureRegistrationForm should render generation step 1`] = `
                     </button>
                     <button
                       aria-checked="false"
-                      class="sc-fzqBZW dJUDOf relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+                      class="sc-fzqBZW dJUDOf relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
                       data-testid="SelectionBarOption"
                       role="radio"
                       type="button"

--- a/src/domains/transaction/components/SendTransactionForm/SendTransactionForm.test.tsx
+++ b/src/domains/transaction/components/SendTransactionForm/SendTransactionForm.test.tsx
@@ -71,7 +71,7 @@ describe("SendTransactionForm", () => {
 			);
 		});
 
-		const { getByTestId, getAllByTestId } = rendered;
+		const { getByTestId } = rendered;
 
 		await act(async () => {
 			await waitFor(() => expect(form.current.getValues("fee")).toEqual(defaultFee));
@@ -124,7 +124,7 @@ describe("SendTransactionForm", () => {
 			await waitFor(() => expect(rendered.getByTestId("SelectAddress__wrapper")).toBeTruthy());
 		});
 
-		const { getByTestId, getAllByTestId } = rendered;
+		const { getByTestId } = rendered;
 
 		await act(async () => {
 			await waitFor(() => expect(form.current.getValues("fee")).toEqual(defaultFee));
@@ -142,7 +142,7 @@ describe("SendTransactionForm", () => {
 			const secondWallet = profile.wallets().values()[1];
 			await waitFor(() =>
 				expect(historySpy).toHaveBeenCalledWith(
-					`/profiles/${profile?.id()}/transactions/${secondWallet.id()}/transfer`,
+					`/profiles/${profile?.id()}/wallets/${secondWallet.id()}/send-transfer`,
 				),
 			);
 

--- a/src/domains/transaction/components/SendTransactionForm/SendTransactionForm.tsx
+++ b/src/domains/transaction/components/SendTransactionForm/SendTransactionForm.tsx
@@ -49,8 +49,9 @@ export const SendTransactionForm = ({ children, networks, profile }: SendTransac
 
 	useEffect(() => {
 		if (network) {
-			setWallets(profile.wallets().findByCoinWithNetwork(network.coin(), network.id()));
+			return setWallets(profile.wallets().findByCoinWithNetwork(network.coin(), network.id()));
 		}
+		setWallets(profile.wallets().values());
 	}, [network, profile]);
 
 	const onSelectSender = (address: any) => {
@@ -66,7 +67,13 @@ export const SendTransactionForm = ({ children, networks, profile }: SendTransac
 				<div className="mb-2">
 					<FormLabel label="Network" />
 				</div>
-				<SelectNetwork id="SendTransactionForm__network" networks={networks} selected={network} disabled />
+				<SelectNetwork
+					id="SendTransactionForm__network"
+					networks={networks}
+					selected={network}
+					disabled={!!senderAddress}
+					onSelect={(selectedNetwork: NetworkData | null | undefined) => setValue("network", selectedNetwork)}
+				/>
 			</FormField>
 
 			<FormField name="senderAddress" className="relative">

--- a/src/domains/transaction/components/SendTransactionForm/SendTransactionForm.tsx
+++ b/src/domains/transaction/components/SendTransactionForm/SendTransactionForm.tsx
@@ -57,7 +57,7 @@ export const SendTransactionForm = ({ children, networks, profile }: SendTransac
 		setValue("senderAddress", address, true);
 
 		const wallet = wallets.find((wallet) => wallet.address() === address);
-		history.push(`/profiles/${profile.id()}/transactions/${wallet!.id()}/transfer`);
+		history.push(`/profiles/${profile.id()}/wallets/${wallet!.id()}/send-transfer`);
 	};
 
 	return (

--- a/src/domains/transaction/components/SendTransactionForm/__snapshots__/SendTransactionForm.test.tsx.snap
+++ b/src/domains/transaction/components/SendTransactionForm/__snapshots__/SendTransactionForm.test.tsx.snap
@@ -63,7 +63,7 @@ exports[`SendTransactionForm should render 1`] = `
       </div>
       <ul
         aria-labelledby="SendTransactionForm__network-label"
-        class="mt-6 grid grid-cols-6 gap-6"
+        class="grid grid-cols-6 gap-6 mt-6"
         id="SendTransactionForm__network-menu"
         role="listbox"
       >
@@ -244,7 +244,7 @@ exports[`SendTransactionForm should render 1`] = `
           >
             <button
               aria-checked="false"
-              class="sc-fzokOt bHylAC relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+              class="sc-fzokOt bHylAC relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
               data-testid="SelectionBarOption"
               role="radio"
               type="button"
@@ -253,7 +253,7 @@ exports[`SendTransactionForm should render 1`] = `
             </button>
             <button
               aria-checked="false"
-              class="sc-fzokOt bHylAC relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+              class="sc-fzokOt bHylAC relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
               data-testid="SelectionBarOption"
               role="radio"
               type="button"
@@ -262,7 +262,7 @@ exports[`SendTransactionForm should render 1`] = `
             </button>
             <button
               aria-checked="false"
-              class="sc-fzokOt bHylAC relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+              class="sc-fzokOt bHylAC relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
               data-testid="SelectionBarOption"
               role="radio"
               type="button"
@@ -339,7 +339,7 @@ exports[`SendTransactionForm should select fill out form 1`] = `
       </div>
       <ul
         aria-labelledby="SendTransactionForm__network-label"
-        class="mt-6 grid grid-cols-6 gap-6"
+        class="grid grid-cols-6 gap-6 mt-6"
         id="SendTransactionForm__network-menu"
         role="listbox"
       >
@@ -543,7 +543,7 @@ exports[`SendTransactionForm should select fill out form 1`] = `
           >
             <button
               aria-checked="false"
-              class="sc-fzokOt bHylAC relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+              class="sc-fzokOt bHylAC relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
               data-testid="SelectionBarOption"
               role="radio"
               type="button"
@@ -552,7 +552,7 @@ exports[`SendTransactionForm should select fill out form 1`] = `
             </button>
             <button
               aria-checked="true"
-              class="sc-fzokOt bHylAC relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+              class="sc-fzokOt bHylAC relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
               data-testid="SelectionBarOption"
               role="radio"
               type="button"
@@ -561,7 +561,7 @@ exports[`SendTransactionForm should select fill out form 1`] = `
             </button>
             <button
               aria-checked="false"
-              class="sc-fzokOt bHylAC relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+              class="sc-fzokOt bHylAC relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
               data-testid="SelectionBarOption"
               role="radio"
               type="button"

--- a/src/domains/transaction/components/SendTransactionForm/__snapshots__/SendTransactionForm.test.tsx.snap
+++ b/src/domains/transaction/components/SendTransactionForm/__snapshots__/SendTransactionForm.test.tsx.snap
@@ -55,7 +55,6 @@ exports[`SendTransactionForm should render 1`] = `
             autocomplete="off"
             class="sc-AxhCb biYFdn overflow-hidden w-full bg-theme-background appearance-none rounded border border-theme-neutral-300 text-theme-neutral-900 transition-colors duration-200 px-4 py-3 pl-15"
             data-testid="SelectNetworkInput__input"
-            disabled=""
             id="SendTransactionForm__network-input"
             placeholder="Enter a network name"
             value=""
@@ -72,7 +71,6 @@ exports[`SendTransactionForm should render 1`] = `
           aria-selected="false"
           class="inline-block cursor-pointer"
           data-testid="SelectNetwork__NetworkIcon--container"
-          disabled=""
           id="SendTransactionForm__network-item-0"
           role="option"
         >
@@ -97,7 +95,6 @@ exports[`SendTransactionForm should render 1`] = `
           aria-selected="false"
           class="inline-block cursor-pointer"
           data-testid="SelectNetwork__NetworkIcon--container"
-          disabled=""
           id="SendTransactionForm__network-item-1"
           role="option"
         >
@@ -143,9 +140,8 @@ exports[`SendTransactionForm should render 1`] = `
       >
         <div>
           <button
-            class="sc-fznZeY jUYMgc SelectAddress is-disabled "
+            class="sc-fznZeY jUYMgc SelectAddress  "
             data-testid="SelectAddress__wrapper"
-            disabled=""
             type="button"
           >
             <div
@@ -422,9 +418,8 @@ exports[`SendTransactionForm should select fill out form 1`] = `
       >
         <div>
           <button
-            class="sc-fznZeY jUYMgc SelectAddress is-disabled "
+            class="sc-fznZeY jUYMgc SelectAddress  "
             data-testid="SelectAddress__wrapper"
-            disabled=""
             type="button"
           >
             <div

--- a/src/domains/transaction/components/TransactionTable/TransactionRow/TransactionRowInfo.tsx
+++ b/src/domains/transaction/components/TransactionTable/TransactionRow/TransactionRowInfo.tsx
@@ -25,7 +25,7 @@ const MultiSignature = () => (
 );
 
 export const TransactionRowInfo = ({ transaction }: Props) => (
-	<div data-testid="TransactionRowInfo" className="inline-flex align-middle space-x-1">
+	<div data-testid="TransactionRowInfo" className="inline-flex space-x-1 align-middle">
 		{transaction?.isMultiSignature() && <MultiSignature />}
 		{transaction?.memo() && <VendorField vendorField={transaction?.memo()} />}
 	</div>

--- a/src/domains/transaction/components/TransactionTable/__snapshots__/TransactionTable.test.tsx.snap
+++ b/src/domains/transaction/components/TransactionTable/__snapshots__/TransactionTable.test.tsx.snap
@@ -162,7 +162,7 @@ exports[`TransactionTable should render 1`] = `
                 class="inline-block align-middle"
               >
                 <a
-                  class="sc-AxheI bALhgA inline-flex items-center font-semibold cursor-pointer transition-colors duration-200 text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+                  class="sc-AxheI bALhgA inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
                   data-testid="TransactionRow__ID"
                   rel="noopener noreferrer"
                   to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
@@ -242,7 +242,7 @@ exports[`TransactionTable should render 1`] = `
               class="text-center"
             >
               <div
-                class="inline-flex align-middle space-x-1"
+                class="inline-flex space-x-1 align-middle"
                 data-testid="TransactionRowInfo"
               >
                 <span
@@ -307,7 +307,7 @@ exports[`TransactionTable should render 1`] = `
                 class="inline-block align-middle"
               >
                 <a
-                  class="sc-AxheI bALhgA inline-flex items-center font-semibold cursor-pointer transition-colors duration-200 text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+                  class="sc-AxheI bALhgA inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
                   data-testid="TransactionRow__ID"
                   rel="noopener noreferrer"
                   to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
@@ -387,7 +387,7 @@ exports[`TransactionTable should render 1`] = `
               class="text-center"
             >
               <div
-                class="inline-flex align-middle space-x-1"
+                class="inline-flex space-x-1 align-middle"
                 data-testid="TransactionRowInfo"
               >
                 <span
@@ -3004,7 +3004,7 @@ exports[`TransactionTable should render with sign 1`] = `
                 class="inline-block align-middle"
               >
                 <a
-                  class="sc-AxheI bALhgA inline-flex items-center font-semibold cursor-pointer transition-colors duration-200 text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+                  class="sc-AxheI bALhgA inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
                   data-testid="TransactionRow__ID"
                   rel="noopener noreferrer"
                   to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
@@ -3084,7 +3084,7 @@ exports[`TransactionTable should render with sign 1`] = `
               class="text-center"
             >
               <div
-                class="inline-flex align-middle space-x-1"
+                class="inline-flex space-x-1 align-middle"
                 data-testid="TransactionRowInfo"
               >
                 <span
@@ -3172,7 +3172,7 @@ exports[`TransactionTable should render with sign 1`] = `
                 class="inline-block align-middle"
               >
                 <a
-                  class="sc-AxheI bALhgA inline-flex items-center font-semibold cursor-pointer transition-colors duration-200 text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+                  class="sc-AxheI bALhgA inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
                   data-testid="TransactionRow__ID"
                   rel="noopener noreferrer"
                   to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
@@ -3252,7 +3252,7 @@ exports[`TransactionTable should render with sign 1`] = `
               class="text-center"
             >
               <div
-                class="inline-flex align-middle space-x-1"
+                class="inline-flex space-x-1 align-middle"
                 data-testid="TransactionRowInfo"
               >
                 <span

--- a/src/domains/transaction/pages/SendEntityRegistration/__snapshots__/SendEntityRegistration.test.tsx.snap
+++ b/src/domains/transaction/pages/SendEntityRegistration/__snapshots__/SendEntityRegistration.test.tsx.snap
@@ -800,7 +800,7 @@ exports[`Registration should not have delegate option if wallet is a delegate 1`
                         </div>
                         <ul
                           aria-labelledby="SendTransactionForm__network-label"
-                          class="mt-6 grid grid-cols-6 gap-6"
+                          class="grid grid-cols-6 gap-6 mt-6"
                           id="SendTransactionForm__network-menu"
                           role="listbox"
                         >
@@ -1106,7 +1106,7 @@ exports[`Registration should not set fee if no fee options 1`] = `
         </div>
         <ul
           aria-labelledby="SendTransactionForm__network-label"
-          class="mt-6 grid grid-cols-6 gap-6"
+          class="grid grid-cols-6 gap-6 mt-6"
           id="SendTransactionForm__network-menu"
           role="listbox"
         >
@@ -1612,7 +1612,7 @@ exports[`Registration should not unregister fields when going back to step 2 onw
                         Make up a name and register your delegate online.
                       </div>
                       <div
-                        class="mt-4 grid grid-flow-row gap-2"
+                        class="grid grid-flow-row gap-2 mt-4"
                       >
                         <div
                           class="flex items-center py-6 true "
@@ -2488,7 +2488,7 @@ exports[`Registration should render 1st step 1`] = `
         </div>
         <ul
           aria-labelledby="SendTransactionForm__network-label"
-          class="mt-6 grid grid-cols-6 gap-6"
+          class="grid grid-cols-6 gap-6 mt-6"
           id="SendTransactionForm__network-menu"
           role="listbox"
         >
@@ -3152,7 +3152,7 @@ exports[`Registration should select registration type & show form 1`] = `
                               >
                                 <button
                                   aria-checked="true"
-                                  class="sc-fzoNJl gCmvhq relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+                                  class="sc-fzoNJl gCmvhq relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
                                   data-testid="SelectionBarOption"
                                   role="radio"
                                   type="button"
@@ -3161,7 +3161,7 @@ exports[`Registration should select registration type & show form 1`] = `
                                 </button>
                                 <button
                                   aria-checked="true"
-                                  class="sc-fzoNJl gCmvhq relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+                                  class="sc-fzoNJl gCmvhq relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
                                   data-testid="SelectionBarOption"
                                   role="radio"
                                   type="button"
@@ -3170,7 +3170,7 @@ exports[`Registration should select registration type & show form 1`] = `
                                 </button>
                                 <button
                                   aria-checked="true"
-                                  class="sc-fzoNJl gCmvhq relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+                                  class="sc-fzoNJl gCmvhq relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
                                   data-testid="SelectionBarOption"
                                   role="radio"
                                   type="button"
@@ -3692,7 +3692,7 @@ exports[`Registration should should go back and forth & correctly register field
                               >
                                 <button
                                   aria-checked="true"
-                                  class="sc-fzoNJl gCmvhq relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+                                  class="sc-fzoNJl gCmvhq relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
                                   data-testid="SelectionBarOption"
                                   role="radio"
                                   type="button"
@@ -3701,7 +3701,7 @@ exports[`Registration should should go back and forth & correctly register field
                                 </button>
                                 <button
                                   aria-checked="true"
-                                  class="sc-fzoNJl gCmvhq relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+                                  class="sc-fzoNJl gCmvhq relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
                                   data-testid="SelectionBarOption"
                                   role="radio"
                                   type="button"
@@ -3710,7 +3710,7 @@ exports[`Registration should should go back and forth & correctly register field
                                 </button>
                                 <button
                                   aria-checked="true"
-                                  class="sc-fzoNJl gCmvhq relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+                                  class="sc-fzoNJl gCmvhq relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
                                   data-testid="SelectionBarOption"
                                   role="radio"
                                   type="button"

--- a/src/domains/transaction/pages/SendEntityResignation/Step2.tsx
+++ b/src/domains/transaction/pages/SendEntityResignation/Step2.tsx
@@ -25,7 +25,7 @@ export const SecondStep = ({ senderWallet, delegate, fees }: StepProps) => {
 					{t("TRANSACTION.PAGE_RESIGN_REGISTRATION.SECOND_STEP.DESCRIPTION")}
 				</p>
 			</div>
-			<div className="mt-4 grid grid-flow-row gap-2">
+			<div className="grid grid-flow-row gap-2 mt-4">
 				<TransactionDetail
 					border={false}
 					label={t("TRANSACTION.NETWORK")}

--- a/src/domains/transaction/pages/SendEntityResignation/__snapshots__/SendEntityResignation.test.tsx.snap
+++ b/src/domains/transaction/pages/SendEntityResignation/__snapshots__/SendEntityResignation.test.tsx.snap
@@ -473,7 +473,7 @@ exports[`SendEntityResignation should render 1st step 1`] = `
                                     >
                                       <button
                                         aria-checked="true"
-                                        class="sc-fzoyTs chLCDw relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+                                        class="sc-fzoyTs chLCDw relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
                                         data-testid="SelectionBarOption"
                                         role="radio"
                                         type="button"
@@ -482,7 +482,7 @@ exports[`SendEntityResignation should render 1st step 1`] = `
                                       </button>
                                       <button
                                         aria-checked="true"
-                                        class="sc-fzoyTs chLCDw relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+                                        class="sc-fzoyTs chLCDw relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
                                         data-testid="SelectionBarOption"
                                         role="radio"
                                         type="button"
@@ -491,7 +491,7 @@ exports[`SendEntityResignation should render 1st step 1`] = `
                                       </button>
                                       <button
                                         aria-checked="true"
-                                        class="sc-fzoyTs chLCDw relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+                                        class="sc-fzoyTs chLCDw relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
                                         data-testid="SelectionBarOption"
                                         role="radio"
                                         type="button"
@@ -857,7 +857,7 @@ exports[`SendEntityResignation should render 2nd step 1`] = `
                         </p>
                       </div>
                       <div
-                        class="mt-4 grid grid-flow-row gap-2"
+                        class="grid grid-flow-row gap-2 mt-4"
                       >
                         <div
                           class="flex items-center py-6 true "

--- a/src/domains/transaction/pages/SendEntityUpdate/Step2.tsx
+++ b/src/domains/transaction/pages/SendEntityUpdate/Step2.tsx
@@ -40,7 +40,7 @@ export const SecondStep = () => {
 					{t("TRANSACTION.PAGE_UPDATE_REGISTRATION.SECOND_STEP.DESCRIPTION")}
 				</p>
 			</div>
-			<div className="mt-4 grid grid-flow-row">
+			<div className="grid grid-flow-row mt-4">
 				<TransactionDetail
 					border={false}
 					label={t("TRANSACTION.NETWORK")}

--- a/src/domains/transaction/pages/SendEntityUpdate/__snapshots__/SendEntityUpdate.test.tsx.snap
+++ b/src/domains/transaction/pages/SendEntityUpdate/__snapshots__/SendEntityUpdate.test.tsx.snap
@@ -613,7 +613,7 @@ exports[`SendEntityUpdate should render 1st step 1`] = `
                                   >
                                     <button
                                       aria-checked="false"
-                                      class="sc-fzqARJ fRqGEl relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+                                      class="sc-fzqARJ fRqGEl relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
                                       data-testid="SelectionBarOption"
                                       role="radio"
                                       type="button"
@@ -622,7 +622,7 @@ exports[`SendEntityUpdate should render 1st step 1`] = `
                                     </button>
                                     <button
                                       aria-checked="false"
-                                      class="sc-fzqARJ fRqGEl relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+                                      class="sc-fzqARJ fRqGEl relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
                                       data-testid="SelectionBarOption"
                                       role="radio"
                                       type="button"
@@ -631,7 +631,7 @@ exports[`SendEntityUpdate should render 1st step 1`] = `
                                     </button>
                                     <button
                                       aria-checked="false"
-                                      class="sc-fzqARJ fRqGEl relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+                                      class="sc-fzqARJ fRqGEl relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
                                       data-testid="SelectionBarOption"
                                       role="radio"
                                       type="button"
@@ -1001,7 +1001,7 @@ exports[`SendEntityUpdate should render 2nd step 1`] = `
                       </p>
                     </div>
                     <div
-                      class="mt-4 grid grid-flow-row"
+                      class="grid grid-flow-row mt-4"
                     >
                       <div
                         class="flex items-center py-6 true "
@@ -3059,7 +3059,7 @@ exports[`SendEntityUpdate should should go back 1`] = `
                                   >
                                     <button
                                       aria-checked="false"
-                                      class="sc-fzqARJ fRqGEl relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+                                      class="sc-fzqARJ fRqGEl relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
                                       data-testid="SelectionBarOption"
                                       role="radio"
                                       type="button"
@@ -3068,7 +3068,7 @@ exports[`SendEntityUpdate should should go back 1`] = `
                                     </button>
                                     <button
                                       aria-checked="false"
-                                      class="sc-fzqARJ fRqGEl relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+                                      class="sc-fzqARJ fRqGEl relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
                                       data-testid="SelectionBarOption"
                                       role="radio"
                                       type="button"
@@ -3077,7 +3077,7 @@ exports[`SendEntityUpdate should should go back 1`] = `
                                     </button>
                                     <button
                                       aria-checked="false"
-                                      class="sc-fzqARJ fRqGEl relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+                                      class="sc-fzqARJ fRqGEl relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
                                       data-testid="SelectionBarOption"
                                       role="radio"
                                       type="button"

--- a/src/domains/transaction/pages/SendIpfs/Step2.tsx
+++ b/src/domains/transaction/pages/SendIpfs/Step2.tsx
@@ -27,7 +27,7 @@ export const SecondStep = ({ wallet }: { wallet: ReadWriteWallet }) => {
 			<h1 className="mb-0">{t("TRANSACTION.PAGE_IPFS.SECOND_STEP.TITLE")}</h1>
 			<div className="text-theme-neutral-dark">{t("TRANSACTION.PAGE_IPFS.SECOND_STEP.DESCRIPTION")}</div>
 
-			<div className="mt-4 grid grid-flow-row gap-2">
+			<div className="grid grid-flow-row gap-2 mt-4">
 				<TransactionDetail
 					border={false}
 					label={t("TRANSACTION.NETWORK")}

--- a/src/domains/transaction/pages/SendIpfs/__snapshots__/SendIpfs.test.tsx.snap
+++ b/src/domains/transaction/pages/SendIpfs/__snapshots__/SendIpfs.test.tsx.snap
@@ -1000,7 +1000,6 @@ exports[`SendIpfs should render 1st step 1`] = `
                 autocomplete="off"
                 class="sc-fzplWN hjcjbm overflow-hidden w-full bg-theme-background appearance-none rounded border border-theme-neutral-300 text-theme-neutral-900 transition-colors duration-200 px-4 py-3 pl-15"
                 data-testid="SelectNetworkInput__input"
-                disabled=""
                 id="SendTransactionForm__network-input"
                 placeholder="Enter a network name"
                 value=""
@@ -1037,9 +1036,8 @@ exports[`SendIpfs should render 1st step 1`] = `
           >
             <div>
               <button
-                class="sc-fzqARJ dKMWCk SelectAddress is-disabled "
+                class="sc-fzqARJ dKMWCk SelectAddress  "
                 data-testid="SelectAddress__wrapper"
-                disabled=""
                 type="button"
               >
                 <div

--- a/src/domains/transaction/pages/SendIpfs/__snapshots__/SendIpfs.test.tsx.snap
+++ b/src/domains/transaction/pages/SendIpfs/__snapshots__/SendIpfs.test.tsx.snap
@@ -1008,7 +1008,7 @@ exports[`SendIpfs should render 1st step 1`] = `
           </div>
           <ul
             aria-labelledby="SendTransactionForm__network-label"
-            class="mt-6 grid grid-cols-6 gap-6"
+            class="grid grid-cols-6 gap-6 mt-6"
             id="SendTransactionForm__network-menu"
             role="listbox"
           />
@@ -1171,7 +1171,7 @@ exports[`SendIpfs should render 1st step 1`] = `
               >
                 <button
                   aria-checked="false"
-                  class="sc-fzqNqU lfdFBe relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+                  class="sc-fzqNqU lfdFBe relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
                   data-testid="SelectionBarOption"
                   role="radio"
                   type="button"
@@ -1180,7 +1180,7 @@ exports[`SendIpfs should render 1st step 1`] = `
                 </button>
                 <button
                   aria-checked="false"
-                  class="sc-fzqNqU lfdFBe relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+                  class="sc-fzqNqU lfdFBe relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
                   data-testid="SelectionBarOption"
                   role="radio"
                   type="button"
@@ -1189,7 +1189,7 @@ exports[`SendIpfs should render 1st step 1`] = `
                 </button>
                 <button
                   aria-checked="false"
-                  class="sc-fzqNqU lfdFBe relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+                  class="sc-fzqNqU lfdFBe relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
                   data-testid="SelectionBarOption"
                   role="radio"
                   type="button"
@@ -1222,7 +1222,7 @@ exports[`SendIpfs should render 2nd step 1`] = `
       Check the information again before voting
     </div>
     <div
-      class="mt-4 grid grid-flow-row gap-2"
+      class="grid grid-flow-row gap-2 mt-4"
     >
       <div
         class="flex items-center py-6 true "
@@ -2078,7 +2078,7 @@ exports[`SendIpfs should show an error if an invalid IPFS hash is entered 1`] = 
                           </div>
                           <ul
                             aria-labelledby="SendTransactionForm__network-label"
-                            class="mt-6 grid grid-cols-6 gap-6"
+                            class="grid grid-cols-6 gap-6 mt-6"
                             id="SendTransactionForm__network-menu"
                             role="listbox"
                           >
@@ -2319,7 +2319,7 @@ exports[`SendIpfs should show an error if an invalid IPFS hash is entered 1`] = 
                               >
                                 <button
                                   aria-checked="false"
-                                  class="sc-fzqNqU lfdFBe relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+                                  class="sc-fzqNqU lfdFBe relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
                                   data-testid="SelectionBarOption"
                                   role="radio"
                                   type="button"
@@ -2328,7 +2328,7 @@ exports[`SendIpfs should show an error if an invalid IPFS hash is entered 1`] = 
                                 </button>
                                 <button
                                   aria-checked="true"
-                                  class="sc-fzqNqU lfdFBe relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+                                  class="sc-fzqNqU lfdFBe relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
                                   data-testid="SelectionBarOption"
                                   role="radio"
                                   type="button"
@@ -2337,7 +2337,7 @@ exports[`SendIpfs should show an error if an invalid IPFS hash is entered 1`] = 
                                 </button>
                                 <button
                                   aria-checked="false"
-                                  class="sc-fzqNqU lfdFBe relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+                                  class="sc-fzqNqU lfdFBe relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
                                   data-testid="SelectionBarOption"
                                   role="radio"
                                   type="button"

--- a/src/domains/transaction/pages/SendTransfer/SendTransfer.test.tsx
+++ b/src/domains/transaction/pages/SendTransfer/SendTransfer.test.tsx
@@ -155,6 +155,90 @@ describe("Transaction Send", () => {
 		expect(asFragment()).toMatchSnapshot();
 	});
 
+	it("should render registration form without selected wallet", async () => {
+		const history = createMemoryHistory();
+		let rendered: RenderResult;
+
+		const transferURL = `/profiles/${fixtureProfileId}/send-transfer`;
+		history.push(transferURL);
+
+		await act(async () => {
+			rendered = renderWithRouter(
+				<Route path="/profiles/:profileId/send-transfer">
+					<SendTransfer />
+				</Route>,
+				{
+					routes: [transferURL],
+					history,
+				},
+			);
+
+			await waitFor(() => expect(rendered.getByTestId("SendTransfer__step--first")).toBeTruthy());
+		});
+
+		expect(rendered.asFragment()).toMatchSnapshot();
+	});
+
+	it("should select network first and see select address input clickable", async () => {
+		const history = createMemoryHistory();
+		let rendered: RenderResult;
+
+		const transferURL = `/profiles/${fixtureProfileId}/send-transfer`;
+		history.push(transferURL);
+
+		await act(async () => {
+			rendered = renderWithRouter(
+				<Route path="/profiles/:profileId/send-transfer">
+					<SendTransfer />
+				</Route>,
+				{
+					routes: [transferURL],
+					history,
+				},
+			);
+
+			await waitFor(() => expect(rendered.getByTestId("SendTransfer__step--first")).toBeTruthy());
+		});
+
+		act(() => {
+			fireEvent.click(rendered.getByTestId("NetworkIcon-ARK-devnet"));
+		});
+
+		expect(rendered.getByTestId("SelectNetworkInput__network")).toHaveAttribute("aria-label", "Ark Devnet");
+		expect(rendered.getByTestId("SelectAddress__wrapper")).not.toHaveAttribute("disabled");
+		expect(rendered.asFragment()).toMatchSnapshot();
+	});
+
+	it("should display disabled address selection input if selected network has not available wallets", async () => {
+		const history = createMemoryHistory();
+		let rendered: RenderResult;
+
+		const transferURL = `/profiles/${fixtureProfileId}/send-transfer`;
+		history.push(transferURL);
+
+		await act(async () => {
+			rendered = renderWithRouter(
+				<Route path="/profiles/:profileId/send-transfer">
+					<SendTransfer />
+				</Route>,
+				{
+					routes: [transferURL],
+					history,
+				},
+			);
+
+			await waitFor(() => expect(rendered.getByTestId("SendTransfer__step--first")).toBeTruthy());
+		});
+
+		act(() => {
+			fireEvent.click(rendered.getByTestId("NetworkIcon-ARK-mainnet"));
+		});
+
+		expect(rendered.getByTestId("SelectNetworkInput__network")).toHaveAttribute("aria-label", "Ark");
+		expect(rendered.getByTestId("SelectAddress__wrapper")).toHaveAttribute("disabled");
+		expect(rendered.asFragment()).toMatchSnapshot();
+	});
+
 	it("should send a single transfer", async () => {
 		const history = createMemoryHistory();
 		const transferURL = `/profiles/${fixtureProfileId}/transactions/${wallet.id()}/transfer`;

--- a/src/domains/transaction/pages/SendTransfer/SendTransfer.tsx
+++ b/src/domains/transaction/pages/SendTransfer/SendTransfer.tsx
@@ -43,6 +43,10 @@ export const SendTransfer = () => {
 		register("senderAddress", { required: true });
 		register("fee", { required: true });
 		register("smartbridge");
+	}, [register]);
+
+	useEffect(() => {
+		if (!activeWallet?.address?.()) return;
 
 		setValue("senderAddress", activeWallet.address(), true);
 
@@ -53,7 +57,7 @@ export const SendTransfer = () => {
 				break;
 			}
 		}
-	}, [activeWallet, networks, register, setValue]);
+	}, [activeWallet, networks, setValue]);
 
 	const submitForm = async () => {
 		clearError("mnemonic");

--- a/src/domains/transaction/pages/SendTransfer/Step2.tsx
+++ b/src/domains/transaction/pages/SendTransfer/Step2.tsx
@@ -37,7 +37,7 @@ export const SecondStep = ({ wallet }: { wallet: ReadWriteWallet }) => {
 				</div>
 			</div>
 
-			<div className="mt-4 grid grid-flow-row gap-2">
+			<div className="grid grid-flow-row gap-2 mt-4">
 				<TransactionDetail
 					border={false}
 					label={t("TRANSACTION.NETWORK")}

--- a/src/domains/transaction/pages/SendTransfer/__snapshots__/SendTransfer.test.tsx.snap
+++ b/src/domains/transaction/pages/SendTransfer/__snapshots__/SendTransfer.test.tsx.snap
@@ -1,5 +1,846 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Transaction Send should display disabled address selection input if selected network has not available wallets 1`] = `
+<DocumentFragment>
+  <div
+    class="relative flex flex-col min-h-screen bg-theme-neutral-contrast"
+  >
+    <nav
+      aria-labelledby="main menu"
+      class="sc-fzoLag gnHGCp"
+    >
+      <div
+        class="px-4 sm:px-6 lg:px-10"
+      >
+        <div
+          class="relative flex justify-between h-20 md:h-24"
+        >
+          <div
+            class="flex items-center my-auto"
+          >
+            <div
+              class="sc-fzoXzr cumsaa"
+            >
+              <svg
+                width="40"
+              >
+                ark-logo.svg
+              </svg>
+            </div>
+          </div>
+          <ul
+            class="flex h-20 mr-auto md:h-24"
+          >
+            <li
+              class="flex"
+            >
+              <a
+                class="flex items-center mx-4 font-semibold transition-colors duration-200 text-md text-theme-neutral-dark hover:text-theme-neutral-900"
+                href="/profiles/b999d134-7a24-481e-a95d-bc47c543bfc9/dashboard"
+                title="Portfolio"
+              >
+                Portfolio
+              </a>
+            </li>
+            <li
+              class="flex"
+            >
+              <a
+                class="flex items-center mx-4 font-semibold transition-colors duration-200 text-md text-theme-neutral-dark hover:text-theme-neutral-900"
+                href="/profiles/b999d134-7a24-481e-a95d-bc47c543bfc9/plugins"
+                title="Plugins"
+              >
+                Plugins
+              </a>
+            </li>
+            <li
+              class="flex"
+            >
+              <a
+                class="flex items-center mx-4 font-semibold transition-colors duration-200 text-md text-theme-neutral-dark hover:text-theme-neutral-900"
+                href="/profiles/b999d134-7a24-481e-a95d-bc47c543bfc9/exchange"
+                title="Exchange"
+              >
+                Exchange
+              </a>
+            </li>
+            <li
+              class="flex"
+            >
+              <a
+                class="flex items-center mx-4 font-semibold transition-colors duration-200 text-md text-theme-neutral-dark hover:text-theme-neutral-900"
+                href="/profiles/b999d134-7a24-481e-a95d-bc47c543bfc9/news"
+                title="News"
+              >
+                News
+              </a>
+            </li>
+          </ul>
+          <div
+            class="flex items-center my-auto space-x-4"
+          >
+            <div
+              class="relative"
+              data-testid="dropdown__toggle"
+            >
+              <div
+                class="overflow-hidden rounded-lg"
+              >
+                <button
+                  class="sc-AxjAm goVygI text-theme-primary-300 hover:text-theme-primary-700 hover:bg-theme-primary-50"
+                  color="primary"
+                  data-testid="navbar__buttons--notifications"
+                  type="button"
+                >
+                  <div
+                    class="sc-AxiKw fFXzuz p-1"
+                    height="22"
+                    width="22"
+                  >
+                    <svg>
+                      notification.svg
+                    </svg>
+                  </div>
+                </button>
+              </div>
+            </div>
+            <div
+              class="h-8 border-r border-theme-neutral-200"
+            />
+            <div
+              class="flex items-center overflow-hidden rounded-lg"
+            >
+              <button
+                class="sc-AxjAm goVygI text-theme-primary-300 hover:text-theme-primary-dark hover:bg-theme-primary-50"
+                color="primary"
+                data-testid="navbar__buttons--send"
+                type="button"
+              >
+                <div
+                  class="sc-AxiKw fFXzuz p-1"
+                  height="22"
+                  width="22"
+                >
+                  <svg>
+                    sent.svg
+                  </svg>
+                </div>
+              </button>
+            </div>
+            <div
+              class="h-8 border-r border-theme-neutral-200"
+            />
+            <div
+              class="flex items-center overflow-hidden rounded-lg"
+            >
+              <button
+                class="sc-AxjAm goVygI text-theme-primary-300 hover:text-theme-primary-dark hover:bg-theme-primary-50"
+                color="primary"
+                data-testid="navbar__buttons--receive"
+                type="button"
+              >
+                <div
+                  class="sc-AxiKw fFXzuz p-1"
+                  height="22"
+                  width="22"
+                >
+                  <svg>
+                    receive.svg
+                  </svg>
+                </div>
+              </button>
+            </div>
+            <div
+              class="h-8 border-r border-theme-neutral-200"
+            />
+          </div>
+          <div
+            class="flex items-center my-auto ml-8 mr-4"
+          >
+            <div
+              class="text-right"
+            >
+              <div
+                class="text-xs font-medium text-theme-neutral"
+              >
+                Your balance
+              </div>
+              <div
+                class="text-sm font-bold text-theme-neutral-dark"
+              >
+                <span
+                  data-testid="Amount"
+                >
+                  91.43089801 BTC
+                </span>
+              </div>
+            </div>
+            <div
+              class="relative"
+              data-testid="dropdown__toggle"
+            >
+              <div
+                class="ml-4 cursor-pointer"
+                data-testid="navbar__useractions"
+              >
+                <div
+                  class="sc-AxgMl daFHdi -mr-2 border-theme-primary-contrast"
+                >
+                  <span
+                    class="text-theme-neutral-dark"
+                  >
+                    <div
+                      class="sc-AxiKw dzBdqj"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        btc.svg
+                      </svg>
+                    </div>
+                  </span>
+                </div>
+                <div
+                  class="relative inline-flex items-center justify-center align-middle rounded-full"
+                  data-testid="navbar__user--avatar"
+                >
+                  <div
+                    class="Avatar__AvatarWrapper-sc-1vsy2s2-0 fGjnTn"
+                  >
+                    <img
+                      alt="Profile Avatar"
+                      src="data:image/svg+xml;utf8,<svg version=\\"1.1\\" xmlns=\\"http://www.w3.org/2000/svg\\" width=\\"100\\" height=\\"100\\" viewBox=\\"0 0 100 100\\"><style>circle{mix-blend-mode:soft-light;}</style><rect fill=\\"rgb(233, 30, 99)\\" width=\\"100\\" height=\\"100\\"/><circle r=\\"45\\" cx=\\"80\\" cy=\\"30\\" fill=\\"rgb(76, 175, 80)\\"/><circle r=\\"55\\" cx=\\"0\\" cy=\\"60\\" fill=\\"rgb(255, 152, 0)\\"/><circle r=\\"40\\" cx=\\"50\\" cy=\\"50\\" fill=\\"rgb(3, 169, 244)\\"/></svg>"
+                    />
+                    <span
+                      class="absolute text-sm font-semibold text-theme-background"
+                    >
+                      JO
+                    </span>
+                  </div>
+                  <span
+                    class="sc-AxhUy kTPsmA flex border-2 rounded-full justify-center w-5 h-5 items-center align-middle bg-theme-background border-transparent bg-theme-primary-contrast border-theme-primary-contrast text-theme-primary-500"
+                  >
+                    <div
+                      class="sc-AxiKw ksjdLL"
+                      height="10"
+                      width="10"
+                    >
+                      <svg>
+                        chevron-down.svg
+                      </svg>
+                    </div>
+                    <span />
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </nav>
+    <div
+      class="flex items-center space-x-2 container py-5 mx-auto font-semibold px-14 text-theme-neutral-dark"
+      data-testid="breadcrumbs__wrapper"
+    >
+      <div
+        class="sc-AxiKw bGpsrC"
+        height="10"
+        width="19"
+      >
+        <svg>
+          arrow-back.svg
+        </svg>
+      </div>
+      <div
+        class="space-x-2"
+      >
+        <a
+          class="text-theme-neutral-dark"
+          href="/profiles/b999d134-7a24-481e-a95d-bc47c543bfc9/dashboard"
+        >
+          <span>
+            Go back to Portfolio
+          </span>
+        </a>
+      </div>
+    </div>
+    <div
+      class="flex flex-col flex-1 space-y-5 "
+    >
+      <div
+        class="sc-fzpjYC deOkAw flex-1"
+      >
+        <div
+          class="container py-16 mx-auto px-14"
+        >
+          <form
+            class="max-w-xl mx-auto"
+            data-testid="Form"
+          >
+            <div>
+              <ul
+                class="sc-fznJRM kDmVaQ"
+              >
+                <li
+                  class="sc-fznxsB keKrAv"
+                />
+                <li
+                  class="sc-fznxsB exHzky"
+                />
+                <li
+                  class="sc-fznxsB exHzky"
+                />
+                <li
+                  class="sc-fznxsB exHzky"
+                />
+                <li
+                  class="sc-fznxsB exHzky"
+                />
+              </ul>
+              <div
+                class="mt-8"
+              >
+                <div
+                  data-testid="tab-pabel__active-panel"
+                >
+                  <section
+                    data-testid="SendTransfer__step--first"
+                  >
+                    <div>
+                      <h1
+                        class="mb-0"
+                      >
+                        Send
+                      </h1>
+                      <div
+                        class="text-theme-neutral-dark"
+                      >
+                        Enter details to send your money
+                      </div>
+                    </div>
+                    <div
+                      class="mt-8"
+                    >
+                      <div
+                        class="space-y-8 SendTransactionForm"
+                      >
+                        <fieldset
+                          class="sc-AxirZ izhStr relative"
+                        >
+                          <div
+                            class="mb-2"
+                          >
+                            <label
+                              class="flex inline-block mb-2 text-sm font-semibold transition-colors duration-100 FormLabel text-theme-neutral-dark"
+                              data-testid="FormLabel"
+                              for="network"
+                            >
+                              Network
+                              <div
+                                class="w-1 h-1 mt-1 ml-1 rounded-full bg-theme-danger-400"
+                                data-testid="FormLabel__required"
+                              />
+                            </label>
+                          </div>
+                          <div
+                            aria-expanded="false"
+                            aria-haspopup="listbox"
+                            aria-owns="SendTransactionForm__network-menu"
+                            data-testid="SelectNetwork"
+                            role="combobox"
+                          >
+                            <label
+                              for="SendTransactionForm__network-input"
+                              id="SendTransactionForm__network-label"
+                            />
+                            <div
+                              class="sc-fzokOt feJGYk"
+                              data-testid="SelectNetworkInput"
+                            >
+                              <div
+                                class="sc-fznyAO sc-fznKkj dKbLCT px-4"
+                              >
+                                <div
+                                  aria-label="Ark"
+                                  class="sc-AxgMl hdkviZ border-theme-danger-light text-theme-danger-400"
+                                  data-testid="SelectNetworkInput__network"
+                                >
+                                  <div
+                                    class="sc-AxiKw dzBdqj"
+                                    data-testid="NetworkIcon__icon"
+                                    height="1em"
+                                    width="1em"
+                                  >
+                                    <svg>
+                                      ark.svg
+                                    </svg>
+                                  </div>
+                                </div>
+                              </div>
+                              <input
+                                aria-autocomplete="list"
+                                aria-controls="SendTransactionForm__network-menu"
+                                aria-labelledby="SendTransactionForm__network-label"
+                                autocomplete="off"
+                                class="sc-fzplWN hjcjbm overflow-hidden w-full bg-theme-background appearance-none rounded border border-theme-neutral-300 text-theme-neutral-900 transition-colors duration-200 px-4 py-3 pl-15"
+                                data-testid="SelectNetworkInput__input"
+                                id="SendTransactionForm__network-input"
+                                placeholder="Enter a network name"
+                                value="Ark"
+                              />
+                            </div>
+                          </div>
+                          <ul
+                            aria-labelledby="SendTransactionForm__network-label"
+                            class="mt-6 grid grid-cols-6 gap-6"
+                            id="SendTransactionForm__network-menu"
+                            role="listbox"
+                          >
+                            <li
+                              aria-selected="false"
+                              class="inline-block cursor-pointer"
+                              data-testid="SelectNetwork__NetworkIcon--container"
+                              id="SendTransactionForm__network-item-0"
+                              role="option"
+                            >
+                              <div
+                                aria-label="Ark"
+                                class="sc-AxgMl eikNkl text-theme-success-500 border-theme-success-200"
+                                data-testid="NetworkIcon-ARK-mainnet"
+                              >
+                                <div
+                                  class="sc-AxiKw fubePL"
+                                  data-testid="NetworkIcon__icon"
+                                  height="26"
+                                  width="26"
+                                >
+                                  <svg>
+                                    ark.svg
+                                  </svg>
+                                </div>
+                              </div>
+                            </li>
+                            <li
+                              aria-selected="false"
+                              class="inline-block cursor-pointer"
+                              data-testid="SelectNetwork__NetworkIcon--container"
+                              id="SendTransactionForm__network-item-1"
+                              role="option"
+                            >
+                              <div
+                                aria-label="Ark Devnet"
+                                class="sc-AxgMl eikNkl text-theme-neutral-light"
+                                data-testid="NetworkIcon-ARK-devnet"
+                              >
+                                <div
+                                  class="sc-AxiKw fubePL"
+                                  data-testid="NetworkIcon__icon"
+                                  height="26"
+                                  width="26"
+                                >
+                                  <svg>
+                                    ark.svg
+                                  </svg>
+                                </div>
+                              </div>
+                            </li>
+                          </ul>
+                        </fieldset>
+                        <fieldset
+                          class="sc-AxirZ izhStr relative"
+                        >
+                          <div
+                            class="mb-2"
+                          >
+                            <label
+                              class="flex inline-block mb-2 text-sm font-semibold transition-colors duration-100 FormLabel text-theme-neutral-dark"
+                              data-testid="FormLabel"
+                              for="senderAddress"
+                            >
+                              Sender
+                              <div
+                                class="w-1 h-1 mt-1 ml-1 rounded-full bg-theme-danger-400"
+                                data-testid="FormLabel__required"
+                              />
+                            </label>
+                          </div>
+                          <div
+                            data-testid="sender-address"
+                          >
+                            <div>
+                              <button
+                                class="sc-fzoyTs bPtMIB SelectAddress is-disabled "
+                                data-testid="SelectAddress__wrapper"
+                                disabled=""
+                                type="button"
+                              >
+                                <div
+                                  class="sc-AxgMl hdkviZ mx-4 bg-theme-neutral-200 border-theme-neutral-200"
+                                />
+                                <div
+                                  class="absolute flex items-center space-x-3 right-4"
+                                >
+                                  <div
+                                    class="sc-AxiKw dklFyP"
+                                    height="20"
+                                    width="20"
+                                  >
+                                    <svg>
+                                      user.svg
+                                    </svg>
+                                  </div>
+                                </div>
+                              </button>
+                              <input
+                                class="sc-fzplWN hjcjbm overflow-hidden w-full bg-theme-background appearance-none rounded border border-theme-neutral-300 text-theme-neutral-900 transition-colors duration-200 px-4 py-3 hidden"
+                                data-testid="SelectAddress__input"
+                                name="senderAddress"
+                                readonly=""
+                                type="text"
+                                value=""
+                              />
+                            </div>
+                          </div>
+                        </fieldset>
+                        <div
+                          data-testid="recipient-address"
+                        >
+                          <div
+                            class="sc-fzqNqU dODLJr"
+                          >
+                            <div
+                              class="text-theme-neutral-dark hover:text-theme-primary"
+                            >
+                              <div
+                                class="flex items-center mb-2 space-x-2"
+                              >
+                                <div
+                                  class="font-normal transition-colors duration-100 text-md"
+                                >
+                                  Select a Single or Multiple Recipient Transaction
+                                </div>
+                                <div>
+                                  <div
+                                    class="rounded-full cursor-pointer text-theme-primary-600 hover:text-theme-primary-100 questionmark"
+                                  >
+                                    <div
+                                      class="sc-AxiKw dklFyP"
+                                      height="20"
+                                      width="20"
+                                    >
+                                      <svg>
+                                        questionmark.svg
+                                      </svg>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                              <div
+                                class="flex items-stretch select-buttons"
+                              >
+                                <button
+                                  class="sc-AxjAm kbZyZT flex-1"
+                                  color="primary"
+                                  data-testid="add-recipient-is-single-toggle"
+                                  type="button"
+                                >
+                                  Single
+                                </button>
+                                <button
+                                  class="sc-AxjAm fPpool flex-1 border-l-0"
+                                  color="primary"
+                                  data-testid="add-recipient-is-multiple-toggle"
+                                  type="button"
+                                >
+                                  Multiple
+                                </button>
+                              </div>
+                            </div>
+                            <div
+                              class="SubForm__SubFormWrapper-c4tqfs-0 gIKSHW mt-6"
+                            >
+                              <div
+                                class="space-y-8"
+                              >
+                                <fieldset
+                                  class="sc-AxirZ izhStr relative mt-1"
+                                >
+                                  <div
+                                    class="mb-2"
+                                  >
+                                    <label
+                                      class="flex inline-block mb-2 text-sm font-semibold transition-colors duration-100 FormLabel text-theme-neutral-dark"
+                                      data-testid="FormLabel"
+                                      for="recipientAddress"
+                                    >
+                                      Recipient
+                                      <div
+                                        class="w-1 h-1 mt-1 ml-1 rounded-full bg-theme-danger-400"
+                                        data-testid="FormLabel__required"
+                                      />
+                                    </label>
+                                  </div>
+                                  <div>
+                                    <div
+                                      class="relative flex items-center w-full text-left"
+                                      data-testid="SelectRecipient__wrapper"
+                                    >
+                                      <div
+                                        class="absolute left-1"
+                                      >
+                                        <div
+                                          class="sc-AxgMl hdkviZ mx-3 bg-theme-neutral-200 border-theme-neutral-200"
+                                        />
+                                      </div>
+                                      <input
+                                        class="sc-fzplWN hjcjbm overflow-hidden w-full bg-theme-background appearance-none rounded border border-theme-neutral-300 text-theme-neutral-900 transition-colors duration-200 px-4 py-3 pl-14 pr-11"
+                                        data-testid="SelectRecipient__input"
+                                        name="recipientAddress"
+                                        type="text"
+                                        value=""
+                                      />
+                                      <div
+                                        class="absolute flex items-center cursor-pointer right-4 space-x-3"
+                                        data-testid="SelectRecipient__select-contact"
+                                      >
+                                        <div
+                                          class="sc-AxiKw dklFyP"
+                                          height="20"
+                                          width="20"
+                                        >
+                                          <svg>
+                                            user.svg
+                                          </svg>
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </div>
+                                </fieldset>
+                                <fieldset
+                                  class="sc-AxirZ izhStr relative mt-1"
+                                >
+                                  <div
+                                    class="mb-2"
+                                  >
+                                    <label
+                                      class="flex inline-block mb-2 text-sm font-semibold transition-colors duration-100 FormLabel text-theme-neutral-dark"
+                                      data-testid="FormLabel"
+                                      for="amount"
+                                    >
+                                      Amount
+                                      <div
+                                        class="w-1 h-1 mt-1 ml-1 rounded-full bg-theme-danger-400"
+                                        data-testid="FormLabel__required"
+                                      />
+                                    </label>
+                                  </div>
+                                  <div
+                                    class="sc-fzokOt feJGYk"
+                                  >
+                                    <input
+                                      class="sc-fzplWN hjcjbm overflow-hidden w-full bg-theme-background appearance-none rounded border border-theme-neutral-300 text-theme-neutral-900 transition-colors duration-200 px-4 py-3 pr-20"
+                                      data-testid="add-recipient__amount-input"
+                                      name="amount"
+                                      placeholder="Amount"
+                                      type="number"
+                                      value="0"
+                                    />
+                                    <div
+                                      class="sc-fznyAO sc-fznZeY dZgvBo"
+                                    >
+                                      <button
+                                        class="h-12 pl-6 pr-3 mr-1 text-theme-primary focus:outline-none"
+                                        data-testid="add-recipient__send-all"
+                                        type="button"
+                                      >
+                                        Send All
+                                      </button>
+                                    </div>
+                                  </div>
+                                </fieldset>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                        <fieldset
+                          class="sc-AxirZ izhStr relative"
+                        >
+                          <div
+                            class="mb-2"
+                          >
+                            <label
+                              class="flex inline-block mb-2 text-sm font-semibold transition-colors duration-100 FormLabel text-theme-neutral-dark"
+                              data-testid="FormLabel"
+                              for="smartbridge"
+                            >
+                              Smartbridge
+                              <div
+                                class="w-1 h-1 mt-1 ml-1 rounded-full bg-theme-danger-400"
+                                data-testid="FormLabel__required"
+                              />
+                            </label>
+                          </div>
+                          <div
+                            class="sc-fzokOt feJGYk"
+                          >
+                            <input
+                              class="sc-fzplWN hjcjbm overflow-hidden w-full bg-theme-background appearance-none rounded border border-theme-neutral-300 text-theme-neutral-900 transition-colors duration-200 px-4 py-3 pr-24"
+                              data-testid="Input__smartbridge"
+                              maxlength="255"
+                              name="smartbridge"
+                              placeholder=" "
+                              type="text"
+                              value=""
+                            />
+                            <div
+                              class="sc-fznyAO sc-fznZeY dZgvBo"
+                            >
+                              <button
+                                class="px-4 text-theme-neutral-light focus:outline-none"
+                                type="button"
+                              >
+                                255 Max
+                              </button>
+                            </div>
+                          </div>
+                        </fieldset>
+                        <fieldset
+                          class="sc-AxirZ izhStr flex flex-col space-y-2"
+                        >
+                          <label
+                            class="flex inline-block mb-2 text-sm font-semibold transition-colors duration-100 FormLabel text-theme-neutral-dark"
+                            data-testid="FormLabel"
+                            for="fee"
+                          >
+                            Transaction Fee
+                            <div
+                              class="w-1 h-1 mt-1 ml-1 rounded-full bg-theme-danger-400"
+                              data-testid="FormLabel__required"
+                            />
+                          </label>
+                          <div
+                            class="flex space-x-2"
+                            data-testid="InputFee"
+                          >
+                            <div
+                              class="flex-1"
+                            >
+                              <div
+                                class="sc-fzokOt feJGYk"
+                              >
+                                <input
+                                  class="sc-fzplWN hjcjbm overflow-hidden w-full bg-theme-background appearance-none rounded border border-theme-neutral-300 text-theme-neutral-900 transition-colors duration-200 px-4 py-3 "
+                                  data-testid="InputCurrency"
+                                  name="fee"
+                                  type="text"
+                                  value="0"
+                                />
+                                <div
+                                  class="absolute bottom-0 w-full px-1"
+                                >
+                                  <div
+                                    class="flex flex-wrap justify-center"
+                                    data-testid="Range"
+                                  >
+                                    <div
+                                      class="sc-fzqBZW jucamx"
+                                      data-testid="Range__track"
+                                      style="transform: scale(1); cursor: pointer;"
+                                    >
+                                      <div
+                                        class="sc-fzqNJr eNfzLl"
+                                        data-testid="Range__track__filled"
+                                      >
+                                        <div
+                                          aria-valuemax="2e-8"
+                                          aria-valuemin="0"
+                                          aria-valuenow="0"
+                                          class="sc-fzoyAV eFJKNt"
+                                          data-testid="Range__thumb"
+                                          draggable="false"
+                                          role="slider"
+                                          style="position: absolute; z-index: 0; cursor: grab; user-select: none; transform: translate(0px, 0px);"
+                                          tabindex="0"
+                                        />
+                                      </div>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                            <div>
+                              <div
+                                class="inline-flex items-center flex-shrink-0 overflow-hidden border rounded border-theme-neutral-300"
+                                data-testid="SelectionBar"
+                                role="radiogroup"
+                              >
+                                <button
+                                  aria-checked="false"
+                                  class="sc-fzoNJl gCmvhq relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+                                  data-testid="SelectionBarOption"
+                                  role="radio"
+                                  type="button"
+                                >
+                                  Min
+                                </button>
+                                <button
+                                  aria-checked="false"
+                                  class="sc-fzoNJl gCmvhq relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+                                  data-testid="SelectionBarOption"
+                                  role="radio"
+                                  type="button"
+                                >
+                                  Average
+                                </button>
+                                <button
+                                  aria-checked="false"
+                                  class="sc-fzoNJl gCmvhq relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+                                  data-testid="SelectionBarOption"
+                                  role="radio"
+                                  type="button"
+                                >
+                                  Max
+                                </button>
+                              </div>
+                            </div>
+                          </div>
+                        </fieldset>
+                      </div>
+                    </div>
+                  </section>
+                </div>
+                <div
+                  class="flex justify-end mt-10 space-x-3"
+                >
+                  <button
+                    class="sc-AxjAm fPpool"
+                    color="primary"
+                    data-testid="SendTransfer__button--back"
+                    disabled=""
+                    type="button"
+                  >
+                    Back
+                  </button>
+                  <button
+                    class="sc-AxjAm kbZyZT"
+                    color="primary"
+                    data-testid="SendTransfer__button--continue"
+                    disabled=""
+                    type="button"
+                  >
+                    Continue
+                  </button>
+                </div>
+              </div>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`Transaction Send should error if wrong mnemonic 1`] = `
 <div>
   <div
@@ -477,7 +1318,6 @@ exports[`Transaction Send should render 1st step 1`] = `
                 autocomplete="off"
                 class="sc-fzplWN hjcjbm overflow-hidden w-full bg-theme-background appearance-none rounded border border-theme-neutral-300 text-theme-neutral-900 transition-colors duration-200 px-4 py-3 pl-15"
                 data-testid="SelectNetworkInput__input"
-                disabled=""
                 id="SendTransactionForm__network-input"
                 placeholder="Enter a network name"
                 value=""
@@ -514,9 +1354,8 @@ exports[`Transaction Send should render 1st step 1`] = `
           >
             <div>
               <button
-                class="sc-fzoyTs bPtMIB SelectAddress is-disabled "
+                class="sc-fzoyTs bPtMIB SelectAddress  "
                 data-testid="SelectAddress__wrapper"
-                disabled=""
                 type="button"
               >
                 <div
@@ -1543,6 +2382,1680 @@ exports[`Transaction Send should render 5th step 1`] = `
       </div>
     </div>
   </section>
+</DocumentFragment>
+`;
+
+exports[`Transaction Send should render registration form without selected wallet 1`] = `
+<DocumentFragment>
+  <div
+    class="relative flex flex-col min-h-screen bg-theme-neutral-contrast"
+  >
+    <nav
+      aria-labelledby="main menu"
+      class="sc-fzoLag gnHGCp"
+    >
+      <div
+        class="px-4 sm:px-6 lg:px-10"
+      >
+        <div
+          class="relative flex justify-between h-20 md:h-24"
+        >
+          <div
+            class="flex items-center my-auto"
+          >
+            <div
+              class="sc-fzoXzr cumsaa"
+            >
+              <svg
+                width="40"
+              >
+                ark-logo.svg
+              </svg>
+            </div>
+          </div>
+          <ul
+            class="flex h-20 mr-auto md:h-24"
+          >
+            <li
+              class="flex"
+            >
+              <a
+                class="flex items-center mx-4 font-semibold transition-colors duration-200 text-md text-theme-neutral-dark hover:text-theme-neutral-900"
+                href="/profiles/b999d134-7a24-481e-a95d-bc47c543bfc9/dashboard"
+                title="Portfolio"
+              >
+                Portfolio
+              </a>
+            </li>
+            <li
+              class="flex"
+            >
+              <a
+                class="flex items-center mx-4 font-semibold transition-colors duration-200 text-md text-theme-neutral-dark hover:text-theme-neutral-900"
+                href="/profiles/b999d134-7a24-481e-a95d-bc47c543bfc9/plugins"
+                title="Plugins"
+              >
+                Plugins
+              </a>
+            </li>
+            <li
+              class="flex"
+            >
+              <a
+                class="flex items-center mx-4 font-semibold transition-colors duration-200 text-md text-theme-neutral-dark hover:text-theme-neutral-900"
+                href="/profiles/b999d134-7a24-481e-a95d-bc47c543bfc9/exchange"
+                title="Exchange"
+              >
+                Exchange
+              </a>
+            </li>
+            <li
+              class="flex"
+            >
+              <a
+                class="flex items-center mx-4 font-semibold transition-colors duration-200 text-md text-theme-neutral-dark hover:text-theme-neutral-900"
+                href="/profiles/b999d134-7a24-481e-a95d-bc47c543bfc9/news"
+                title="News"
+              >
+                News
+              </a>
+            </li>
+          </ul>
+          <div
+            class="flex items-center my-auto space-x-4"
+          >
+            <div
+              class="relative"
+              data-testid="dropdown__toggle"
+            >
+              <div
+                class="overflow-hidden rounded-lg"
+              >
+                <button
+                  class="sc-AxjAm goVygI text-theme-primary-300 hover:text-theme-primary-700 hover:bg-theme-primary-50"
+                  color="primary"
+                  data-testid="navbar__buttons--notifications"
+                  type="button"
+                >
+                  <div
+                    class="sc-AxiKw fFXzuz p-1"
+                    height="22"
+                    width="22"
+                  >
+                    <svg>
+                      notification.svg
+                    </svg>
+                  </div>
+                </button>
+              </div>
+            </div>
+            <div
+              class="h-8 border-r border-theme-neutral-200"
+            />
+            <div
+              class="flex items-center overflow-hidden rounded-lg"
+            >
+              <button
+                class="sc-AxjAm goVygI text-theme-primary-300 hover:text-theme-primary-dark hover:bg-theme-primary-50"
+                color="primary"
+                data-testid="navbar__buttons--send"
+                type="button"
+              >
+                <div
+                  class="sc-AxiKw fFXzuz p-1"
+                  height="22"
+                  width="22"
+                >
+                  <svg>
+                    sent.svg
+                  </svg>
+                </div>
+              </button>
+            </div>
+            <div
+              class="h-8 border-r border-theme-neutral-200"
+            />
+            <div
+              class="flex items-center overflow-hidden rounded-lg"
+            >
+              <button
+                class="sc-AxjAm goVygI text-theme-primary-300 hover:text-theme-primary-dark hover:bg-theme-primary-50"
+                color="primary"
+                data-testid="navbar__buttons--receive"
+                type="button"
+              >
+                <div
+                  class="sc-AxiKw fFXzuz p-1"
+                  height="22"
+                  width="22"
+                >
+                  <svg>
+                    receive.svg
+                  </svg>
+                </div>
+              </button>
+            </div>
+            <div
+              class="h-8 border-r border-theme-neutral-200"
+            />
+          </div>
+          <div
+            class="flex items-center my-auto ml-8 mr-4"
+          >
+            <div
+              class="text-right"
+            >
+              <div
+                class="text-xs font-medium text-theme-neutral"
+              >
+                Your balance
+              </div>
+              <div
+                class="text-sm font-bold text-theme-neutral-dark"
+              >
+                <span
+                  data-testid="Amount"
+                >
+                  91.43089801 BTC
+                </span>
+              </div>
+            </div>
+            <div
+              class="relative"
+              data-testid="dropdown__toggle"
+            >
+              <div
+                class="ml-4 cursor-pointer"
+                data-testid="navbar__useractions"
+              >
+                <div
+                  class="sc-AxgMl daFHdi -mr-2 border-theme-primary-contrast"
+                >
+                  <span
+                    class="text-theme-neutral-dark"
+                  >
+                    <div
+                      class="sc-AxiKw dzBdqj"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        btc.svg
+                      </svg>
+                    </div>
+                  </span>
+                </div>
+                <div
+                  class="relative inline-flex items-center justify-center align-middle rounded-full"
+                  data-testid="navbar__user--avatar"
+                >
+                  <div
+                    class="Avatar__AvatarWrapper-sc-1vsy2s2-0 fGjnTn"
+                  >
+                    <img
+                      alt="Profile Avatar"
+                      src="data:image/svg+xml;utf8,<svg version=\\"1.1\\" xmlns=\\"http://www.w3.org/2000/svg\\" width=\\"100\\" height=\\"100\\" viewBox=\\"0 0 100 100\\"><style>circle{mix-blend-mode:soft-light;}</style><rect fill=\\"rgb(233, 30, 99)\\" width=\\"100\\" height=\\"100\\"/><circle r=\\"45\\" cx=\\"80\\" cy=\\"30\\" fill=\\"rgb(76, 175, 80)\\"/><circle r=\\"55\\" cx=\\"0\\" cy=\\"60\\" fill=\\"rgb(255, 152, 0)\\"/><circle r=\\"40\\" cx=\\"50\\" cy=\\"50\\" fill=\\"rgb(3, 169, 244)\\"/></svg>"
+                    />
+                    <span
+                      class="absolute text-sm font-semibold text-theme-background"
+                    >
+                      JO
+                    </span>
+                  </div>
+                  <span
+                    class="sc-AxhUy kTPsmA flex border-2 rounded-full justify-center w-5 h-5 items-center align-middle bg-theme-background border-transparent bg-theme-primary-contrast border-theme-primary-contrast text-theme-primary-500"
+                  >
+                    <div
+                      class="sc-AxiKw ksjdLL"
+                      height="10"
+                      width="10"
+                    >
+                      <svg>
+                        chevron-down.svg
+                      </svg>
+                    </div>
+                    <span />
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </nav>
+    <div
+      class="flex items-center space-x-2 container py-5 mx-auto font-semibold px-14 text-theme-neutral-dark"
+      data-testid="breadcrumbs__wrapper"
+    >
+      <div
+        class="sc-AxiKw bGpsrC"
+        height="10"
+        width="19"
+      >
+        <svg>
+          arrow-back.svg
+        </svg>
+      </div>
+      <div
+        class="space-x-2"
+      >
+        <a
+          class="text-theme-neutral-dark"
+          href="/profiles/b999d134-7a24-481e-a95d-bc47c543bfc9/dashboard"
+        >
+          <span>
+            Go back to Portfolio
+          </span>
+        </a>
+      </div>
+    </div>
+    <div
+      class="flex flex-col flex-1 space-y-5 "
+    >
+      <div
+        class="sc-fzpjYC deOkAw flex-1"
+      >
+        <div
+          class="container py-16 mx-auto px-14"
+        >
+          <form
+            class="max-w-xl mx-auto"
+            data-testid="Form"
+          >
+            <div>
+              <ul
+                class="sc-fznJRM kDmVaQ"
+              >
+                <li
+                  class="sc-fznxsB keKrAv"
+                />
+                <li
+                  class="sc-fznxsB exHzky"
+                />
+                <li
+                  class="sc-fznxsB exHzky"
+                />
+                <li
+                  class="sc-fznxsB exHzky"
+                />
+                <li
+                  class="sc-fznxsB exHzky"
+                />
+              </ul>
+              <div
+                class="mt-8"
+              >
+                <div
+                  data-testid="tab-pabel__active-panel"
+                >
+                  <section
+                    data-testid="SendTransfer__step--first"
+                  >
+                    <div>
+                      <h1
+                        class="mb-0"
+                      >
+                        Send
+                      </h1>
+                      <div
+                        class="text-theme-neutral-dark"
+                      >
+                        Enter details to send your money
+                      </div>
+                    </div>
+                    <div
+                      class="mt-8"
+                    >
+                      <div
+                        class="space-y-8 SendTransactionForm"
+                      >
+                        <fieldset
+                          class="sc-AxirZ izhStr relative"
+                        >
+                          <div
+                            class="mb-2"
+                          >
+                            <label
+                              class="flex inline-block mb-2 text-sm font-semibold transition-colors duration-100 FormLabel text-theme-neutral-dark"
+                              data-testid="FormLabel"
+                              for="network"
+                            >
+                              Network
+                              <div
+                                class="w-1 h-1 mt-1 ml-1 rounded-full bg-theme-danger-400"
+                                data-testid="FormLabel__required"
+                              />
+                            </label>
+                          </div>
+                          <div
+                            aria-expanded="false"
+                            aria-haspopup="listbox"
+                            aria-owns="SendTransactionForm__network-menu"
+                            data-testid="SelectNetwork"
+                            role="combobox"
+                          >
+                            <label
+                              for="SendTransactionForm__network-input"
+                              id="SendTransactionForm__network-label"
+                            />
+                            <div
+                              class="sc-fzokOt feJGYk"
+                              data-testid="SelectNetworkInput"
+                            >
+                              <div
+                                class="sc-fznyAO sc-fznKkj dKbLCT px-4"
+                              >
+                                <div
+                                  class="sc-AxgMl hdkviZ border-theme-neutral-light text-theme-neutral"
+                                  data-testid="SelectNetworkInput__network"
+                                />
+                              </div>
+                              <input
+                                aria-autocomplete="list"
+                                aria-controls="SendTransactionForm__network-menu"
+                                aria-labelledby="SendTransactionForm__network-label"
+                                autocomplete="off"
+                                class="sc-fzplWN hjcjbm overflow-hidden w-full bg-theme-background appearance-none rounded border border-theme-neutral-300 text-theme-neutral-900 transition-colors duration-200 px-4 py-3 pl-15"
+                                data-testid="SelectNetworkInput__input"
+                                id="SendTransactionForm__network-input"
+                                placeholder="Enter a network name"
+                                value=""
+                              />
+                            </div>
+                          </div>
+                          <ul
+                            aria-labelledby="SendTransactionForm__network-label"
+                            class="mt-6 grid grid-cols-6 gap-6"
+                            id="SendTransactionForm__network-menu"
+                            role="listbox"
+                          >
+                            <li
+                              aria-selected="false"
+                              class="inline-block cursor-pointer"
+                              data-testid="SelectNetwork__NetworkIcon--container"
+                              id="SendTransactionForm__network-item-0"
+                              role="option"
+                            >
+                              <div
+                                aria-label="Ark"
+                                class="sc-AxgMl eikNkl border-theme-danger-light text-theme-danger-400"
+                                data-testid="NetworkIcon-ARK-mainnet"
+                              >
+                                <div
+                                  class="sc-AxiKw fubePL"
+                                  data-testid="NetworkIcon__icon"
+                                  height="26"
+                                  width="26"
+                                >
+                                  <svg>
+                                    ark.svg
+                                  </svg>
+                                </div>
+                              </div>
+                            </li>
+                            <li
+                              aria-selected="false"
+                              class="inline-block cursor-pointer"
+                              data-testid="SelectNetwork__NetworkIcon--container"
+                              id="SendTransactionForm__network-item-1"
+                              role="option"
+                            >
+                              <div
+                                aria-label="Ark Devnet"
+                                class="sc-AxgMl eikNkl border-theme-primary-100 text-theme-primary-400"
+                                data-testid="NetworkIcon-ARK-devnet"
+                              >
+                                <div
+                                  class="sc-AxiKw fubePL"
+                                  data-testid="NetworkIcon__icon"
+                                  height="26"
+                                  width="26"
+                                >
+                                  <svg>
+                                    ark.svg
+                                  </svg>
+                                </div>
+                              </div>
+                            </li>
+                          </ul>
+                        </fieldset>
+                        <fieldset
+                          class="sc-AxirZ izhStr relative"
+                        >
+                          <div
+                            class="mb-2"
+                          >
+                            <label
+                              class="flex inline-block mb-2 text-sm font-semibold transition-colors duration-100 FormLabel text-theme-neutral-dark"
+                              data-testid="FormLabel"
+                              for="senderAddress"
+                            >
+                              Sender
+                              <div
+                                class="w-1 h-1 mt-1 ml-1 rounded-full bg-theme-danger-400"
+                                data-testid="FormLabel__required"
+                              />
+                            </label>
+                          </div>
+                          <div
+                            data-testid="sender-address"
+                          >
+                            <div>
+                              <button
+                                class="sc-fzoyTs bPtMIB SelectAddress  "
+                                data-testid="SelectAddress__wrapper"
+                                type="button"
+                              >
+                                <div
+                                  class="sc-AxgMl hdkviZ mx-4 bg-theme-neutral-200 border-theme-neutral-200"
+                                />
+                                <div
+                                  class="absolute flex items-center space-x-3 right-4"
+                                >
+                                  <div
+                                    class="sc-AxiKw dklFyP"
+                                    height="20"
+                                    width="20"
+                                  >
+                                    <svg>
+                                      user.svg
+                                    </svg>
+                                  </div>
+                                </div>
+                              </button>
+                              <input
+                                class="sc-fzplWN hjcjbm overflow-hidden w-full bg-theme-background appearance-none rounded border border-theme-neutral-300 text-theme-neutral-900 transition-colors duration-200 px-4 py-3 hidden"
+                                data-testid="SelectAddress__input"
+                                name="senderAddress"
+                                readonly=""
+                                type="text"
+                                value=""
+                              />
+                            </div>
+                          </div>
+                        </fieldset>
+                        <div
+                          data-testid="recipient-address"
+                        >
+                          <div
+                            class="sc-fzqNqU dODLJr"
+                          >
+                            <div
+                              class="text-theme-neutral-dark hover:text-theme-primary"
+                            >
+                              <div
+                                class="flex items-center mb-2 space-x-2"
+                              >
+                                <div
+                                  class="font-normal transition-colors duration-100 text-md"
+                                >
+                                  Select a Single or Multiple Recipient Transaction
+                                </div>
+                                <div>
+                                  <div
+                                    class="rounded-full cursor-pointer text-theme-primary-600 hover:text-theme-primary-100 questionmark"
+                                  >
+                                    <div
+                                      class="sc-AxiKw dklFyP"
+                                      height="20"
+                                      width="20"
+                                    >
+                                      <svg>
+                                        questionmark.svg
+                                      </svg>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                              <div
+                                class="flex items-stretch select-buttons"
+                              >
+                                <button
+                                  class="sc-AxjAm kbZyZT flex-1"
+                                  color="primary"
+                                  data-testid="add-recipient-is-single-toggle"
+                                  type="button"
+                                >
+                                  Single
+                                </button>
+                                <button
+                                  class="sc-AxjAm fPpool flex-1 border-l-0"
+                                  color="primary"
+                                  data-testid="add-recipient-is-multiple-toggle"
+                                  type="button"
+                                >
+                                  Multiple
+                                </button>
+                              </div>
+                            </div>
+                            <div
+                              class="SubForm__SubFormWrapper-c4tqfs-0 gIKSHW mt-6"
+                            >
+                              <div
+                                class="space-y-8"
+                              >
+                                <fieldset
+                                  class="sc-AxirZ izhStr relative mt-1"
+                                >
+                                  <div
+                                    class="mb-2"
+                                  >
+                                    <label
+                                      class="flex inline-block mb-2 text-sm font-semibold transition-colors duration-100 FormLabel text-theme-neutral-dark"
+                                      data-testid="FormLabel"
+                                      for="recipientAddress"
+                                    >
+                                      Recipient
+                                      <div
+                                        class="w-1 h-1 mt-1 ml-1 rounded-full bg-theme-danger-400"
+                                        data-testid="FormLabel__required"
+                                      />
+                                    </label>
+                                  </div>
+                                  <div>
+                                    <div
+                                      class="relative flex items-center w-full text-left"
+                                      data-testid="SelectRecipient__wrapper"
+                                    >
+                                      <div
+                                        class="absolute left-1"
+                                      >
+                                        <div
+                                          class="sc-AxgMl hdkviZ mx-3 bg-theme-neutral-200 border-theme-neutral-200"
+                                        />
+                                      </div>
+                                      <input
+                                        class="sc-fzplWN hjcjbm overflow-hidden w-full bg-theme-background appearance-none rounded border border-theme-neutral-300 text-theme-neutral-900 transition-colors duration-200 px-4 py-3 pl-14 pr-11"
+                                        data-testid="SelectRecipient__input"
+                                        name="recipientAddress"
+                                        type="text"
+                                        value=""
+                                      />
+                                      <div
+                                        class="absolute flex items-center cursor-pointer right-4 space-x-3"
+                                        data-testid="SelectRecipient__select-contact"
+                                      >
+                                        <div
+                                          class="sc-AxiKw dklFyP"
+                                          height="20"
+                                          width="20"
+                                        >
+                                          <svg>
+                                            user.svg
+                                          </svg>
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </div>
+                                </fieldset>
+                                <fieldset
+                                  class="sc-AxirZ izhStr relative mt-1"
+                                >
+                                  <div
+                                    class="mb-2"
+                                  >
+                                    <label
+                                      class="flex inline-block mb-2 text-sm font-semibold transition-colors duration-100 FormLabel text-theme-neutral-dark"
+                                      data-testid="FormLabel"
+                                      for="amount"
+                                    >
+                                      Amount
+                                      <div
+                                        class="w-1 h-1 mt-1 ml-1 rounded-full bg-theme-danger-400"
+                                        data-testid="FormLabel__required"
+                                      />
+                                    </label>
+                                  </div>
+                                  <div
+                                    class="sc-fzokOt feJGYk"
+                                  >
+                                    <input
+                                      class="sc-fzplWN hjcjbm overflow-hidden w-full bg-theme-background appearance-none rounded border border-theme-neutral-300 text-theme-neutral-900 transition-colors duration-200 px-4 py-3 pr-20"
+                                      data-testid="add-recipient__amount-input"
+                                      name="amount"
+                                      placeholder="Amount"
+                                      type="number"
+                                      value="0"
+                                    />
+                                    <div
+                                      class="sc-fznyAO sc-fznZeY dZgvBo"
+                                    >
+                                      <button
+                                        class="h-12 pl-6 pr-3 mr-1 text-theme-primary focus:outline-none"
+                                        data-testid="add-recipient__send-all"
+                                        type="button"
+                                      >
+                                        Send All
+                                      </button>
+                                    </div>
+                                  </div>
+                                </fieldset>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                        <fieldset
+                          class="sc-AxirZ izhStr relative"
+                        >
+                          <div
+                            class="mb-2"
+                          >
+                            <label
+                              class="flex inline-block mb-2 text-sm font-semibold transition-colors duration-100 FormLabel text-theme-neutral-dark"
+                              data-testid="FormLabel"
+                              for="smartbridge"
+                            >
+                              Smartbridge
+                              <div
+                                class="w-1 h-1 mt-1 ml-1 rounded-full bg-theme-danger-400"
+                                data-testid="FormLabel__required"
+                              />
+                            </label>
+                          </div>
+                          <div
+                            class="sc-fzokOt feJGYk"
+                          >
+                            <input
+                              class="sc-fzplWN hjcjbm overflow-hidden w-full bg-theme-background appearance-none rounded border border-theme-neutral-300 text-theme-neutral-900 transition-colors duration-200 px-4 py-3 pr-24"
+                              data-testid="Input__smartbridge"
+                              maxlength="255"
+                              name="smartbridge"
+                              placeholder=" "
+                              type="text"
+                              value=""
+                            />
+                            <div
+                              class="sc-fznyAO sc-fznZeY dZgvBo"
+                            >
+                              <button
+                                class="px-4 text-theme-neutral-light focus:outline-none"
+                                type="button"
+                              >
+                                255 Max
+                              </button>
+                            </div>
+                          </div>
+                        </fieldset>
+                        <fieldset
+                          class="sc-AxirZ izhStr flex flex-col space-y-2"
+                        >
+                          <label
+                            class="flex inline-block mb-2 text-sm font-semibold transition-colors duration-100 FormLabel text-theme-neutral-dark"
+                            data-testid="FormLabel"
+                            for="fee"
+                          >
+                            Transaction Fee
+                            <div
+                              class="w-1 h-1 mt-1 ml-1 rounded-full bg-theme-danger-400"
+                              data-testid="FormLabel__required"
+                            />
+                          </label>
+                          <div
+                            class="flex space-x-2"
+                            data-testid="InputFee"
+                          >
+                            <div
+                              class="flex-1"
+                            >
+                              <div
+                                class="sc-fzokOt feJGYk"
+                              >
+                                <input
+                                  class="sc-fzplWN hjcjbm overflow-hidden w-full bg-theme-background appearance-none rounded border border-theme-neutral-300 text-theme-neutral-900 transition-colors duration-200 px-4 py-3 "
+                                  data-testid="InputCurrency"
+                                  name="fee"
+                                  type="text"
+                                  value="0"
+                                />
+                                <div
+                                  class="absolute bottom-0 w-full px-1"
+                                >
+                                  <div
+                                    class="flex flex-wrap justify-center"
+                                    data-testid="Range"
+                                  >
+                                    <div
+                                      class="sc-fzqBZW jucamx"
+                                      data-testid="Range__track"
+                                      style="transform: scale(1); cursor: pointer;"
+                                    >
+                                      <div
+                                        class="sc-fzqNJr eNfzLl"
+                                        data-testid="Range__track__filled"
+                                      >
+                                        <div
+                                          aria-valuemax="2e-8"
+                                          aria-valuemin="0"
+                                          aria-valuenow="0"
+                                          class="sc-fzoyAV eFJKNt"
+                                          data-testid="Range__thumb"
+                                          draggable="false"
+                                          role="slider"
+                                          style="position: absolute; z-index: 0; cursor: grab; user-select: none; transform: translate(0px, 0px);"
+                                          tabindex="0"
+                                        />
+                                      </div>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                            <div>
+                              <div
+                                class="inline-flex items-center flex-shrink-0 overflow-hidden border rounded border-theme-neutral-300"
+                                data-testid="SelectionBar"
+                                role="radiogroup"
+                              >
+                                <button
+                                  aria-checked="false"
+                                  class="sc-fzoNJl gCmvhq relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+                                  data-testid="SelectionBarOption"
+                                  role="radio"
+                                  type="button"
+                                >
+                                  Min
+                                </button>
+                                <button
+                                  aria-checked="false"
+                                  class="sc-fzoNJl gCmvhq relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+                                  data-testid="SelectionBarOption"
+                                  role="radio"
+                                  type="button"
+                                >
+                                  Average
+                                </button>
+                                <button
+                                  aria-checked="false"
+                                  class="sc-fzoNJl gCmvhq relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+                                  data-testid="SelectionBarOption"
+                                  role="radio"
+                                  type="button"
+                                >
+                                  Max
+                                </button>
+                              </div>
+                            </div>
+                          </div>
+                        </fieldset>
+                      </div>
+                    </div>
+                  </section>
+                </div>
+                <div
+                  class="flex justify-end mt-10 space-x-3"
+                >
+                  <button
+                    class="sc-AxjAm fPpool"
+                    color="primary"
+                    data-testid="SendTransfer__button--back"
+                    disabled=""
+                    type="button"
+                  >
+                    Back
+                  </button>
+                  <button
+                    class="sc-AxjAm kbZyZT"
+                    color="primary"
+                    data-testid="SendTransfer__button--continue"
+                    disabled=""
+                    type="button"
+                  >
+                    Continue
+                  </button>
+                </div>
+              </div>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`Transaction Send should select network first and see select address input clickable 1`] = `
+<DocumentFragment>
+  <div
+    class="relative flex flex-col min-h-screen bg-theme-neutral-contrast"
+  >
+    <nav
+      aria-labelledby="main menu"
+      class="sc-fzoLag gnHGCp"
+    >
+      <div
+        class="px-4 sm:px-6 lg:px-10"
+      >
+        <div
+          class="relative flex justify-between h-20 md:h-24"
+        >
+          <div
+            class="flex items-center my-auto"
+          >
+            <div
+              class="sc-fzoXzr cumsaa"
+            >
+              <svg
+                width="40"
+              >
+                ark-logo.svg
+              </svg>
+            </div>
+          </div>
+          <ul
+            class="flex h-20 mr-auto md:h-24"
+          >
+            <li
+              class="flex"
+            >
+              <a
+                class="flex items-center mx-4 font-semibold transition-colors duration-200 text-md text-theme-neutral-dark hover:text-theme-neutral-900"
+                href="/profiles/b999d134-7a24-481e-a95d-bc47c543bfc9/dashboard"
+                title="Portfolio"
+              >
+                Portfolio
+              </a>
+            </li>
+            <li
+              class="flex"
+            >
+              <a
+                class="flex items-center mx-4 font-semibold transition-colors duration-200 text-md text-theme-neutral-dark hover:text-theme-neutral-900"
+                href="/profiles/b999d134-7a24-481e-a95d-bc47c543bfc9/plugins"
+                title="Plugins"
+              >
+                Plugins
+              </a>
+            </li>
+            <li
+              class="flex"
+            >
+              <a
+                class="flex items-center mx-4 font-semibold transition-colors duration-200 text-md text-theme-neutral-dark hover:text-theme-neutral-900"
+                href="/profiles/b999d134-7a24-481e-a95d-bc47c543bfc9/exchange"
+                title="Exchange"
+              >
+                Exchange
+              </a>
+            </li>
+            <li
+              class="flex"
+            >
+              <a
+                class="flex items-center mx-4 font-semibold transition-colors duration-200 text-md text-theme-neutral-dark hover:text-theme-neutral-900"
+                href="/profiles/b999d134-7a24-481e-a95d-bc47c543bfc9/news"
+                title="News"
+              >
+                News
+              </a>
+            </li>
+          </ul>
+          <div
+            class="flex items-center my-auto space-x-4"
+          >
+            <div
+              class="relative"
+              data-testid="dropdown__toggle"
+            >
+              <div
+                class="overflow-hidden rounded-lg"
+              >
+                <button
+                  class="sc-AxjAm goVygI text-theme-primary-300 hover:text-theme-primary-700 hover:bg-theme-primary-50"
+                  color="primary"
+                  data-testid="navbar__buttons--notifications"
+                  type="button"
+                >
+                  <div
+                    class="sc-AxiKw fFXzuz p-1"
+                    height="22"
+                    width="22"
+                  >
+                    <svg>
+                      notification.svg
+                    </svg>
+                  </div>
+                </button>
+              </div>
+            </div>
+            <div
+              class="h-8 border-r border-theme-neutral-200"
+            />
+            <div
+              class="flex items-center overflow-hidden rounded-lg"
+            >
+              <button
+                class="sc-AxjAm goVygI text-theme-primary-300 hover:text-theme-primary-dark hover:bg-theme-primary-50"
+                color="primary"
+                data-testid="navbar__buttons--send"
+                type="button"
+              >
+                <div
+                  class="sc-AxiKw fFXzuz p-1"
+                  height="22"
+                  width="22"
+                >
+                  <svg>
+                    sent.svg
+                  </svg>
+                </div>
+              </button>
+            </div>
+            <div
+              class="h-8 border-r border-theme-neutral-200"
+            />
+            <div
+              class="flex items-center overflow-hidden rounded-lg"
+            >
+              <button
+                class="sc-AxjAm goVygI text-theme-primary-300 hover:text-theme-primary-dark hover:bg-theme-primary-50"
+                color="primary"
+                data-testid="navbar__buttons--receive"
+                type="button"
+              >
+                <div
+                  class="sc-AxiKw fFXzuz p-1"
+                  height="22"
+                  width="22"
+                >
+                  <svg>
+                    receive.svg
+                  </svg>
+                </div>
+              </button>
+            </div>
+            <div
+              class="h-8 border-r border-theme-neutral-200"
+            />
+          </div>
+          <div
+            class="flex items-center my-auto ml-8 mr-4"
+          >
+            <div
+              class="text-right"
+            >
+              <div
+                class="text-xs font-medium text-theme-neutral"
+              >
+                Your balance
+              </div>
+              <div
+                class="text-sm font-bold text-theme-neutral-dark"
+              >
+                <span
+                  data-testid="Amount"
+                >
+                  91.43089801 BTC
+                </span>
+              </div>
+            </div>
+            <div
+              class="relative"
+              data-testid="dropdown__toggle"
+            >
+              <div
+                class="ml-4 cursor-pointer"
+                data-testid="navbar__useractions"
+              >
+                <div
+                  class="sc-AxgMl daFHdi -mr-2 border-theme-primary-contrast"
+                >
+                  <span
+                    class="text-theme-neutral-dark"
+                  >
+                    <div
+                      class="sc-AxiKw dzBdqj"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        btc.svg
+                      </svg>
+                    </div>
+                  </span>
+                </div>
+                <div
+                  class="relative inline-flex items-center justify-center align-middle rounded-full"
+                  data-testid="navbar__user--avatar"
+                >
+                  <div
+                    class="Avatar__AvatarWrapper-sc-1vsy2s2-0 fGjnTn"
+                  >
+                    <img
+                      alt="Profile Avatar"
+                      src="data:image/svg+xml;utf8,<svg version=\\"1.1\\" xmlns=\\"http://www.w3.org/2000/svg\\" width=\\"100\\" height=\\"100\\" viewBox=\\"0 0 100 100\\"><style>circle{mix-blend-mode:soft-light;}</style><rect fill=\\"rgb(233, 30, 99)\\" width=\\"100\\" height=\\"100\\"/><circle r=\\"45\\" cx=\\"80\\" cy=\\"30\\" fill=\\"rgb(76, 175, 80)\\"/><circle r=\\"55\\" cx=\\"0\\" cy=\\"60\\" fill=\\"rgb(255, 152, 0)\\"/><circle r=\\"40\\" cx=\\"50\\" cy=\\"50\\" fill=\\"rgb(3, 169, 244)\\"/></svg>"
+                    />
+                    <span
+                      class="absolute text-sm font-semibold text-theme-background"
+                    >
+                      JO
+                    </span>
+                  </div>
+                  <span
+                    class="sc-AxhUy kTPsmA flex border-2 rounded-full justify-center w-5 h-5 items-center align-middle bg-theme-background border-transparent bg-theme-primary-contrast border-theme-primary-contrast text-theme-primary-500"
+                  >
+                    <div
+                      class="sc-AxiKw ksjdLL"
+                      height="10"
+                      width="10"
+                    >
+                      <svg>
+                        chevron-down.svg
+                      </svg>
+                    </div>
+                    <span />
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </nav>
+    <div
+      class="flex items-center space-x-2 container py-5 mx-auto font-semibold px-14 text-theme-neutral-dark"
+      data-testid="breadcrumbs__wrapper"
+    >
+      <div
+        class="sc-AxiKw bGpsrC"
+        height="10"
+        width="19"
+      >
+        <svg>
+          arrow-back.svg
+        </svg>
+      </div>
+      <div
+        class="space-x-2"
+      >
+        <a
+          class="text-theme-neutral-dark"
+          href="/profiles/b999d134-7a24-481e-a95d-bc47c543bfc9/dashboard"
+        >
+          <span>
+            Go back to Portfolio
+          </span>
+        </a>
+      </div>
+    </div>
+    <div
+      class="flex flex-col flex-1 space-y-5 "
+    >
+      <div
+        class="sc-fzpjYC deOkAw flex-1"
+      >
+        <div
+          class="container py-16 mx-auto px-14"
+        >
+          <form
+            class="max-w-xl mx-auto"
+            data-testid="Form"
+          >
+            <div>
+              <ul
+                class="sc-fznJRM kDmVaQ"
+              >
+                <li
+                  class="sc-fznxsB keKrAv"
+                />
+                <li
+                  class="sc-fznxsB exHzky"
+                />
+                <li
+                  class="sc-fznxsB exHzky"
+                />
+                <li
+                  class="sc-fznxsB exHzky"
+                />
+                <li
+                  class="sc-fznxsB exHzky"
+                />
+              </ul>
+              <div
+                class="mt-8"
+              >
+                <div
+                  data-testid="tab-pabel__active-panel"
+                >
+                  <section
+                    data-testid="SendTransfer__step--first"
+                  >
+                    <div>
+                      <h1
+                        class="mb-0"
+                      >
+                        Send
+                      </h1>
+                      <div
+                        class="text-theme-neutral-dark"
+                      >
+                        Enter details to send your money
+                      </div>
+                    </div>
+                    <div
+                      class="mt-8"
+                    >
+                      <div
+                        class="space-y-8 SendTransactionForm"
+                      >
+                        <fieldset
+                          class="sc-AxirZ izhStr relative"
+                        >
+                          <div
+                            class="mb-2"
+                          >
+                            <label
+                              class="flex inline-block mb-2 text-sm font-semibold transition-colors duration-100 FormLabel text-theme-neutral-dark"
+                              data-testid="FormLabel"
+                              for="network"
+                            >
+                              Network
+                              <div
+                                class="w-1 h-1 mt-1 ml-1 rounded-full bg-theme-danger-400"
+                                data-testid="FormLabel__required"
+                              />
+                            </label>
+                          </div>
+                          <div
+                            aria-expanded="false"
+                            aria-haspopup="listbox"
+                            aria-owns="SendTransactionForm__network-menu"
+                            data-testid="SelectNetwork"
+                            role="combobox"
+                          >
+                            <label
+                              for="SendTransactionForm__network-input"
+                              id="SendTransactionForm__network-label"
+                            />
+                            <div
+                              class="sc-fzokOt feJGYk"
+                              data-testid="SelectNetworkInput"
+                            >
+                              <div
+                                class="sc-fznyAO sc-fznKkj dKbLCT px-4"
+                              >
+                                <div
+                                  aria-label="Ark Devnet"
+                                  class="sc-AxgMl hdkviZ border-theme-primary-100 text-theme-primary-400"
+                                  data-testid="SelectNetworkInput__network"
+                                >
+                                  <div
+                                    class="sc-AxiKw dzBdqj"
+                                    data-testid="NetworkIcon__icon"
+                                    height="1em"
+                                    width="1em"
+                                  >
+                                    <svg>
+                                      ark.svg
+                                    </svg>
+                                  </div>
+                                </div>
+                              </div>
+                              <span
+                                class="sc-fznyAO fiElDx py-3 font-normal border border-transparent opacity-50 pointer-events-none pl-15"
+                                data-testid="SelectNetworkInput__typeahead"
+                              >
+                                Ark Devnet
+                              </span>
+                              <input
+                                aria-autocomplete="list"
+                                aria-controls="SendTransactionForm__network-menu"
+                                aria-labelledby="SendTransactionForm__network-label"
+                                autocomplete="off"
+                                class="sc-fzplWN hjcjbm overflow-hidden w-full bg-theme-background appearance-none rounded border border-theme-neutral-300 text-theme-neutral-900 transition-colors duration-200 px-4 py-3 pl-15"
+                                data-testid="SelectNetworkInput__input"
+                                id="SendTransactionForm__network-input"
+                                placeholder="Enter a network name"
+                                value="Ark Devnet"
+                              />
+                            </div>
+                          </div>
+                          <ul
+                            aria-labelledby="SendTransactionForm__network-label"
+                            class="mt-6 grid grid-cols-6 gap-6"
+                            id="SendTransactionForm__network-menu"
+                            role="listbox"
+                          >
+                            <li
+                              aria-selected="false"
+                              class="inline-block cursor-pointer"
+                              data-testid="SelectNetwork__NetworkIcon--container"
+                              id="SendTransactionForm__network-item-0"
+                              role="option"
+                            >
+                              <div
+                                aria-label="Ark"
+                                class="sc-AxgMl eikNkl text-theme-neutral-light"
+                                data-testid="NetworkIcon-ARK-mainnet"
+                              >
+                                <div
+                                  class="sc-AxiKw fubePL"
+                                  data-testid="NetworkIcon__icon"
+                                  height="26"
+                                  width="26"
+                                >
+                                  <svg>
+                                    ark.svg
+                                  </svg>
+                                </div>
+                              </div>
+                            </li>
+                            <li
+                              aria-selected="false"
+                              class="inline-block cursor-pointer"
+                              data-testid="SelectNetwork__NetworkIcon--container"
+                              id="SendTransactionForm__network-item-1"
+                              role="option"
+                            >
+                              <div
+                                aria-label="Ark Devnet"
+                                class="sc-AxgMl eikNkl text-theme-success-500 border-theme-success-200"
+                                data-testid="NetworkIcon-ARK-devnet"
+                              >
+                                <div
+                                  class="sc-AxiKw fubePL"
+                                  data-testid="NetworkIcon__icon"
+                                  height="26"
+                                  width="26"
+                                >
+                                  <svg>
+                                    ark.svg
+                                  </svg>
+                                </div>
+                              </div>
+                            </li>
+                          </ul>
+                        </fieldset>
+                        <fieldset
+                          class="sc-AxirZ izhStr relative"
+                        >
+                          <div
+                            class="mb-2"
+                          >
+                            <label
+                              class="flex inline-block mb-2 text-sm font-semibold transition-colors duration-100 FormLabel text-theme-neutral-dark"
+                              data-testid="FormLabel"
+                              for="senderAddress"
+                            >
+                              Sender
+                              <div
+                                class="w-1 h-1 mt-1 ml-1 rounded-full bg-theme-danger-400"
+                                data-testid="FormLabel__required"
+                              />
+                            </label>
+                          </div>
+                          <div
+                            data-testid="sender-address"
+                          >
+                            <div>
+                              <button
+                                class="sc-fzoyTs bPtMIB SelectAddress  "
+                                data-testid="SelectAddress__wrapper"
+                                type="button"
+                              >
+                                <div
+                                  class="sc-AxgMl hdkviZ mx-4 bg-theme-neutral-200 border-theme-neutral-200"
+                                />
+                                <div
+                                  class="absolute flex items-center space-x-3 right-4"
+                                >
+                                  <div
+                                    class="sc-AxiKw dklFyP"
+                                    height="20"
+                                    width="20"
+                                  >
+                                    <svg>
+                                      user.svg
+                                    </svg>
+                                  </div>
+                                </div>
+                              </button>
+                              <input
+                                class="sc-fzplWN hjcjbm overflow-hidden w-full bg-theme-background appearance-none rounded border border-theme-neutral-300 text-theme-neutral-900 transition-colors duration-200 px-4 py-3 hidden"
+                                data-testid="SelectAddress__input"
+                                name="senderAddress"
+                                readonly=""
+                                type="text"
+                                value=""
+                              />
+                            </div>
+                          </div>
+                        </fieldset>
+                        <div
+                          data-testid="recipient-address"
+                        >
+                          <div
+                            class="sc-fzqNqU dODLJr"
+                          >
+                            <div
+                              class="text-theme-neutral-dark hover:text-theme-primary"
+                            >
+                              <div
+                                class="flex items-center mb-2 space-x-2"
+                              >
+                                <div
+                                  class="font-normal transition-colors duration-100 text-md"
+                                >
+                                  Select a Single or Multiple Recipient Transaction
+                                </div>
+                                <div>
+                                  <div
+                                    class="rounded-full cursor-pointer text-theme-primary-600 hover:text-theme-primary-100 questionmark"
+                                  >
+                                    <div
+                                      class="sc-AxiKw dklFyP"
+                                      height="20"
+                                      width="20"
+                                    >
+                                      <svg>
+                                        questionmark.svg
+                                      </svg>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                              <div
+                                class="flex items-stretch select-buttons"
+                              >
+                                <button
+                                  class="sc-AxjAm kbZyZT flex-1"
+                                  color="primary"
+                                  data-testid="add-recipient-is-single-toggle"
+                                  type="button"
+                                >
+                                  Single
+                                </button>
+                                <button
+                                  class="sc-AxjAm fPpool flex-1 border-l-0"
+                                  color="primary"
+                                  data-testid="add-recipient-is-multiple-toggle"
+                                  type="button"
+                                >
+                                  Multiple
+                                </button>
+                              </div>
+                            </div>
+                            <div
+                              class="SubForm__SubFormWrapper-c4tqfs-0 gIKSHW mt-6"
+                            >
+                              <div
+                                class="space-y-8"
+                              >
+                                <fieldset
+                                  class="sc-AxirZ izhStr relative mt-1"
+                                >
+                                  <div
+                                    class="mb-2"
+                                  >
+                                    <label
+                                      class="flex inline-block mb-2 text-sm font-semibold transition-colors duration-100 FormLabel text-theme-neutral-dark"
+                                      data-testid="FormLabel"
+                                      for="recipientAddress"
+                                    >
+                                      Recipient
+                                      <div
+                                        class="w-1 h-1 mt-1 ml-1 rounded-full bg-theme-danger-400"
+                                        data-testid="FormLabel__required"
+                                      />
+                                    </label>
+                                  </div>
+                                  <div>
+                                    <div
+                                      class="relative flex items-center w-full text-left"
+                                      data-testid="SelectRecipient__wrapper"
+                                    >
+                                      <div
+                                        class="absolute left-1"
+                                      >
+                                        <div
+                                          class="sc-AxgMl hdkviZ mx-3 bg-theme-neutral-200 border-theme-neutral-200"
+                                        />
+                                      </div>
+                                      <input
+                                        class="sc-fzplWN hjcjbm overflow-hidden w-full bg-theme-background appearance-none rounded border border-theme-neutral-300 text-theme-neutral-900 transition-colors duration-200 px-4 py-3 pl-14 pr-11"
+                                        data-testid="SelectRecipient__input"
+                                        name="recipientAddress"
+                                        type="text"
+                                        value=""
+                                      />
+                                      <div
+                                        class="absolute flex items-center cursor-pointer right-4 space-x-3"
+                                        data-testid="SelectRecipient__select-contact"
+                                      >
+                                        <div
+                                          class="sc-AxiKw dklFyP"
+                                          height="20"
+                                          width="20"
+                                        >
+                                          <svg>
+                                            user.svg
+                                          </svg>
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </div>
+                                </fieldset>
+                                <fieldset
+                                  class="sc-AxirZ izhStr relative mt-1"
+                                >
+                                  <div
+                                    class="mb-2"
+                                  >
+                                    <label
+                                      class="flex inline-block mb-2 text-sm font-semibold transition-colors duration-100 FormLabel text-theme-neutral-dark"
+                                      data-testid="FormLabel"
+                                      for="amount"
+                                    >
+                                      Amount
+                                      <div
+                                        class="w-1 h-1 mt-1 ml-1 rounded-full bg-theme-danger-400"
+                                        data-testid="FormLabel__required"
+                                      />
+                                    </label>
+                                  </div>
+                                  <div
+                                    class="sc-fzokOt feJGYk"
+                                  >
+                                    <input
+                                      class="sc-fzplWN hjcjbm overflow-hidden w-full bg-theme-background appearance-none rounded border border-theme-neutral-300 text-theme-neutral-900 transition-colors duration-200 px-4 py-3 pr-20"
+                                      data-testid="add-recipient__amount-input"
+                                      name="amount"
+                                      placeholder="Amount"
+                                      type="number"
+                                      value="0"
+                                    />
+                                    <div
+                                      class="sc-fznyAO sc-fznZeY dZgvBo"
+                                    >
+                                      <button
+                                        class="h-12 pl-6 pr-3 mr-1 text-theme-primary focus:outline-none"
+                                        data-testid="add-recipient__send-all"
+                                        type="button"
+                                      >
+                                        Send All
+                                      </button>
+                                    </div>
+                                  </div>
+                                </fieldset>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                        <fieldset
+                          class="sc-AxirZ izhStr relative"
+                        >
+                          <div
+                            class="mb-2"
+                          >
+                            <label
+                              class="flex inline-block mb-2 text-sm font-semibold transition-colors duration-100 FormLabel text-theme-neutral-dark"
+                              data-testid="FormLabel"
+                              for="smartbridge"
+                            >
+                              Smartbridge
+                              <div
+                                class="w-1 h-1 mt-1 ml-1 rounded-full bg-theme-danger-400"
+                                data-testid="FormLabel__required"
+                              />
+                            </label>
+                          </div>
+                          <div
+                            class="sc-fzokOt feJGYk"
+                          >
+                            <input
+                              class="sc-fzplWN hjcjbm overflow-hidden w-full bg-theme-background appearance-none rounded border border-theme-neutral-300 text-theme-neutral-900 transition-colors duration-200 px-4 py-3 pr-24"
+                              data-testid="Input__smartbridge"
+                              maxlength="255"
+                              name="smartbridge"
+                              placeholder=" "
+                              type="text"
+                              value=""
+                            />
+                            <div
+                              class="sc-fznyAO sc-fznZeY dZgvBo"
+                            >
+                              <button
+                                class="px-4 text-theme-neutral-light focus:outline-none"
+                                type="button"
+                              >
+                                255 Max
+                              </button>
+                            </div>
+                          </div>
+                        </fieldset>
+                        <fieldset
+                          class="sc-AxirZ izhStr flex flex-col space-y-2"
+                        >
+                          <label
+                            class="flex inline-block mb-2 text-sm font-semibold transition-colors duration-100 FormLabel text-theme-neutral-dark"
+                            data-testid="FormLabel"
+                            for="fee"
+                          >
+                            Transaction Fee
+                            <div
+                              class="w-1 h-1 mt-1 ml-1 rounded-full bg-theme-danger-400"
+                              data-testid="FormLabel__required"
+                            />
+                          </label>
+                          <div
+                            class="flex space-x-2"
+                            data-testid="InputFee"
+                          >
+                            <div
+                              class="flex-1"
+                            >
+                              <div
+                                class="sc-fzokOt feJGYk"
+                              >
+                                <input
+                                  class="sc-fzplWN hjcjbm overflow-hidden w-full bg-theme-background appearance-none rounded border border-theme-neutral-300 text-theme-neutral-900 transition-colors duration-200 px-4 py-3 "
+                                  data-testid="InputCurrency"
+                                  name="fee"
+                                  type="text"
+                                  value="0"
+                                />
+                                <div
+                                  class="absolute bottom-0 w-full px-1"
+                                >
+                                  <div
+                                    class="flex flex-wrap justify-center"
+                                    data-testid="Range"
+                                  >
+                                    <div
+                                      class="sc-fzqBZW jucamx"
+                                      data-testid="Range__track"
+                                      style="transform: scale(1); cursor: pointer;"
+                                    >
+                                      <div
+                                        class="sc-fzqNJr eNfzLl"
+                                        data-testid="Range__track__filled"
+                                      >
+                                        <div
+                                          aria-valuemax="2e-8"
+                                          aria-valuemin="0"
+                                          aria-valuenow="0"
+                                          class="sc-fzoyAV eFJKNt"
+                                          data-testid="Range__thumb"
+                                          draggable="false"
+                                          role="slider"
+                                          style="position: absolute; z-index: 0; cursor: grab; user-select: none; transform: translate(0px, 0px);"
+                                          tabindex="0"
+                                        />
+                                      </div>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                            <div>
+                              <div
+                                class="inline-flex items-center flex-shrink-0 overflow-hidden border rounded border-theme-neutral-300"
+                                data-testid="SelectionBar"
+                                role="radiogroup"
+                              >
+                                <button
+                                  aria-checked="false"
+                                  class="sc-fzoNJl gCmvhq relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+                                  data-testid="SelectionBarOption"
+                                  role="radio"
+                                  type="button"
+                                >
+                                  Min
+                                </button>
+                                <button
+                                  aria-checked="false"
+                                  class="sc-fzoNJl gCmvhq relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+                                  data-testid="SelectionBarOption"
+                                  role="radio"
+                                  type="button"
+                                >
+                                  Average
+                                </button>
+                                <button
+                                  aria-checked="false"
+                                  class="sc-fzoNJl gCmvhq relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+                                  data-testid="SelectionBarOption"
+                                  role="radio"
+                                  type="button"
+                                >
+                                  Max
+                                </button>
+                              </div>
+                            </div>
+                          </div>
+                        </fieldset>
+                      </div>
+                    </div>
+                  </section>
+                </div>
+                <div
+                  class="flex justify-end mt-10 space-x-3"
+                >
+                  <button
+                    class="sc-AxjAm fPpool"
+                    color="primary"
+                    data-testid="SendTransfer__button--back"
+                    disabled=""
+                    type="button"
+                  >
+                    Back
+                  </button>
+                  <button
+                    class="sc-AxjAm kbZyZT"
+                    color="primary"
+                    data-testid="SendTransfer__button--continue"
+                    disabled=""
+                    type="button"
+                  >
+                    Continue
+                  </button>
+                </div>
+              </div>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
 </DocumentFragment>
 `;
 

--- a/src/domains/transaction/pages/SendTransfer/__snapshots__/SendTransfer.test.tsx.snap
+++ b/src/domains/transaction/pages/SendTransfer/__snapshots__/SendTransfer.test.tsx.snap
@@ -392,7 +392,7 @@ exports[`Transaction Send should display disabled address selection input if sel
                           </div>
                           <ul
                             aria-labelledby="SendTransactionForm__network-label"
-                            class="mt-6 grid grid-cols-6 gap-6"
+                            class="grid grid-cols-6 gap-6 mt-6"
                             id="SendTransactionForm__network-menu"
                             role="listbox"
                           >
@@ -600,7 +600,7 @@ exports[`Transaction Send should display disabled address selection input if sel
                                         value=""
                                       />
                                       <div
-                                        class="absolute flex items-center cursor-pointer right-4 space-x-3"
+                                        class="absolute flex items-center space-x-3 cursor-pointer right-4"
                                         data-testid="SelectRecipient__select-contact"
                                       >
                                         <div
@@ -776,7 +776,7 @@ exports[`Transaction Send should display disabled address selection input if sel
                               >
                                 <button
                                   aria-checked="false"
-                                  class="sc-fzoNJl gCmvhq relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+                                  class="sc-fzoNJl gCmvhq relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
                                   data-testid="SelectionBarOption"
                                   role="radio"
                                   type="button"
@@ -785,7 +785,7 @@ exports[`Transaction Send should display disabled address selection input if sel
                                 </button>
                                 <button
                                   aria-checked="false"
-                                  class="sc-fzoNJl gCmvhq relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+                                  class="sc-fzoNJl gCmvhq relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
                                   data-testid="SelectionBarOption"
                                   role="radio"
                                   type="button"
@@ -794,7 +794,7 @@ exports[`Transaction Send should display disabled address selection input if sel
                                 </button>
                                 <button
                                   aria-checked="false"
-                                  class="sc-fzoNJl gCmvhq relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+                                  class="sc-fzoNJl gCmvhq relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
                                   data-testid="SelectionBarOption"
                                   role="radio"
                                   type="button"
@@ -1326,7 +1326,7 @@ exports[`Transaction Send should render 1st step 1`] = `
           </div>
           <ul
             aria-labelledby="SendTransactionForm__network-label"
-            class="mt-6 grid grid-cols-6 gap-6"
+            class="grid grid-cols-6 gap-6 mt-6"
             id="SendTransactionForm__network-menu"
             role="listbox"
           />
@@ -1484,7 +1484,7 @@ exports[`Transaction Send should render 1st step 1`] = `
                         value=""
                       />
                       <div
-                        class="absolute flex items-center cursor-pointer right-4 space-x-3"
+                        class="absolute flex items-center space-x-3 cursor-pointer right-4"
                         data-testid="SelectRecipient__select-contact"
                       >
                         <div
@@ -1660,7 +1660,7 @@ exports[`Transaction Send should render 1st step 1`] = `
               >
                 <button
                   aria-checked="false"
-                  class="sc-fzoNJl gCmvhq relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+                  class="sc-fzoNJl gCmvhq relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
                   data-testid="SelectionBarOption"
                   role="radio"
                   type="button"
@@ -1669,7 +1669,7 @@ exports[`Transaction Send should render 1st step 1`] = `
                 </button>
                 <button
                   aria-checked="false"
-                  class="sc-fzoNJl gCmvhq relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+                  class="sc-fzoNJl gCmvhq relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
                   data-testid="SelectionBarOption"
                   role="radio"
                   type="button"
@@ -1678,7 +1678,7 @@ exports[`Transaction Send should render 1st step 1`] = `
                 </button>
                 <button
                   aria-checked="false"
-                  class="sc-fzoNJl gCmvhq relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+                  class="sc-fzoNJl gCmvhq relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
                   data-testid="SelectionBarOption"
                   role="radio"
                   type="button"
@@ -1713,7 +1713,7 @@ exports[`Transaction Send should render 2nd step 1`] = `
       </div>
     </div>
     <div
-      class="mt-4 grid grid-flow-row gap-2"
+      class="grid grid-flow-row gap-2 mt-4"
     >
       <div
         class="flex items-center py-6 true "
@@ -2765,7 +2765,7 @@ exports[`Transaction Send should render registration form without selected walle
                           </div>
                           <ul
                             aria-labelledby="SendTransactionForm__network-label"
-                            class="mt-6 grid grid-cols-6 gap-6"
+                            class="grid grid-cols-6 gap-6 mt-6"
                             id="SendTransactionForm__network-menu"
                             role="listbox"
                           >
@@ -2972,7 +2972,7 @@ exports[`Transaction Send should render registration form without selected walle
                                         value=""
                                       />
                                       <div
-                                        class="absolute flex items-center cursor-pointer right-4 space-x-3"
+                                        class="absolute flex items-center space-x-3 cursor-pointer right-4"
                                         data-testid="SelectRecipient__select-contact"
                                       >
                                         <div
@@ -3148,7 +3148,7 @@ exports[`Transaction Send should render registration form without selected walle
                               >
                                 <button
                                   aria-checked="false"
-                                  class="sc-fzoNJl gCmvhq relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+                                  class="sc-fzoNJl gCmvhq relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
                                   data-testid="SelectionBarOption"
                                   role="radio"
                                   type="button"
@@ -3157,7 +3157,7 @@ exports[`Transaction Send should render registration form without selected walle
                                 </button>
                                 <button
                                   aria-checked="false"
-                                  class="sc-fzoNJl gCmvhq relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+                                  class="sc-fzoNJl gCmvhq relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
                                   data-testid="SelectionBarOption"
                                   role="radio"
                                   type="button"
@@ -3166,7 +3166,7 @@ exports[`Transaction Send should render registration form without selected walle
                                 </button>
                                 <button
                                   aria-checked="false"
-                                  class="sc-fzoNJl gCmvhq relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+                                  class="sc-fzoNJl gCmvhq relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
                                   data-testid="SelectionBarOption"
                                   role="radio"
                                   type="button"
@@ -3611,7 +3611,7 @@ exports[`Transaction Send should select network first and see select address inp
                           </div>
                           <ul
                             aria-labelledby="SendTransactionForm__network-label"
-                            class="mt-6 grid grid-cols-6 gap-6"
+                            class="grid grid-cols-6 gap-6 mt-6"
                             id="SendTransactionForm__network-menu"
                             role="listbox"
                           >
@@ -3818,7 +3818,7 @@ exports[`Transaction Send should select network first and see select address inp
                                         value=""
                                       />
                                       <div
-                                        class="absolute flex items-center cursor-pointer right-4 space-x-3"
+                                        class="absolute flex items-center space-x-3 cursor-pointer right-4"
                                         data-testid="SelectRecipient__select-contact"
                                       >
                                         <div
@@ -3994,7 +3994,7 @@ exports[`Transaction Send should select network first and see select address inp
                               >
                                 <button
                                   aria-checked="false"
-                                  class="sc-fzoNJl gCmvhq relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+                                  class="sc-fzoNJl gCmvhq relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
                                   data-testid="SelectionBarOption"
                                   role="radio"
                                   type="button"
@@ -4003,7 +4003,7 @@ exports[`Transaction Send should select network first and see select address inp
                                 </button>
                                 <button
                                   aria-checked="false"
-                                  class="sc-fzoNJl gCmvhq relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+                                  class="sc-fzoNJl gCmvhq relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
                                   data-testid="SelectionBarOption"
                                   role="radio"
                                   type="button"
@@ -4012,7 +4012,7 @@ exports[`Transaction Send should select network first and see select address inp
                                 </button>
                                 <button
                                   aria-checked="false"
-                                  class="sc-fzoNJl gCmvhq relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+                                  class="sc-fzoNJl gCmvhq relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
                                   data-testid="SelectionBarOption"
                                   role="radio"
                                   type="button"

--- a/src/domains/transaction/pages/SendVote/Step1.tsx
+++ b/src/domains/transaction/pages/SendVote/Step1.tsx
@@ -56,7 +56,7 @@ export const FirstStep = ({
 			<h1 className="mb-0">{t("TRANSACTION.PAGE_VOTE.FIRST_STEP.TITLE")}</h1>
 			<div className="text-theme-neutral-dark">{t("TRANSACTION.PAGE_VOTE.FIRST_STEP.DESCRIPTION")}</div>
 
-			<div className="mt-4 grid grid-flow-row gap-2">
+			<div className="grid grid-flow-row gap-2 mt-4">
 				<TransactionDetail
 					border={false}
 					label={t("TRANSACTION.NETWORK")}

--- a/src/domains/transaction/pages/SendVote/Step2.tsx
+++ b/src/domains/transaction/pages/SendVote/Step2.tsx
@@ -40,7 +40,7 @@ export const SecondStep = ({
 				<p className="text-theme-neutral-dark">{t("TRANSACTION.PAGE_VOTE.SECOND_STEP.DESCRIPTION")}</p>
 			</div>
 
-			<div className="mt-4 grid grid-flow-row gap-2">
+			<div className="grid grid-flow-row gap-2 mt-4">
 				<TransactionDetail
 					border={false}
 					label={t("TRANSACTION.NETWORK")}

--- a/src/domains/transaction/pages/SendVote/__snapshots__/SendVote.test.tsx.snap
+++ b/src/domains/transaction/pages/SendVote/__snapshots__/SendVote.test.tsx.snap
@@ -419,7 +419,7 @@ exports[`Vote For Delegate should render 1st step 1`] = `
       Select a fee to continue
     </div>
     <div
-      class="mt-4 grid grid-flow-row gap-2"
+      class="grid grid-flow-row gap-2 mt-4"
     >
       <div
         class="flex items-center py-6 true "
@@ -637,7 +637,7 @@ exports[`Vote For Delegate should render 1st step 1`] = `
                   >
                     <button
                       aria-checked="false"
-                      class="sc-fzqARJ fRqGEl relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+                      class="sc-fzqARJ fRqGEl relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
                       data-testid="SelectionBarOption"
                       role="radio"
                       type="button"
@@ -646,7 +646,7 @@ exports[`Vote For Delegate should render 1st step 1`] = `
                     </button>
                     <button
                       aria-checked="false"
-                      class="sc-fzqARJ fRqGEl relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+                      class="sc-fzqARJ fRqGEl relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
                       data-testid="SelectionBarOption"
                       role="radio"
                       type="button"
@@ -655,7 +655,7 @@ exports[`Vote For Delegate should render 1st step 1`] = `
                     </button>
                     <button
                       aria-checked="false"
-                      class="sc-fzqARJ fRqGEl relative px-5 border-transparent focus:outline-none border-b-3 transition-colors duration-300"
+                      class="sc-fzqARJ fRqGEl relative px-5 transition-colors duration-300 border-transparent focus:outline-none border-b-3"
                       data-testid="SelectionBarOption"
                       role="radio"
                       type="button"
@@ -692,7 +692,7 @@ exports[`Vote For Delegate should render 2st step 1`] = `
       </p>
     </div>
     <div
-      class="mt-4 grid grid-flow-row gap-2"
+      class="grid grid-flow-row gap-2 mt-4"
     >
       <div
         class="flex items-center py-6 true "

--- a/src/domains/transaction/routing.ts
+++ b/src/domains/transaction/routing.ts
@@ -29,6 +29,11 @@ export const TransactionRoutes = [
 		component: SendTransfer,
 	},
 	{
+		path: "/profiles/:profileId/send-transfer",
+		exact: true,
+		component: SendTransfer,
+	},
+	{
 		path: "/profiles/:profileId/wallets/:walletId/send-ipfs",
 		exact: true,
 		component: SendIpfs,

--- a/src/domains/vote/pages/Votes/Votes.tsx
+++ b/src/domains/vote/pages/Votes/Votes.tsx
@@ -133,7 +133,7 @@ export const Votes = () => {
 			</Section>
 
 			<div className="container mx-auto px-14">
-				<div className="-my-5 grid grid-flow-col grid-cols-2 gap-6">
+				<div className="grid grid-flow-col grid-cols-2 gap-6 -my-5">
 					<TransactionDetail border={false} label={t("COMMON.NETWORK")}>
 						<SelectNetwork
 							id="Votes__network"

--- a/src/domains/vote/pages/Votes/__snapshots__/Votes.test.tsx.snap
+++ b/src/domains/vote/pages/Votes/__snapshots__/Votes.test.tsx.snap
@@ -326,7 +326,7 @@ exports[`Votes should render 1`] = `
         class="container mx-auto px-14"
       >
         <div
-          class="-my-5 grid grid-flow-col grid-cols-2 gap-6"
+          class="grid grid-flow-col grid-cols-2 gap-6 -my-5"
         >
           <div
             class="flex items-center py-6 true "
@@ -400,7 +400,7 @@ exports[`Votes should render 1`] = `
                 </div>
                 <ul
                   aria-labelledby="Votes__network-label"
-                  class="mt-6 grid grid-cols-6 gap-6"
+                  class="grid grid-cols-6 gap-6 mt-6"
                   id="Votes__network-menu"
                   role="listbox"
                 >
@@ -1496,7 +1496,7 @@ exports[`Votes should select a delegate 1`] = `
         class="container mx-auto px-14"
       >
         <div
-          class="-my-5 grid grid-flow-col grid-cols-2 gap-6"
+          class="grid grid-flow-col grid-cols-2 gap-6 -my-5"
         >
           <div
             class="flex items-center py-6 true "
@@ -1570,7 +1570,7 @@ exports[`Votes should select a delegate 1`] = `
                 </div>
                 <ul
                   aria-labelledby="Votes__network-label"
-                  class="mt-6 grid grid-cols-6 gap-6"
+                  class="grid grid-cols-6 gap-6 mt-6"
                   id="Votes__network-menu"
                   role="listbox"
                 >

--- a/src/domains/wallet/components/MnemonicList/MnemonicList.tsx
+++ b/src/domains/wallet/components/MnemonicList/MnemonicList.tsx
@@ -6,7 +6,7 @@ type Props = {
 
 export function MnemonicList({ mnemonic }: Props) {
 	return (
-		<ul className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 row-gap-5 col-gap-3">
+		<ul className="grid grid-cols-2 row-gap-5 col-gap-3 md:grid-cols-3 lg:grid-cols-4">
 			{mnemonic.split(" ").map((word, index) => (
 				<li
 					data-testid="MnemonicList__item"

--- a/src/domains/wallet/components/MnemonicList/__snapshots__/MnemonicList.test.tsx.snap
+++ b/src/domains/wallet/components/MnemonicList/__snapshots__/MnemonicList.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`MnemonicList should contain mnemonic words 1`] = `
 <DocumentFragment>
   <ul
-    class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 row-gap-5 col-gap-3"
+    class="grid grid-cols-2 row-gap-5 col-gap-3 md:grid-cols-3 lg:grid-cols-4"
   >
     <li
       class="relative px-3 py-3 border rounded border-theme-neutral-light"

--- a/src/domains/wallet/components/WalletVote/WalletVote.tsx
+++ b/src/domains/wallet/components/WalletVote/WalletVote.tsx
@@ -38,7 +38,7 @@ export const WalletVote = ({ votes, onVote, onUnvote, defaultIsOpen, isLoading }
 			</div>
 
 			<Collapse isOpen={isOpen}>
-				<div className="py-4 grid grid-flow-row row-gap-6">
+				<div className="grid grid-flow-row row-gap-6 py-4">
 					{isLoading && <WalletVoteSkeleton />}
 					{!isLoading && hasNoVotes ? (
 						<div data-testid="WalletVote__empty" className="flex items-center justify-between">

--- a/src/domains/wallet/components/WalletVote/__snapshots__/WalletVote.test.tsx.snap
+++ b/src/domains/wallet/components/WalletVote/__snapshots__/WalletVote.test.tsx.snap
@@ -41,7 +41,7 @@ exports[`WalletVote should render 1`] = `
       style="max-height: auto; height: auto; opacity: 1; overflow: auto;"
     >
       <div
-        class="py-4 grid grid-flow-row row-gap-6"
+        class="grid grid-flow-row row-gap-6 py-4"
       >
         <div
           class="flex items-center justify-between"
@@ -254,7 +254,7 @@ exports[`WalletVote should render if a delegate is missing its rank 1`] = `
       style="max-height: auto; height: auto; opacity: 1; overflow: auto;"
     >
       <div
-        class="py-4 grid grid-flow-row row-gap-6"
+        class="grid grid-flow-row row-gap-6 py-4"
       >
         <div
           class="flex items-center justify-between"
@@ -467,7 +467,7 @@ exports[`WalletVote should render loading state 1`] = `
       style="max-height: auto; height: auto; opacity: 1; overflow: auto;"
     >
       <div
-        class="py-4 grid grid-flow-row row-gap-6"
+        class="grid grid-flow-row row-gap-6 py-4"
       >
         <div
           class="flex items-center pr-8 space-x-4"
@@ -731,7 +731,7 @@ exports[`WalletVote should render without votes 1`] = `
       style="max-height: auto; height: auto; opacity: 1; overflow: auto;"
     >
       <div
-        class="py-4 grid grid-flow-row row-gap-6"
+        class="grid grid-flow-row row-gap-6 py-4"
       >
         <div
           class="flex items-center justify-between"
@@ -777,7 +777,7 @@ exports[`WalletVote should render without votes 1`] = `
                   You haven't voted for more than one delegate yet.
                 </span>
                 <a
-                  class="sc-AxgMl fZdMHS inline-flex items-center font-semibold cursor-pointer transition-colors duration-200 text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+                  class="sc-AxgMl fZdMHS inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
                   data-testid="Link"
                   rel="noopener noreferrer"
                   to="https://guides.ark.dev/usage-guides/desktop-wallet-voting"

--- a/src/domains/wallet/pages/CreateWallet/__snapshots__/CreateWallet.test.tsx.snap
+++ b/src/domains/wallet/pages/CreateWallet/__snapshots__/CreateWallet.test.tsx.snap
@@ -385,7 +385,7 @@ exports[`CreateWallet should not allow quick swapping of networks 1`] = `
                         </div>
                         <ul
                           aria-labelledby="CreateWallet__network-label"
-                          class="mt-6 grid grid-cols-6 gap-6"
+                          class="grid grid-cols-6 gap-6 mt-6"
                           id="CreateWallet__network-menu"
                           role="listbox"
                         >
@@ -861,7 +861,7 @@ exports[`CreateWallet should remove pending wallet if not submitted 1`] = `
                         </div>
                         <ul
                           aria-labelledby="CreateWallet__network-label"
-                          class="mt-6 grid grid-cols-6 gap-6"
+                          class="grid grid-cols-6 gap-6 mt-6"
                           id="CreateWallet__network-menu"
                           role="listbox"
                         >
@@ -1337,7 +1337,7 @@ exports[`CreateWallet should render 1`] = `
                         </div>
                         <ul
                           aria-labelledby="CreateWallet__network-label"
-                          class="mt-6 grid grid-cols-6 gap-6"
+                          class="grid grid-cols-6 gap-6 mt-6"
                           id="CreateWallet__network-menu"
                           role="listbox"
                         >
@@ -1513,7 +1513,7 @@ exports[`CreateWallet should render 1st step 1`] = `
         </div>
         <ul
           aria-labelledby="CreateWallet__network-label"
-          class="mt-6 grid grid-cols-6 gap-6"
+          class="grid grid-cols-6 gap-6 mt-6"
           id="CreateWallet__network-menu"
           role="listbox"
         >
@@ -1621,7 +1621,7 @@ exports[`CreateWallet should render 2nd step 1`] = `
         </div>
       </div>
       <ul
-        class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 row-gap-5 col-gap-3"
+        class="grid grid-cols-2 row-gap-5 col-gap-3 md:grid-cols-3 lg:grid-cols-4"
       >
         <li
           class="relative px-3 py-3 border rounded border-theme-neutral-light"

--- a/src/domains/wallet/pages/ImportWallet/__snapshots__/ImportWallet.test.tsx.snap
+++ b/src/domains/wallet/pages/ImportWallet/__snapshots__/ImportWallet.test.tsx.snap
@@ -382,7 +382,7 @@ exports[`ImportWallet should go to previous step 1`] = `
                         </div>
                         <ul
                           aria-labelledby="ImportWallet__network-label"
-                          class="mt-6 grid grid-cols-6 gap-6"
+                          class="grid grid-cols-6 gap-6 mt-6"
                           id="ImportWallet__network-menu"
                           role="listbox"
                         >
@@ -853,7 +853,7 @@ exports[`ImportWallet should import by address 1`] = `
                         </div>
                         <ul
                           aria-labelledby="ImportWallet__network-label"
-                          class="mt-6 grid grid-cols-6 gap-6"
+                          class="grid grid-cols-6 gap-6 mt-6"
                           id="ImportWallet__network-menu"
                           role="listbox"
                         >
@@ -1324,7 +1324,7 @@ exports[`ImportWallet should import by mnemonic 1`] = `
                         </div>
                         <ul
                           aria-labelledby="ImportWallet__network-label"
-                          class="mt-6 grid grid-cols-6 gap-6"
+                          class="grid grid-cols-6 gap-6 mt-6"
                           id="ImportWallet__network-menu"
                           role="listbox"
                         >
@@ -1500,7 +1500,7 @@ exports[`ImportWallet should render 1st step 1`] = `
         </div>
         <ul
           aria-labelledby="ImportWallet__network-label"
-          class="mt-6 grid grid-cols-6 gap-6"
+          class="grid grid-cols-6 gap-6 mt-6"
           id="ImportWallet__network-menu"
           role="listbox"
         >
@@ -2187,7 +2187,7 @@ exports[`ImportWallet should show an error message for duplicate address 1`] = `
                         </div>
                         <ul
                           aria-labelledby="ImportWallet__network-label"
-                          class="mt-6 grid grid-cols-6 gap-6"
+                          class="grid grid-cols-6 gap-6 mt-6"
                           id="ImportWallet__network-menu"
                           role="listbox"
                         >
@@ -2658,7 +2658,7 @@ exports[`ImportWallet should show an error message for invalid address 1`] = `
                         </div>
                         <ul
                           aria-labelledby="ImportWallet__network-label"
-                          class="mt-6 grid grid-cols-6 gap-6"
+                          class="grid grid-cols-6 gap-6 mt-6"
                           id="ImportWallet__network-menu"
                           role="listbox"
                         >

--- a/src/domains/wallet/pages/WalletDetails/__snapshots__/WalletDetails.test.tsx.snap
+++ b/src/domains/wallet/pages/WalletDetails/__snapshots__/WalletDetails.test.tsx.snap
@@ -527,7 +527,7 @@ exports[`WalletDetails should not render the bottom sheet menu when there is onl
               style="max-height: auto; height: auto; opacity: 1; overflow: auto;"
             >
               <div
-                class="py-4 grid grid-flow-row row-gap-6"
+                class="grid grid-flow-row row-gap-6 py-4"
               >
                 <div
                   class="flex items-center justify-between"
@@ -573,7 +573,7 @@ exports[`WalletDetails should not render the bottom sheet menu when there is onl
                           You haven't voted for more than one delegate yet.
                         </span>
                         <a
-                          class="sc-fzozJi fCisHH inline-flex items-center font-semibold cursor-pointer transition-colors duration-200 text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+                          class="sc-fzozJi fCisHH inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
                           data-testid="Link"
                           rel="noopener noreferrer"
                           to="https://guides.ark.dev/usage-guides/desktop-wallet-voting"
@@ -906,7 +906,7 @@ exports[`WalletDetails should not render the bottom sheet menu when there is onl
                           class="inline-block align-middle"
                         >
                           <a
-                            class="sc-fzozJi fCisHH inline-flex items-center font-semibold cursor-pointer transition-colors duration-200 text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+                            class="sc-fzozJi fCisHH inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
                             data-testid="TransactionRow__ID"
                             rel="noopener noreferrer"
                             to="https://dexplorer.ark.io/transaction/8f913b6b719e7767d49861c0aec79ced212767645cb793d75d2f1b89abb49877"
@@ -986,7 +986,7 @@ exports[`WalletDetails should not render the bottom sheet menu when there is onl
                         class="text-center"
                       >
                         <div
-                          class="inline-flex align-middle space-x-1"
+                          class="inline-flex space-x-1 align-middle"
                           data-testid="TransactionRowInfo"
                         />
                       </td>
@@ -1241,7 +1241,7 @@ exports[`WalletDetails should not render the bottom sheet menu when there is onl
                           class="inline-block align-middle"
                         >
                           <a
-                            class="sc-fzozJi fCisHH inline-flex items-center font-semibold cursor-pointer transition-colors duration-200 text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+                            class="sc-fzozJi fCisHH inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
                             data-testid="TransactionRow__ID"
                             rel="noopener noreferrer"
                             to="https://dexplorer.ark.io/transaction/8f913b6b719e7767d49861c0aec79ced212767645cb793d75d2f1b89abb49877"
@@ -1321,7 +1321,7 @@ exports[`WalletDetails should not render the bottom sheet menu when there is onl
                         class="text-center"
                       >
                         <div
-                          class="inline-flex align-middle space-x-1"
+                          class="inline-flex space-x-1 align-middle"
                           data-testid="TransactionRowInfo"
                         />
                       </td>
@@ -1931,7 +1931,7 @@ exports[`WalletDetails should remove wallet name 1`] = `
               style="max-height: auto; height: auto; opacity: 1; overflow: auto;"
             >
               <div
-                class="py-4 grid grid-flow-row row-gap-6"
+                class="grid grid-flow-row row-gap-6 py-4"
               >
                 <div
                   class="flex items-center justify-between"
@@ -1977,7 +1977,7 @@ exports[`WalletDetails should remove wallet name 1`] = `
                           You haven't voted for more than one delegate yet.
                         </span>
                         <a
-                          class="sc-fzozJi fCisHH inline-flex items-center font-semibold cursor-pointer transition-colors duration-200 text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+                          class="sc-fzozJi fCisHH inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
                           data-testid="Link"
                           rel="noopener noreferrer"
                           to="https://guides.ark.dev/usage-guides/desktop-wallet-voting"
@@ -2316,7 +2316,7 @@ exports[`WalletDetails should remove wallet name 1`] = `
                           class="inline-block align-middle"
                         >
                           <a
-                            class="sc-fzozJi fCisHH inline-flex items-center font-semibold cursor-pointer transition-colors duration-200 text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+                            class="sc-fzozJi fCisHH inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
                             data-testid="TransactionRow__ID"
                             rel="noopener noreferrer"
                             to="https://dexplorer.ark.io/transaction/8f913b6b719e7767d49861c0aec79ced212767645cb793d75d2f1b89abb49877"
@@ -2396,7 +2396,7 @@ exports[`WalletDetails should remove wallet name 1`] = `
                         class="text-center"
                       >
                         <div
-                          class="inline-flex align-middle space-x-1"
+                          class="inline-flex space-x-1 align-middle"
                           data-testid="TransactionRowInfo"
                         />
                       </td>
@@ -2651,7 +2651,7 @@ exports[`WalletDetails should remove wallet name 1`] = `
                           class="inline-block align-middle"
                         >
                           <a
-                            class="sc-fzozJi fCisHH inline-flex items-center font-semibold cursor-pointer transition-colors duration-200 text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+                            class="sc-fzozJi fCisHH inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
                             data-testid="TransactionRow__ID"
                             rel="noopener noreferrer"
                             to="https://dexplorer.ark.io/transaction/8f913b6b719e7767d49861c0aec79ced212767645cb793d75d2f1b89abb49877"
@@ -2731,7 +2731,7 @@ exports[`WalletDetails should remove wallet name 1`] = `
                         class="text-center"
                       >
                         <div
-                          class="inline-flex align-middle space-x-1"
+                          class="inline-flex space-x-1 align-middle"
                           data-testid="TransactionRowInfo"
                         />
                       </td>
@@ -3898,7 +3898,7 @@ exports[`WalletDetails should render 1`] = `
               style="max-height: auto; height: auto; opacity: 1; overflow: auto;"
             >
               <div
-                class="py-4 grid grid-flow-row row-gap-6"
+                class="grid grid-flow-row row-gap-6 py-4"
               >
                 <div
                   class="flex items-center justify-between"
@@ -3944,7 +3944,7 @@ exports[`WalletDetails should render 1`] = `
                           You haven't voted for more than one delegate yet.
                         </span>
                         <a
-                          class="sc-fzozJi fCisHH inline-flex items-center font-semibold cursor-pointer transition-colors duration-200 text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+                          class="sc-fzozJi fCisHH inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
                           data-testid="Link"
                           rel="noopener noreferrer"
                           to="https://guides.ark.dev/usage-guides/desktop-wallet-voting"
@@ -4283,7 +4283,7 @@ exports[`WalletDetails should render 1`] = `
                           class="inline-block align-middle"
                         >
                           <a
-                            class="sc-fzozJi fCisHH inline-flex items-center font-semibold cursor-pointer transition-colors duration-200 text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+                            class="sc-fzozJi fCisHH inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
                             data-testid="TransactionRow__ID"
                             rel="noopener noreferrer"
                             to="https://dexplorer.ark.io/transaction/8f913b6b719e7767d49861c0aec79ced212767645cb793d75d2f1b89abb49877"
@@ -4363,7 +4363,7 @@ exports[`WalletDetails should render 1`] = `
                         class="text-center"
                       >
                         <div
-                          class="inline-flex align-middle space-x-1"
+                          class="inline-flex space-x-1 align-middle"
                           data-testid="TransactionRowInfo"
                         />
                       </td>
@@ -4618,7 +4618,7 @@ exports[`WalletDetails should render 1`] = `
                           class="inline-block align-middle"
                         >
                           <a
-                            class="sc-fzozJi fCisHH inline-flex items-center font-semibold cursor-pointer transition-colors duration-200 text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+                            class="sc-fzozJi fCisHH inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
                             data-testid="TransactionRow__ID"
                             rel="noopener noreferrer"
                             to="https://dexplorer.ark.io/transaction/8f913b6b719e7767d49861c0aec79ced212767645cb793d75d2f1b89abb49877"
@@ -4698,7 +4698,7 @@ exports[`WalletDetails should render 1`] = `
                         class="text-center"
                       >
                         <div
-                          class="inline-flex align-middle space-x-1"
+                          class="inline-flex space-x-1 align-middle"
                           data-testid="TransactionRowInfo"
                         />
                       </td>
@@ -5856,7 +5856,7 @@ exports[`WalletDetails should render when wallet hasn't voted 1`] = `
               style="max-height: auto; height: auto; opacity: 1; overflow: auto;"
             >
               <div
-                class="py-4 grid grid-flow-row row-gap-6"
+                class="grid grid-flow-row row-gap-6 py-4"
               >
                 <div
                   class="flex items-center justify-between"
@@ -5902,7 +5902,7 @@ exports[`WalletDetails should render when wallet hasn't voted 1`] = `
                           You haven't voted for more than one delegate yet.
                         </span>
                         <a
-                          class="sc-fzozJi fCisHH inline-flex items-center font-semibold cursor-pointer transition-colors duration-200 text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+                          class="sc-fzozJi fCisHH inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
                           data-testid="Link"
                           rel="noopener noreferrer"
                           to="https://guides.ark.dev/usage-guides/desktop-wallet-voting"
@@ -6235,7 +6235,7 @@ exports[`WalletDetails should render when wallet hasn't voted 1`] = `
                           class="inline-block align-middle"
                         >
                           <a
-                            class="sc-fzozJi fCisHH inline-flex items-center font-semibold cursor-pointer transition-colors duration-200 text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+                            class="sc-fzozJi fCisHH inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
                             data-testid="TransactionRow__ID"
                             rel="noopener noreferrer"
                             to="https://dexplorer.ark.io/transaction/8f913b6b719e7767d49861c0aec79ced212767645cb793d75d2f1b89abb49877"
@@ -6315,7 +6315,7 @@ exports[`WalletDetails should render when wallet hasn't voted 1`] = `
                         class="text-center"
                       >
                         <div
-                          class="inline-flex align-middle space-x-1"
+                          class="inline-flex space-x-1 align-middle"
                           data-testid="TransactionRowInfo"
                         />
                       </td>
@@ -6570,7 +6570,7 @@ exports[`WalletDetails should render when wallet hasn't voted 1`] = `
                           class="inline-block align-middle"
                         >
                           <a
-                            class="sc-fzozJi fCisHH inline-flex items-center font-semibold cursor-pointer transition-colors duration-200 text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+                            class="sc-fzozJi fCisHH inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
                             data-testid="TransactionRow__ID"
                             rel="noopener noreferrer"
                             to="https://dexplorer.ark.io/transaction/8f913b6b719e7767d49861c0aec79ced212767645cb793d75d2f1b89abb49877"
@@ -6650,7 +6650,7 @@ exports[`WalletDetails should render when wallet hasn't voted 1`] = `
                         class="text-center"
                       >
                         <div
-                          class="inline-flex align-middle space-x-1"
+                          class="inline-flex space-x-1 align-middle"
                           data-testid="TransactionRowInfo"
                         />
                       </td>
@@ -7808,7 +7808,7 @@ exports[`WalletDetails should render when wallet not found for votes 1`] = `
               style="max-height: auto; height: auto; opacity: 1; overflow: auto;"
             >
               <div
-                class="py-4 grid grid-flow-row row-gap-6"
+                class="grid grid-flow-row row-gap-6 py-4"
               >
                 <div
                   class="flex items-center justify-between"
@@ -7854,7 +7854,7 @@ exports[`WalletDetails should render when wallet not found for votes 1`] = `
                           You haven't voted for more than one delegate yet.
                         </span>
                         <a
-                          class="sc-fzozJi fCisHH inline-flex items-center font-semibold cursor-pointer transition-colors duration-200 text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+                          class="sc-fzozJi fCisHH inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
                           data-testid="Link"
                           rel="noopener noreferrer"
                           to="https://guides.ark.dev/usage-guides/desktop-wallet-voting"
@@ -8187,7 +8187,7 @@ exports[`WalletDetails should render when wallet not found for votes 1`] = `
                           class="inline-block align-middle"
                         >
                           <a
-                            class="sc-fzozJi fCisHH inline-flex items-center font-semibold cursor-pointer transition-colors duration-200 text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+                            class="sc-fzozJi fCisHH inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
                             data-testid="TransactionRow__ID"
                             rel="noopener noreferrer"
                             to="https://dexplorer.ark.io/transaction/8f913b6b719e7767d49861c0aec79ced212767645cb793d75d2f1b89abb49877"
@@ -8267,7 +8267,7 @@ exports[`WalletDetails should render when wallet not found for votes 1`] = `
                         class="text-center"
                       >
                         <div
-                          class="inline-flex align-middle space-x-1"
+                          class="inline-flex space-x-1 align-middle"
                           data-testid="TransactionRowInfo"
                         />
                       </td>
@@ -8522,7 +8522,7 @@ exports[`WalletDetails should render when wallet not found for votes 1`] = `
                           class="inline-block align-middle"
                         >
                           <a
-                            class="sc-fzozJi fCisHH inline-flex items-center font-semibold cursor-pointer transition-colors duration-200 text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+                            class="sc-fzozJi fCisHH inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
                             data-testid="TransactionRow__ID"
                             rel="noopener noreferrer"
                             to="https://dexplorer.ark.io/transaction/8f913b6b719e7767d49861c0aec79ced212767645cb793d75d2f1b89abb49877"
@@ -8602,7 +8602,7 @@ exports[`WalletDetails should render when wallet not found for votes 1`] = `
                         class="text-center"
                       >
                         <div
-                          class="inline-flex align-middle space-x-1"
+                          class="inline-flex space-x-1 align-middle"
                           data-testid="TransactionRowInfo"
                         />
                       </td>
@@ -9773,7 +9773,7 @@ exports[`WalletDetails should render with timers 1`] = `
               style="max-height: auto; height: auto; opacity: 1; overflow: auto;"
             >
               <div
-                class="py-4 grid grid-flow-row row-gap-6"
+                class="grid grid-flow-row row-gap-6 py-4"
               >
                 <div
                   class="flex items-center justify-between"
@@ -9819,7 +9819,7 @@ exports[`WalletDetails should render with timers 1`] = `
                           You haven't voted for more than one delegate yet.
                         </span>
                         <a
-                          class="sc-fzozJi fCisHH inline-flex items-center font-semibold cursor-pointer transition-colors duration-200 text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+                          class="sc-fzozJi fCisHH inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
                           data-testid="Link"
                           rel="noopener noreferrer"
                           to="https://guides.ark.dev/usage-guides/desktop-wallet-voting"
@@ -10158,7 +10158,7 @@ exports[`WalletDetails should render with timers 1`] = `
                           class="inline-block align-middle"
                         >
                           <a
-                            class="sc-fzozJi fCisHH inline-flex items-center font-semibold cursor-pointer transition-colors duration-200 text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+                            class="sc-fzozJi fCisHH inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
                             data-testid="TransactionRow__ID"
                             rel="noopener noreferrer"
                             to="https://dexplorer.ark.io/transaction/8f913b6b719e7767d49861c0aec79ced212767645cb793d75d2f1b89abb49877"
@@ -10238,7 +10238,7 @@ exports[`WalletDetails should render with timers 1`] = `
                         class="text-center"
                       >
                         <div
-                          class="inline-flex align-middle space-x-1"
+                          class="inline-flex space-x-1 align-middle"
                           data-testid="TransactionRowInfo"
                         />
                       </td>
@@ -10493,7 +10493,7 @@ exports[`WalletDetails should render with timers 1`] = `
                           class="inline-block align-middle"
                         >
                           <a
-                            class="sc-fzozJi fCisHH inline-flex items-center font-semibold cursor-pointer transition-colors duration-200 text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+                            class="sc-fzozJi fCisHH inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
                             data-testid="TransactionRow__ID"
                             rel="noopener noreferrer"
                             to="https://dexplorer.ark.io/transaction/8f913b6b719e7767d49861c0aec79ced212767645cb793d75d2f1b89abb49877"
@@ -10573,7 +10573,7 @@ exports[`WalletDetails should render with timers 1`] = `
                         class="text-center"
                       >
                         <div
-                          class="inline-flex align-middle space-x-1"
+                          class="inline-flex space-x-1 align-middle"
                           data-testid="TransactionRowInfo"
                         />
                       </td>
@@ -11738,7 +11738,7 @@ exports[`WalletDetails should star and unstar a wallet 1`] = `
               style="max-height: auto; height: auto; opacity: 1; overflow: auto;"
             >
               <div
-                class="py-4 grid grid-flow-row row-gap-6"
+                class="grid grid-flow-row row-gap-6 py-4"
               >
                 <div
                   class="flex items-center justify-between"
@@ -11784,7 +11784,7 @@ exports[`WalletDetails should star and unstar a wallet 1`] = `
                           You haven't voted for more than one delegate yet.
                         </span>
                         <a
-                          class="sc-fzozJi fCisHH inline-flex items-center font-semibold cursor-pointer transition-colors duration-200 text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+                          class="sc-fzozJi fCisHH inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
                           data-testid="Link"
                           rel="noopener noreferrer"
                           to="https://guides.ark.dev/usage-guides/desktop-wallet-voting"
@@ -12123,7 +12123,7 @@ exports[`WalletDetails should star and unstar a wallet 1`] = `
                           class="inline-block align-middle"
                         >
                           <a
-                            class="sc-fzozJi fCisHH inline-flex items-center font-semibold cursor-pointer transition-colors duration-200 text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+                            class="sc-fzozJi fCisHH inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
                             data-testid="TransactionRow__ID"
                             rel="noopener noreferrer"
                             to="https://dexplorer.ark.io/transaction/8f913b6b719e7767d49861c0aec79ced212767645cb793d75d2f1b89abb49877"
@@ -12203,7 +12203,7 @@ exports[`WalletDetails should star and unstar a wallet 1`] = `
                         class="text-center"
                       >
                         <div
-                          class="inline-flex align-middle space-x-1"
+                          class="inline-flex space-x-1 align-middle"
                           data-testid="TransactionRowInfo"
                         />
                       </td>
@@ -12458,7 +12458,7 @@ exports[`WalletDetails should star and unstar a wallet 1`] = `
                           class="inline-block align-middle"
                         >
                           <a
-                            class="sc-fzozJi fCisHH inline-flex items-center font-semibold cursor-pointer transition-colors duration-200 text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+                            class="sc-fzozJi fCisHH inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
                             data-testid="TransactionRow__ID"
                             rel="noopener noreferrer"
                             to="https://dexplorer.ark.io/transaction/8f913b6b719e7767d49861c0aec79ced212767645cb793d75d2f1b89abb49877"
@@ -12538,7 +12538,7 @@ exports[`WalletDetails should star and unstar a wallet 1`] = `
                         class="text-center"
                       >
                         <div
-                          class="inline-flex align-middle space-x-1"
+                          class="inline-flex space-x-1 align-middle"
                           data-testid="TransactionRowInfo"
                         />
                       </td>
@@ -13705,7 +13705,7 @@ exports[`WalletDetails should update wallet name 1`] = `
               style="max-height: auto; height: auto; opacity: 1; overflow: auto;"
             >
               <div
-                class="py-4 grid grid-flow-row row-gap-6"
+                class="grid grid-flow-row row-gap-6 py-4"
               >
                 <div
                   class="flex items-center justify-between"
@@ -13751,7 +13751,7 @@ exports[`WalletDetails should update wallet name 1`] = `
                           You haven't voted for more than one delegate yet.
                         </span>
                         <a
-                          class="sc-fzozJi fCisHH inline-flex items-center font-semibold cursor-pointer transition-colors duration-200 text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+                          class="sc-fzozJi fCisHH inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
                           data-testid="Link"
                           rel="noopener noreferrer"
                           to="https://guides.ark.dev/usage-guides/desktop-wallet-voting"
@@ -14090,7 +14090,7 @@ exports[`WalletDetails should update wallet name 1`] = `
                           class="inline-block align-middle"
                         >
                           <a
-                            class="sc-fzozJi fCisHH inline-flex items-center font-semibold cursor-pointer transition-colors duration-200 text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+                            class="sc-fzozJi fCisHH inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
                             data-testid="TransactionRow__ID"
                             rel="noopener noreferrer"
                             to="https://dexplorer.ark.io/transaction/8f913b6b719e7767d49861c0aec79ced212767645cb793d75d2f1b89abb49877"
@@ -14170,7 +14170,7 @@ exports[`WalletDetails should update wallet name 1`] = `
                         class="text-center"
                       >
                         <div
-                          class="inline-flex align-middle space-x-1"
+                          class="inline-flex space-x-1 align-middle"
                           data-testid="TransactionRowInfo"
                         />
                       </td>
@@ -14425,7 +14425,7 @@ exports[`WalletDetails should update wallet name 1`] = `
                           class="inline-block align-middle"
                         >
                           <a
-                            class="sc-fzozJi fCisHH inline-flex items-center font-semibold cursor-pointer transition-colors duration-200 text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+                            class="sc-fzozJi fCisHH inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
                             data-testid="TransactionRow__ID"
                             rel="noopener noreferrer"
                             to="https://dexplorer.ark.io/transaction/8f913b6b719e7767d49861c0aec79ced212767645cb793d75d2f1b89abb49877"
@@ -14505,7 +14505,7 @@ exports[`WalletDetails should update wallet name 1`] = `
                         class="text-center"
                       >
                         <div
-                          class="inline-flex align-middle space-x-1"
+                          class="inline-flex space-x-1 align-middle"
                           data-testid="TransactionRowInfo"
                         />
                       </td>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
- [x] Make `activeWallet` from URL param optional in `SendTransfer`. 
- [x] Create new route under `profile/:profileId/send-transfer`
- [x] Navigate from Navbar send button to `SendTransfer` form
- [x] Sender & Network fields UX tweaks


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
