### PR TITLE
test: fix `InputCurrency` tests

### DIFF
--- a/src/app/components/Input/InputCurrency.test.tsx
+++ b/src/app/components/Input/InputCurrency.test.tsx
@@ -69,7 +69,7 @@ describe("InputCurrency", () => {
 		const { getByTestId, rerender } = render(<InputCurrency value=".01" />);
 		const input = getByTestId("InputCurrency");
 
-		waitFor(() => expect(input).toHaveValue("0.01"));
+		expect(input).toHaveValue("0.01");
 
 		rerender(<InputCurrency value={undefined} />);
 


### PR DESCRIPTION
## Summary

This PR fix the error message below:

```
PASS  src/app/components/Input/InputCurrency.test.tsx (374 MB heap size)
  ● Console

    console.error node_modules/@testing-library/react/dist/act-compat.js:52
      Warning: You seem to have overlapping act() calls, this is not supported. Be sure to await previous act() calls before making a new one.
```

## Checklist

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged
