### PR TITLE
refactor: use index as key for mnemonic list

### DIFF
--- a/src/domains/wallet/components/MnemonicList/MnemonicList.tsx
+++ b/src/domains/wallet/components/MnemonicList/MnemonicList.tsx
@@ -10,7 +10,7 @@ export function MnemonicList({ mnemonic }: Props) {
 			{mnemonic.split(" ").map((word, index) => (
 				<li
 					data-testid="MnemonicList__item"
-					key={word}
+					key={index}
 					className="relative px-3 py-3 border rounded border-theme-neutral-light"
 				>
 					<span className="absolute top-0 left-0 px-1 text-xs font-semibold transform translate-x-2 -translate-y-2 bg-theme-background text-theme-neutral">

--- a/src/domains/wallet/components/MnemonicVerification/MnemonicVerificationProgress.tsx
+++ b/src/domains/wallet/components/MnemonicVerification/MnemonicVerificationProgress.tsx
@@ -6,7 +6,7 @@ import tw, { styled } from "twin.macro";
 import { OptionButton } from "./MnemonicVerificationOptions";
 
 const TabStyled = styled(OptionButton)<{ isActive: boolean; isComplete: boolean; isPending: boolean }>`
-	${tw`flex-1 flex justify-center pointer-events-none transition-colors duration-200`};
+	${tw`flex-1 flex items-center justify-center pointer-events-none transition-colors duration-200`};
 	${({ isActive }) => isActive && tw`font-medium bg-theme-success-contrast border-theme-success`};
 	${({ isComplete }) => isComplete && tw`border-transparent bg-theme-success-200`};
 	${({ isPending }) => isPending && tw`border-theme-primary-contrast text-theme-primary`};

--- a/src/domains/wallet/components/MnemonicVerification/__snapshots__/MnemonicVerificationProgress.test.tsx.snap
+++ b/src/domains/wallet/components/MnemonicVerification/__snapshots__/MnemonicVerificationProgress.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`MnemonicVerificationProgress should render tabs 1`] = `
     class="flex space-x-2"
   >
     <button
-      class="sc-AxirZ sc-AxiKw blhJmN"
+      class="sc-AxirZ sc-AxiKw dmBuVu"
       data-testid="MnemonicVerificationProgress__Tab"
       disabled=""
     >
@@ -25,7 +25,7 @@ exports[`MnemonicVerificationProgress should render tabs 1`] = `
       </span>
     </button>
     <button
-      class="sc-AxirZ sc-AxiKw iaFsHC"
+      class="sc-AxirZ sc-AxiKw bAplex"
       data-testid="MnemonicVerificationProgress__Tab"
       disabled=""
     >
@@ -34,7 +34,7 @@ exports[`MnemonicVerificationProgress should render tabs 1`] = `
       </span>
     </button>
     <button
-      class="sc-AxirZ sc-AxiKw eoVinv"
+      class="sc-AxirZ sc-AxiKw fvXQtI"
       data-testid="MnemonicVerificationProgress__Tab"
       disabled=""
     >


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Use the index as key instead of the mnemonic word to avoid potentially duplicate keys.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
