### PR TITLE
refactor: position modal in center

### DIFF
--- a/src/app/components/DeleteResource/__snapshots__/DeleteResource.test.tsx.snap
+++ b/src/app/components/DeleteResource/__snapshots__/DeleteResource.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`DeleteResource should not render if not open 1`] = `<DocumentFragment /
 exports[`DeleteResource should render with children 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"

--- a/src/app/components/DeleteResource/__snapshots__/DeleteResource.test.tsx.snap
+++ b/src/app/components/DeleteResource/__snapshots__/DeleteResource.test.tsx.snap
@@ -5,14 +5,14 @@ exports[`DeleteResource should not render if not open 1`] = `<DocumentFragment /
 exports[`DeleteResource should render with children 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxiKw cTRlJa absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxiKw cTRlJa absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div

--- a/src/app/components/Modal/Modal.test.tsx
+++ b/src/app/components/Modal/Modal.test.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { act, fireEvent, render } from "testing-library";
 
 import { Modal } from "./Modal";
+import { modalTopOffsetClass } from "./utils";
 
 describe("Modal", () => {
 	it("should not render if not open", () => {
@@ -97,5 +98,25 @@ describe("Modal", () => {
 		const { container } = render(<Modal title="ark" size="5xl" isOpen={true} />);
 
 		expect(container).toMatchSnapshot();
+	});
+
+	it("should render a 5x large one", () => {
+		const { container } = render(<Modal title="ark" size="5xl" isOpen={true} />);
+
+		expect(container).toMatchSnapshot();
+	});
+
+	it("should not add top offset class if modal content fits in window height", () => {
+		const modalHeightMock = 400;
+		const windowHeightMock = 1000;
+		const topOffsetClass = modalTopOffsetClass(modalHeightMock, windowHeightMock);
+		expect(topOffsetClass).toBe("");
+	});
+
+	it("should add top offset class if modal content is higher than window height", () => {
+		const modalHeightMock = 1000;
+		const windowHeightMock = 1000;
+		const topOffsetClass = modalTopOffsetClass(modalHeightMock, windowHeightMock);
+		expect(topOffsetClass).not.toBe("");
 	});
 });

--- a/src/app/components/Modal/Modal.tsx
+++ b/src/app/components/Modal/Modal.tsx
@@ -1,8 +1,10 @@
 import { Button } from "app/components/Button";
 import { Icon } from "app/components/Icon";
-import React, { useCallback, useEffect } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import tw, { styled } from "twin.macro";
 import { Size } from "types";
+
+import { modalTopOffsetClass } from "./utils";
 
 type ModalProps = {
 	children: React.ReactNode;
@@ -51,53 +53,64 @@ const ModalContainer = styled.div<{ size?: Size }>`
 	}}
 `;
 
-const ModalContent = (props: ModalContentProps) => (
-	<ModalContainer
-		size={props.size}
-		className="absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
-		data-testid="modal__inner"
-	>
-		<div className="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:text-white hover:bg-theme-neutral-900">
-			<Button
-				data-testid="modal__close-btn"
-				variant="transparent"
-				size="icon"
-				onClick={props.onClose}
-				className="w-11 h-11"
-			>
-				<Icon name="CrossSlim" width={14} height={14} />
-			</Button>
-		</div>
+const ModalContent = (props: ModalContentProps) => {
+	const [topOffsetClass, setTopOffsetClass] = useState<string>();
+	const modalRef = useRef<any>();
 
-		<div className="relative">
-			{props.banner ? (
-				<div className="relative h-56 mb-10 -mx-10 -mt-10">
-					{props.banner}
+	useEffect(() => {
+		const topClass = modalTopOffsetClass(modalRef?.current?.clientHeight, window.innerHeight);
+		setTopOffsetClass(topClass);
+	}, [window, modalRef, setTopOffsetClass, modalTopOffsetClass]);
 
-					<div className="absolute bottom-0 left-0 mb-10 ml-10">
-						<h2
-							className={`text-5xl font-extrabold leading-tight m-0 ${
-								props.titleClass || "text-theme-text"
-							}`}
-						>
-							{props.title}
-						</h2>
-					</div>
-				</div>
-			) : (
-				<h2 className="mb-0 text-3xl font-bold">{props.title}</h2>
-			)}
-
-			<div className="flex-1">
-				{props.image}
-
-				{props.description && <div className="mt-1 text-theme-neutral-dark">{props.description}</div>}
-
-				{props.children}
+	return (
+		<ModalContainer
+			ref={modalRef}
+			size={props.size}
+			className={`absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background ${topOffsetClass}`}
+			data-testid="modal__inner"
+		>
+			<div className="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:text-white hover:bg-theme-neutral-900">
+				<Button
+					data-testid="modal__close-btn"
+					variant="transparent"
+					size="icon"
+					onClick={props.onClose}
+					className="w-11 h-11"
+				>
+					<Icon name="CrossSlim" width={14} height={14} />
+				</Button>
 			</div>
-		</div>
-	</ModalContainer>
-);
+
+			<div className="relative">
+				{props.banner ? (
+					<div className="relative h-56 mb-10 -mx-10 -mt-10">
+						{props.banner}
+
+						<div className="absolute bottom-0 left-0 mb-10 ml-10">
+							<h2
+								className={`text-5xl font-extrabold leading-tight m-0 ${
+									props.titleClass || "text-theme-text"
+								}`}
+							>
+								{props.title}
+							</h2>
+						</div>
+					</div>
+				) : (
+					<h2 className="mb-0 text-3xl font-bold">{props.title}</h2>
+				)}
+
+				<div className="flex-1">
+					{props.image}
+
+					{props.description && <div className="mt-1 text-theme-neutral-dark">{props.description}</div>}
+
+					{props.children}
+				</div>
+			</div>
+		</ModalContainer>
+	);
+};
 
 interface BodyRightOffset {
 	[key: string]: string;
@@ -149,7 +162,7 @@ export const Modal = (props: ModalProps) => {
 	}
 
 	return (
-		<div className="fixed inset-0 z-50 w-full h-full overflow-y-scroll">
+		<div className="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center">
 			<div
 				className="fixed z-50 w-full h-full bg-black opacity-50"
 				data-testid="modal__overlay"

--- a/src/app/components/Modal/Modal.tsx
+++ b/src/app/components/Modal/Modal.tsx
@@ -60,7 +60,7 @@ const ModalContent = (props: ModalContentProps) => {
 	useEffect(() => {
 		const topClass = modalTopOffsetClass(modalRef?.current?.clientHeight, window.innerHeight);
 		setTopOffsetClass(topClass);
-	}, [window, modalRef, setTopOffsetClass, modalTopOffsetClass]);
+	}, [modalRef, setTopOffsetClass]);
 
 	return (
 		<ModalContainer

--- a/src/app/components/Modal/Modal.tsx
+++ b/src/app/components/Modal/Modal.tsx
@@ -162,7 +162,7 @@ export const Modal = (props: ModalProps) => {
 	}
 
 	return (
-		<div className="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center">
+		<div className="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll">
 			<div
 				className="fixed z-50 w-full h-full bg-black opacity-50"
 				data-testid="modal__overlay"

--- a/src/app/components/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/src/app/components/Modal/__snapshots__/Modal.test.tsx.snap
@@ -3,14 +3,14 @@
 exports[`Modal should closed by the Esc key 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxiKw cTRlJa absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxiKw cTRlJa absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div
@@ -55,14 +55,14 @@ exports[`Modal should not render if not open 1`] = `<DocumentFragment />`;
 exports[`Modal should render a 3x large one 1`] = `
 <div>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxiKw jRkhhQ absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxiKw jRkhhQ absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div
@@ -105,14 +105,14 @@ exports[`Modal should render a 3x large one 1`] = `
 exports[`Modal should render a 4x large one 1`] = `
 <div>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxiKw jCpCzv absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxiKw jCpCzv absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div
@@ -155,14 +155,64 @@ exports[`Modal should render a 4x large one 1`] = `
 exports[`Modal should render a 5x large one 1`] = `
 <div>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxiKw bHERBC absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxiKw bHERBC absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
+      data-testid="modal__inner"
+    >
+      <div
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:text-white hover:bg-theme-neutral-900"
+      >
+        <button
+          class="sc-AxjAm goVygI w-11 h-11"
+          color="primary"
+          data-testid="modal__close-btn"
+          type="button"
+        >
+          <div
+            class="sc-AxirZ fFqjhX"
+            height="14"
+            width="14"
+          >
+            <svg>
+              cross-slim.svg
+            </svg>
+          </div>
+        </button>
+      </div>
+      <div
+        class="relative"
+      >
+        <h2
+          class="mb-0 text-3xl font-bold"
+        >
+          ark
+        </h2>
+        <div
+          class="flex-1"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Modal should render a 5x large one 2`] = `
+<div>
+  <div
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+  >
+    <div
+      class="fixed z-50 w-full h-full bg-black opacity-50"
+      data-testid="modal__overlay"
+    />
+    <div
+      class="sc-AxiKw bHERBC absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div
@@ -205,14 +255,14 @@ exports[`Modal should render a 5x large one 1`] = `
 exports[`Modal should render a large one 1`] = `
 <div>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxiKw jnoDfx absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxiKw jnoDfx absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div
@@ -255,14 +305,14 @@ exports[`Modal should render a large one 1`] = `
 exports[`Modal should render a medium one 1`] = `
 <div>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxiKw fWjEmW absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxiKw fWjEmW absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div
@@ -305,14 +355,14 @@ exports[`Modal should render a medium one 1`] = `
 exports[`Modal should render a modal with content 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxiKw cTRlJa absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxiKw cTRlJa absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div
@@ -357,14 +407,14 @@ exports[`Modal should render a modal with content 1`] = `
 exports[`Modal should render a modal with description 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxiKw cTRlJa absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxiKw cTRlJa absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div
@@ -413,14 +463,14 @@ exports[`Modal should render a modal with description 1`] = `
 exports[`Modal should render a modal with overlay 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxiKw cTRlJa absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxiKw cTRlJa absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div
@@ -465,14 +515,14 @@ exports[`Modal should render a modal with overlay 1`] = `
 exports[`Modal should render a small one 1`] = `
 <div>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxiKw wLhVq absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxiKw wLhVq absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div
@@ -515,14 +565,14 @@ exports[`Modal should render a small one 1`] = `
 exports[`Modal should render a xlarge one 1`] = `
 <div>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxiKw Zauxd absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxiKw Zauxd absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div

--- a/src/app/components/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/src/app/components/Modal/__snapshots__/Modal.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Modal should closed by the Esc key 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
@@ -55,7 +55,7 @@ exports[`Modal should not render if not open 1`] = `<DocumentFragment />`;
 exports[`Modal should render a 3x large one 1`] = `
 <div>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
@@ -105,7 +105,7 @@ exports[`Modal should render a 3x large one 1`] = `
 exports[`Modal should render a 4x large one 1`] = `
 <div>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
@@ -155,7 +155,7 @@ exports[`Modal should render a 4x large one 1`] = `
 exports[`Modal should render a 5x large one 1`] = `
 <div>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
@@ -205,7 +205,7 @@ exports[`Modal should render a 5x large one 1`] = `
 exports[`Modal should render a 5x large one 2`] = `
 <div>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
@@ -255,7 +255,7 @@ exports[`Modal should render a 5x large one 2`] = `
 exports[`Modal should render a large one 1`] = `
 <div>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
@@ -305,7 +305,7 @@ exports[`Modal should render a large one 1`] = `
 exports[`Modal should render a medium one 1`] = `
 <div>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
@@ -355,7 +355,7 @@ exports[`Modal should render a medium one 1`] = `
 exports[`Modal should render a modal with content 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
@@ -407,7 +407,7 @@ exports[`Modal should render a modal with content 1`] = `
 exports[`Modal should render a modal with description 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
@@ -463,7 +463,7 @@ exports[`Modal should render a modal with description 1`] = `
 exports[`Modal should render a modal with overlay 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
@@ -515,7 +515,7 @@ exports[`Modal should render a modal with overlay 1`] = `
 exports[`Modal should render a small one 1`] = `
 <div>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
@@ -565,7 +565,7 @@ exports[`Modal should render a small one 1`] = `
 exports[`Modal should render a xlarge one 1`] = `
 <div>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"

--- a/src/app/components/Modal/utils.ts
+++ b/src/app/components/Modal/utils.ts
@@ -1,0 +1,4 @@
+export const modalTopOffsetClass = (itemHeight: number, windowHeight: number) => {
+	const additionalHeight = 10;
+	return itemHeight + additionalHeight > windowHeight ? "mt-36" : "";
+};

--- a/src/app/components/SearchResource/__snapshots__/SearchResource.test.tsx.snap
+++ b/src/app/components/SearchResource/__snapshots__/SearchResource.test.tsx.snap
@@ -5,14 +5,14 @@ exports[`SearchResource should not render if not open 1`] = `<DocumentFragment /
 exports[`SearchResource should render with children 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxiKw bHERBC absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxiKw bHERBC absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div

--- a/src/app/components/SearchResource/__snapshots__/SearchResource.test.tsx.snap
+++ b/src/app/components/SearchResource/__snapshots__/SearchResource.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`SearchResource should not render if not open 1`] = `<DocumentFragment /
 exports[`SearchResource should render with children 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"

--- a/src/domains/contact/components/CreateContact/__snapshots__/CreateContact.test.tsx.snap
+++ b/src/domains/contact/components/CreateContact/__snapshots__/CreateContact.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`CreateContact should not render if not open 1`] = `<DocumentFragment />
 exports[`CreateContact should render create contact modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"

--- a/src/domains/contact/components/CreateContact/__snapshots__/CreateContact.test.tsx.snap
+++ b/src/domains/contact/components/CreateContact/__snapshots__/CreateContact.test.tsx.snap
@@ -5,14 +5,14 @@ exports[`CreateContact should not render if not open 1`] = `<DocumentFragment />
 exports[`CreateContact should render create contact modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxiKw cTRlJa absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxiKw cTRlJa absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div

--- a/src/domains/contact/components/DeleteContact/__snapshots__/DeleteContact.test.tsx.snap
+++ b/src/domains/contact/components/DeleteContact/__snapshots__/DeleteContact.test.tsx.snap
@@ -5,14 +5,14 @@ exports[`DeleteContact should not render if not open 1`] = `<DocumentFragment />
 exports[`DeleteContact should render a modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxiKw cTRlJa absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxiKw cTRlJa absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div

--- a/src/domains/contact/components/DeleteContact/__snapshots__/DeleteContact.test.tsx.snap
+++ b/src/domains/contact/components/DeleteContact/__snapshots__/DeleteContact.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`DeleteContact should not render if not open 1`] = `<DocumentFragment />
 exports[`DeleteContact should render a modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"

--- a/src/domains/contact/components/SearchContact/__snapshots__/SearchContact.test.tsx.snap
+++ b/src/domains/contact/components/SearchContact/__snapshots__/SearchContact.test.tsx.snap
@@ -5,14 +5,14 @@ exports[`SearchContact should not render if not open 1`] = `<DocumentFragment />
 exports[`SearchContact should render a modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxiKw bHERBC absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxiKw bHERBC absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div
@@ -658,14 +658,14 @@ exports[`SearchContact should render a modal 1`] = `
 exports[`SearchContact should render a modal with custom title and description 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxiKw bHERBC absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxiKw bHERBC absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div

--- a/src/domains/contact/components/SearchContact/__snapshots__/SearchContact.test.tsx.snap
+++ b/src/domains/contact/components/SearchContact/__snapshots__/SearchContact.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`SearchContact should not render if not open 1`] = `<DocumentFragment />
 exports[`SearchContact should render a modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
@@ -658,7 +658,7 @@ exports[`SearchContact should render a modal 1`] = `
 exports[`SearchContact should render a modal with custom title and description 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"

--- a/src/domains/contact/components/UpdateContact/__snapshots__/UpdateContact.test.tsx.snap
+++ b/src/domains/contact/components/UpdateContact/__snapshots__/UpdateContact.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`UpdateContact should not render if not open 1`] = `<DocumentFragment />
 exports[`UpdateContact should render a modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"

--- a/src/domains/contact/components/UpdateContact/__snapshots__/UpdateContact.test.tsx.snap
+++ b/src/domains/contact/components/UpdateContact/__snapshots__/UpdateContact.test.tsx.snap
@@ -5,14 +5,14 @@ exports[`UpdateContact should not render if not open 1`] = `<DocumentFragment />
 exports[`UpdateContact should render a modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxiKw cTRlJa absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxiKw cTRlJa absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div

--- a/src/domains/exchange/components/AddExchange/__snapshots__/AddExchange.test.tsx.snap
+++ b/src/domains/exchange/components/AddExchange/__snapshots__/AddExchange.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`AddExchange should not render if not open 1`] = `<DocumentFragment />`;
 exports[`AddExchange should render a modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"

--- a/src/domains/exchange/components/AddExchange/__snapshots__/AddExchange.test.tsx.snap
+++ b/src/domains/exchange/components/AddExchange/__snapshots__/AddExchange.test.tsx.snap
@@ -5,14 +5,14 @@ exports[`AddExchange should not render if not open 1`] = `<DocumentFragment />`;
 exports[`AddExchange should render a modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxiKw jCpCzv absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxiKw jCpCzv absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div

--- a/src/domains/help/components/ContactUs/__snapshots__/ContactUs.test.tsx.snap
+++ b/src/domains/help/components/ContactUs/__snapshots__/ContactUs.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`ContactUs should not render if not open 1`] = `<DocumentFragment />`;
 exports[`ContactUs should render a modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"

--- a/src/domains/help/components/ContactUs/__snapshots__/ContactUs.test.tsx.snap
+++ b/src/domains/help/components/ContactUs/__snapshots__/ContactUs.test.tsx.snap
@@ -5,14 +5,14 @@ exports[`ContactUs should not render if not open 1`] = `<DocumentFragment />`;
 exports[`ContactUs should render a modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-fzplWN jxRzUr absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-fzplWN jxRzUr absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div

--- a/src/domains/help/components/SearchHelp/__snapshots__/SearchHelp.test.tsx.snap
+++ b/src/domains/help/components/SearchHelp/__snapshots__/SearchHelp.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`SearchHelp should not render if not open 1`] = `<DocumentFragment />`;
 exports[`SearchHelp should render a modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
@@ -290,7 +290,7 @@ exports[`SearchHelp should render a modal 1`] = `
 exports[`SearchHelp should render a modal 2`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"

--- a/src/domains/help/components/SearchHelp/__snapshots__/SearchHelp.test.tsx.snap
+++ b/src/domains/help/components/SearchHelp/__snapshots__/SearchHelp.test.tsx.snap
@@ -5,14 +5,14 @@ exports[`SearchHelp should not render if not open 1`] = `<DocumentFragment />`;
 exports[`SearchHelp should render a modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxhCb kNSjES absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxhCb kNSjES absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div
@@ -290,14 +290,14 @@ exports[`SearchHelp should render a modal 1`] = `
 exports[`SearchHelp should render a modal 2`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxhCb kNSjES absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxhCb kNSjES absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div

--- a/src/domains/news/components/AddAssets/__snapshots__/AddAssets.test.tsx.snap
+++ b/src/domains/news/components/AddAssets/__snapshots__/AddAssets.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`AddAssets should not render if not open 1`] = `<DocumentFragment />`;
 exports[`AddAssets should render a modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"

--- a/src/domains/news/components/AddAssets/__snapshots__/AddAssets.test.tsx.snap
+++ b/src/domains/news/components/AddAssets/__snapshots__/AddAssets.test.tsx.snap
@@ -5,14 +5,14 @@ exports[`AddAssets should not render if not open 1`] = `<DocumentFragment />`;
 exports[`AddAssets should render a modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxgMl hWgHJq absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxgMl hWgHJq absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div

--- a/src/domains/plugin/components/AddBlacklistPlugin/__snapshots__/AddBlacklistPlugin.test.tsx.snap
+++ b/src/domains/plugin/components/AddBlacklistPlugin/__snapshots__/AddBlacklistPlugin.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`AddBlacklistPlugin should not render if not open 1`] = `<DocumentFragme
 exports[`AddBlacklistPlugin should render a modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"

--- a/src/domains/plugin/components/AddBlacklistPlugin/__snapshots__/AddBlacklistPlugin.test.tsx.snap
+++ b/src/domains/plugin/components/AddBlacklistPlugin/__snapshots__/AddBlacklistPlugin.test.tsx.snap
@@ -5,14 +5,14 @@ exports[`AddBlacklistPlugin should not render if not open 1`] = `<DocumentFragme
 exports[`AddBlacklistPlugin should render a modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxiKw jCpCzv absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxiKw jCpCzv absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div

--- a/src/domains/plugin/components/BestPlugins/__snapshots__/BestPlugins.test.tsx.snap
+++ b/src/domains/plugin/components/BestPlugins/__snapshots__/BestPlugins.test.tsx.snap
@@ -5,14 +5,14 @@ exports[`BestPlugins should not render if not open 1`] = `<DocumentFragment />`;
 exports[`BestPlugins should render a modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxiKw jCpCzv absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxiKw jCpCzv absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div

--- a/src/domains/plugin/components/BestPlugins/__snapshots__/BestPlugins.test.tsx.snap
+++ b/src/domains/plugin/components/BestPlugins/__snapshots__/BestPlugins.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`BestPlugins should not render if not open 1`] = `<DocumentFragment />`;
 exports[`BestPlugins should render a modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"

--- a/src/domains/plugin/components/BlacklistPlugins/__snapshots__/BlacklistPlugins.test.tsx.snap
+++ b/src/domains/plugin/components/BlacklistPlugins/__snapshots__/BlacklistPlugins.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`BlacklistPlugins should not render if not open 1`] = `<DocumentFragment
 exports[`BlacklistPlugins should render a modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
@@ -185,7 +185,7 @@ exports[`BlacklistPlugins should render a modal 1`] = `
 exports[`BlacklistPlugins should render a modal with blacklist 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"

--- a/src/domains/plugin/components/BlacklistPlugins/__snapshots__/BlacklistPlugins.test.tsx.snap
+++ b/src/domains/plugin/components/BlacklistPlugins/__snapshots__/BlacklistPlugins.test.tsx.snap
@@ -5,14 +5,14 @@ exports[`BlacklistPlugins should not render if not open 1`] = `<DocumentFragment
 exports[`BlacklistPlugins should render a modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxiKw jCpCzv absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxiKw jCpCzv absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div
@@ -185,14 +185,14 @@ exports[`BlacklistPlugins should render a modal 1`] = `
 exports[`BlacklistPlugins should render a modal with blacklist 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxiKw jCpCzv absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxiKw jCpCzv absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div

--- a/src/domains/plugin/components/FeaturedPlugins/__snapshots__/FeaturedPlugins.test.tsx.snap
+++ b/src/domains/plugin/components/FeaturedPlugins/__snapshots__/FeaturedPlugins.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`FeaturedPlugins should not render if not open 1`] = `<DocumentFragment 
 exports[`FeaturedPlugins should render a modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"

--- a/src/domains/plugin/components/FeaturedPlugins/__snapshots__/FeaturedPlugins.test.tsx.snap
+++ b/src/domains/plugin/components/FeaturedPlugins/__snapshots__/FeaturedPlugins.test.tsx.snap
@@ -5,14 +5,14 @@ exports[`FeaturedPlugins should not render if not open 1`] = `<DocumentFragment 
 exports[`FeaturedPlugins should render a modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxiKw jCpCzv absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxiKw jCpCzv absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div

--- a/src/domains/plugin/components/InstallPlugin/__snapshots__/InstallPlugin.test.tsx.snap
+++ b/src/domains/plugin/components/InstallPlugin/__snapshots__/InstallPlugin.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`InstallPlugin should not render if not open 1`] = `<DocumentFragment />
 exports[`InstallPlugin should render 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"

--- a/src/domains/plugin/components/InstallPlugin/__snapshots__/InstallPlugin.test.tsx.snap
+++ b/src/domains/plugin/components/InstallPlugin/__snapshots__/InstallPlugin.test.tsx.snap
@@ -5,14 +5,14 @@ exports[`InstallPlugin should not render if not open 1`] = `<DocumentFragment />
 exports[`InstallPlugin should render 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxiKw jnoDfx absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxiKw jnoDfx absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div

--- a/src/domains/plugin/pages/PluginManager/__snapshots__/PluginManager.test.tsx.snap
+++ b/src/domains/plugin/pages/PluginManager/__snapshots__/PluginManager.test.tsx.snap
@@ -15341,14 +15341,14 @@ exports[`PluginManager should download & install plugin on game 1`] = `
     </div>
   </div>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-fzoXzr hUFzRy absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-fzoXzr hUFzRy absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div
@@ -20067,14 +20067,14 @@ exports[`PluginManager should download & install plugin on home 1`] = `
     </div>
   </div>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-fzoXzr hUFzRy absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-fzoXzr hUFzRy absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div
@@ -22687,14 +22687,14 @@ exports[`PluginManager should install plugin from header install button 1`] = `
     </div>
   </div>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-fzoXzr hUFzRy absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-fzoXzr hUFzRy absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div

--- a/src/domains/plugin/pages/PluginManager/__snapshots__/PluginManager.test.tsx.snap
+++ b/src/domains/plugin/pages/PluginManager/__snapshots__/PluginManager.test.tsx.snap
@@ -15341,7 +15341,7 @@ exports[`PluginManager should download & install plugin on game 1`] = `
     </div>
   </div>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
@@ -20067,7 +20067,7 @@ exports[`PluginManager should download & install plugin on home 1`] = `
     </div>
   </div>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
@@ -22687,7 +22687,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
     </div>
   </div>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"

--- a/src/domains/plugin/pages/PluginsCategory/__snapshots__/PluginsCategory.test.tsx.snap
+++ b/src/domains/plugin/pages/PluginsCategory/__snapshots__/PluginsCategory.test.tsx.snap
@@ -6354,14 +6354,14 @@ exports[`PluginsCategory should download & install plugin 1`] = `
     </div>
   </div>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-fzoXzr hUFzRy absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-fzoXzr hUFzRy absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div
@@ -7558,14 +7558,14 @@ exports[`PluginsCategory should install plugin from header install button 1`] = 
     </div>
   </div>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-fzoXzr hUFzRy absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-fzoXzr hUFzRy absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div

--- a/src/domains/plugin/pages/PluginsCategory/__snapshots__/PluginsCategory.test.tsx.snap
+++ b/src/domains/plugin/pages/PluginsCategory/__snapshots__/PluginsCategory.test.tsx.snap
@@ -6354,7 +6354,7 @@ exports[`PluginsCategory should download & install plugin 1`] = `
     </div>
   </div>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
@@ -7558,7 +7558,7 @@ exports[`PluginsCategory should install plugin from header install button 1`] = 
     </div>
   </div>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"

--- a/src/domains/profile/components/DeleteProfile/__snapshots__/DeleteProfile.test.tsx.snap
+++ b/src/domains/profile/components/DeleteProfile/__snapshots__/DeleteProfile.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`DeleteProfile should render 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"

--- a/src/domains/profile/components/DeleteProfile/__snapshots__/DeleteProfile.test.tsx.snap
+++ b/src/domains/profile/components/DeleteProfile/__snapshots__/DeleteProfile.test.tsx.snap
@@ -3,14 +3,14 @@
 exports[`DeleteProfile should render 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxiKw cTRlJa absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxiKw cTRlJa absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div

--- a/src/domains/profile/components/ProfileCreated/__snapshots__/ProfileCreated.test.tsx.snap
+++ b/src/domains/profile/components/ProfileCreated/__snapshots__/ProfileCreated.test.tsx.snap
@@ -5,14 +5,14 @@ exports[`ProfileCreated should not render if not open 1`] = `<DocumentFragment /
 exports[`ProfileCreated should render a modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxiKw cTRlJa absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxiKw cTRlJa absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div

--- a/src/domains/profile/components/ProfileCreated/__snapshots__/ProfileCreated.test.tsx.snap
+++ b/src/domains/profile/components/ProfileCreated/__snapshots__/ProfileCreated.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`ProfileCreated should not render if not open 1`] = `<DocumentFragment /
 exports[`ProfileCreated should render a modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"

--- a/src/domains/profile/components/ResetProfile/__snapshots__/ResetProfile.test.tsx.snap
+++ b/src/domains/profile/components/ResetProfile/__snapshots__/ResetProfile.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`ResetProfile should render 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"

--- a/src/domains/profile/components/ResetProfile/__snapshots__/ResetProfile.test.tsx.snap
+++ b/src/domains/profile/components/ResetProfile/__snapshots__/ResetProfile.test.tsx.snap
@@ -3,14 +3,14 @@
 exports[`ResetProfile should render 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxiKw cTRlJa absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxiKw cTRlJa absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div

--- a/src/domains/profile/components/SignIn/__snapshots__/SignIn.test.tsx.snap
+++ b/src/domains/profile/components/SignIn/__snapshots__/SignIn.test.tsx.snap
@@ -5,14 +5,14 @@ exports[`SignIn should not render if not open 1`] = `<DocumentFragment />`;
 exports[`SignIn should render a modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-fzplWN jxRzUr absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-fzplWN jxRzUr absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div

--- a/src/domains/profile/components/SignIn/__snapshots__/SignIn.test.tsx.snap
+++ b/src/domains/profile/components/SignIn/__snapshots__/SignIn.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`SignIn should not render if not open 1`] = `<DocumentFragment />`;
 exports[`SignIn should render a modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"

--- a/src/domains/profile/pages/MyRegistrations/components/HistoryModal/__snapshots__/HistoryModal.test.tsx.snap
+++ b/src/domains/profile/pages/MyRegistrations/components/HistoryModal/__snapshots__/HistoryModal.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`HistoryModal should render empty state 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
@@ -165,7 +165,7 @@ exports[`HistoryModal should render empty state 1`] = `
 exports[`HistoryModal should render properly 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"

--- a/src/domains/profile/pages/MyRegistrations/components/HistoryModal/__snapshots__/HistoryModal.test.tsx.snap
+++ b/src/domains/profile/pages/MyRegistrations/components/HistoryModal/__snapshots__/HistoryModal.test.tsx.snap
@@ -3,14 +3,14 @@
 exports[`HistoryModal should render empty state 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxiKw fWjEmW absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxiKw fWjEmW absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div
@@ -165,14 +165,14 @@ exports[`HistoryModal should render empty state 1`] = `
 exports[`HistoryModal should render properly 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxiKw fWjEmW absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxiKw fWjEmW absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div

--- a/src/domains/profile/pages/MyRegistrations/components/RepositoryModal/__snapshots__/RepositoryModal.test.tsx.snap
+++ b/src/domains/profile/pages/MyRegistrations/components/RepositoryModal/__snapshots__/RepositoryModal.test.tsx.snap
@@ -3,14 +3,14 @@
 exports[`RepositoryModal should render empty state 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxiKw wLhVq absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxiKw wLhVq absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div

--- a/src/domains/profile/pages/MyRegistrations/components/RepositoryModal/__snapshots__/RepositoryModal.test.tsx.snap
+++ b/src/domains/profile/pages/MyRegistrations/components/RepositoryModal/__snapshots__/RepositoryModal.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`RepositoryModal should render empty state 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"

--- a/src/domains/profile/pages/Welcome/__snapshots__/Welcome.test.tsx.snap
+++ b/src/domains/profile/pages/Welcome/__snapshots__/Welcome.test.tsx.snap
@@ -809,7 +809,7 @@ exports[`Welcome should navigate to profile dashboard with correct password 1`] 
     </div>
   </div>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"

--- a/src/domains/profile/pages/Welcome/__snapshots__/Welcome.test.tsx.snap
+++ b/src/domains/profile/pages/Welcome/__snapshots__/Welcome.test.tsx.snap
@@ -809,14 +809,14 @@ exports[`Welcome should navigate to profile dashboard with correct password 1`] 
     </div>
   </div>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-fzplWN jxRzUr absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-fzplWN jxRzUr absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div

--- a/src/domains/setting/components/AdvancedMode/__snapshots__/AdvancedMode.test.tsx.snap
+++ b/src/domains/setting/components/AdvancedMode/__snapshots__/AdvancedMode.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`AdvancedMode should not render if not open 1`] = `<DocumentFragment />`
 exports[`AdvancedMode should render a modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"

--- a/src/domains/setting/components/AdvancedMode/__snapshots__/AdvancedMode.test.tsx.snap
+++ b/src/domains/setting/components/AdvancedMode/__snapshots__/AdvancedMode.test.tsx.snap
@@ -5,14 +5,14 @@ exports[`AdvancedMode should not render if not open 1`] = `<DocumentFragment />`
 exports[`AdvancedMode should render a modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxiKw Zauxd absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxiKw Zauxd absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div

--- a/src/domains/setting/components/CustomPeers/__snapshots__/CustomPeers.test.tsx.snap
+++ b/src/domains/setting/components/CustomPeers/__snapshots__/CustomPeers.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`CustomPeers should not render if not open 1`] = `<DocumentFragment />`;
 exports[`CustomPeers should render a modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"

--- a/src/domains/setting/components/CustomPeers/__snapshots__/CustomPeers.test.tsx.snap
+++ b/src/domains/setting/components/CustomPeers/__snapshots__/CustomPeers.test.tsx.snap
@@ -5,14 +5,14 @@ exports[`CustomPeers should not render if not open 1`] = `<DocumentFragment />`;
 exports[`CustomPeers should render a modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-fzplWN hXndMY absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-fzplWN hXndMY absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div

--- a/src/domains/setting/components/PeerList/__snapshots__/PeerList.test.tsx.snap
+++ b/src/domains/setting/components/PeerList/__snapshots__/PeerList.test.tsx.snap
@@ -4,14 +4,14 @@ exports[`PeerList should add peer 1`] = `
 <DocumentFragment>
   <div>
     <div
-      class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+      class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
     >
       <div
         class="fixed z-50 w-full h-full bg-black opacity-50"
         data-testid="modal__overlay"
       />
       <div
-        class="sc-fznZeY dyichR absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+        class="sc-fznZeY dyichR absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
         data-testid="modal__inner"
       >
         <div

--- a/src/domains/setting/components/PeerList/__snapshots__/PeerList.test.tsx.snap
+++ b/src/domains/setting/components/PeerList/__snapshots__/PeerList.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`PeerList should add peer 1`] = `
 <DocumentFragment>
   <div>
     <div
-      class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+      class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
     >
       <div
         class="fixed z-50 w-full h-full bg-black opacity-50"

--- a/src/domains/setting/pages/Settings/__snapshots__/Settings.test.tsx.snap
+++ b/src/domains/setting/pages/Settings/__snapshots__/Settings.test.tsx.snap
@@ -6932,14 +6932,14 @@ exports[`Settings should submit using default props 1`] = `
                   </div>
                 </form>
                 <div
-                  class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+                  class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
                 >
                   <div
                     class="fixed z-50 w-full h-full bg-black opacity-50"
                     data-testid="modal__overlay"
                   />
                   <div
-                    class="sc-fzplWN hXndMY absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+                    class="sc-fzplWN hXndMY absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
                     data-testid="modal__inner"
                   >
                     <div

--- a/src/domains/setting/pages/Settings/__snapshots__/Settings.test.tsx.snap
+++ b/src/domains/setting/pages/Settings/__snapshots__/Settings.test.tsx.snap
@@ -6932,7 +6932,7 @@ exports[`Settings should submit using default props 1`] = `
                   </div>
                 </form>
                 <div
-                  class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+                  class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
                 >
                   <div
                     class="fixed z-50 w-full h-full bg-black opacity-50"

--- a/src/domains/transaction/components/DelegateRegistrationDetail/__snapshots__/DelegateRegistrationDetail.test.tsx.snap
+++ b/src/domains/transaction/components/DelegateRegistrationDetail/__snapshots__/DelegateRegistrationDetail.test.tsx.snap
@@ -5,14 +5,14 @@ exports[`DelegateRegistrationDetail should not render if not open 1`] = `<Docume
 exports[`DelegateRegistrationDetail should render a modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxhCb pcYUy absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxhCb pcYUy absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div
@@ -344,14 +344,14 @@ exports[`DelegateRegistrationDetail should render a modal 1`] = `
 exports[`DelegateRegistrationDetail should render as confirmed 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxhCb pcYUy absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxhCb pcYUy absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div

--- a/src/domains/transaction/components/DelegateRegistrationDetail/__snapshots__/DelegateRegistrationDetail.test.tsx.snap
+++ b/src/domains/transaction/components/DelegateRegistrationDetail/__snapshots__/DelegateRegistrationDetail.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`DelegateRegistrationDetail should not render if not open 1`] = `<Docume
 exports[`DelegateRegistrationDetail should render a modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
@@ -344,7 +344,7 @@ exports[`DelegateRegistrationDetail should render a modal 1`] = `
 exports[`DelegateRegistrationDetail should render as confirmed 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"

--- a/src/domains/transaction/components/DelegateResignationDetail/__snapshots__/DelegateResignationDetail.test.tsx.snap
+++ b/src/domains/transaction/components/DelegateResignationDetail/__snapshots__/DelegateResignationDetail.test.tsx.snap
@@ -5,14 +5,14 @@ exports[`DelegateResignationDetail should not render if not open 1`] = `<Documen
 exports[`DelegateResignationDetail should render a modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxhCb pcYUy absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxhCb pcYUy absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div
@@ -344,14 +344,14 @@ exports[`DelegateResignationDetail should render a modal 1`] = `
 exports[`DelegateResignationDetail should render as confirmed 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxhCb pcYUy absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxhCb pcYUy absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div

--- a/src/domains/transaction/components/DelegateResignationDetail/__snapshots__/DelegateResignationDetail.test.tsx.snap
+++ b/src/domains/transaction/components/DelegateResignationDetail/__snapshots__/DelegateResignationDetail.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`DelegateResignationDetail should not render if not open 1`] = `<Documen
 exports[`DelegateResignationDetail should render a modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
@@ -344,7 +344,7 @@ exports[`DelegateResignationDetail should render a modal 1`] = `
 exports[`DelegateResignationDetail should render as confirmed 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"

--- a/src/domains/transaction/components/EntityDetail/__snapshots__/EntityDetail.test.tsx.snap
+++ b/src/domains/transaction/components/EntityDetail/__snapshots__/EntityDetail.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`EntityDetail should not render if not open 1`] = `<DocumentFragment />`
 exports[`EntityDetail should render a business entity resignation modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
@@ -311,7 +311,7 @@ exports[`EntityDetail should render a business entity resignation modal 1`] = `
 exports[`EntityDetail should render a business entity update modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
@@ -617,7 +617,7 @@ exports[`EntityDetail should render a business entity update modal 1`] = `
 exports[`EntityDetail should render a modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
@@ -923,7 +923,7 @@ exports[`EntityDetail should render a modal 1`] = `
 exports[`EntityDetail should render a modal without a wallet alias 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
@@ -1223,7 +1223,7 @@ exports[`EntityDetail should render a modal without a wallet alias 1`] = `
 exports[`EntityDetail should render a module entity registration modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
@@ -1529,7 +1529,7 @@ exports[`EntityDetail should render a module entity registration modal 1`] = `
 exports[`EntityDetail should render a module entity resignation modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
@@ -1835,7 +1835,7 @@ exports[`EntityDetail should render a module entity resignation modal 1`] = `
 exports[`EntityDetail should render a module entity update modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
@@ -2141,7 +2141,7 @@ exports[`EntityDetail should render a module entity update modal 1`] = `
 exports[`EntityDetail should render a plugin entity registration modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
@@ -2447,7 +2447,7 @@ exports[`EntityDetail should render a plugin entity registration modal 1`] = `
 exports[`EntityDetail should render a plugin entity resignation modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
@@ -2753,7 +2753,7 @@ exports[`EntityDetail should render a plugin entity resignation modal 1`] = `
 exports[`EntityDetail should render a plugin entity update modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
@@ -3059,7 +3059,7 @@ exports[`EntityDetail should render a plugin entity update modal 1`] = `
 exports[`EntityDetail should render a product entity registration modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
@@ -3365,7 +3365,7 @@ exports[`EntityDetail should render a product entity registration modal 1`] = `
 exports[`EntityDetail should render a product entity resignation modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
@@ -3671,7 +3671,7 @@ exports[`EntityDetail should render a product entity resignation modal 1`] = `
 exports[`EntityDetail should render a product entity update modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
@@ -3977,7 +3977,7 @@ exports[`EntityDetail should render a product entity update modal 1`] = `
 exports[`EntityDetail should render as confirmed 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"

--- a/src/domains/transaction/components/EntityDetail/__snapshots__/EntityDetail.test.tsx.snap
+++ b/src/domains/transaction/components/EntityDetail/__snapshots__/EntityDetail.test.tsx.snap
@@ -5,14 +5,14 @@ exports[`EntityDetail should not render if not open 1`] = `<DocumentFragment />`
 exports[`EntityDetail should render a business entity resignation modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxiKw cTRlJa absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxiKw cTRlJa absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div
@@ -311,14 +311,14 @@ exports[`EntityDetail should render a business entity resignation modal 1`] = `
 exports[`EntityDetail should render a business entity update modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxiKw cTRlJa absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxiKw cTRlJa absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div
@@ -617,14 +617,14 @@ exports[`EntityDetail should render a business entity update modal 1`] = `
 exports[`EntityDetail should render a modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxiKw cTRlJa absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxiKw cTRlJa absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div
@@ -923,14 +923,14 @@ exports[`EntityDetail should render a modal 1`] = `
 exports[`EntityDetail should render a modal without a wallet alias 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxiKw cTRlJa absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxiKw cTRlJa absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div
@@ -1223,14 +1223,14 @@ exports[`EntityDetail should render a modal without a wallet alias 1`] = `
 exports[`EntityDetail should render a module entity registration modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxiKw cTRlJa absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxiKw cTRlJa absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div
@@ -1529,14 +1529,14 @@ exports[`EntityDetail should render a module entity registration modal 1`] = `
 exports[`EntityDetail should render a module entity resignation modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxiKw cTRlJa absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxiKw cTRlJa absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div
@@ -1835,14 +1835,14 @@ exports[`EntityDetail should render a module entity resignation modal 1`] = `
 exports[`EntityDetail should render a module entity update modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxiKw cTRlJa absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxiKw cTRlJa absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div
@@ -2141,14 +2141,14 @@ exports[`EntityDetail should render a module entity update modal 1`] = `
 exports[`EntityDetail should render a plugin entity registration modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxiKw cTRlJa absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxiKw cTRlJa absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div
@@ -2447,14 +2447,14 @@ exports[`EntityDetail should render a plugin entity registration modal 1`] = `
 exports[`EntityDetail should render a plugin entity resignation modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxiKw cTRlJa absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxiKw cTRlJa absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div
@@ -2753,14 +2753,14 @@ exports[`EntityDetail should render a plugin entity resignation modal 1`] = `
 exports[`EntityDetail should render a plugin entity update modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxiKw cTRlJa absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxiKw cTRlJa absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div
@@ -3059,14 +3059,14 @@ exports[`EntityDetail should render a plugin entity update modal 1`] = `
 exports[`EntityDetail should render a product entity registration modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxiKw cTRlJa absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxiKw cTRlJa absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div
@@ -3365,14 +3365,14 @@ exports[`EntityDetail should render a product entity registration modal 1`] = `
 exports[`EntityDetail should render a product entity resignation modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxiKw cTRlJa absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxiKw cTRlJa absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div
@@ -3671,14 +3671,14 @@ exports[`EntityDetail should render a product entity resignation modal 1`] = `
 exports[`EntityDetail should render a product entity update modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxiKw cTRlJa absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxiKw cTRlJa absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div
@@ -3977,14 +3977,14 @@ exports[`EntityDetail should render a product entity update modal 1`] = `
 exports[`EntityDetail should render as confirmed 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxiKw cTRlJa absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxiKw cTRlJa absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div

--- a/src/domains/transaction/components/IpfsDetail/__snapshots__/IpfsDetail.test.tsx.snap
+++ b/src/domains/transaction/components/IpfsDetail/__snapshots__/IpfsDetail.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`IpfsDetail should not render if not open 1`] = `<DocumentFragment />`;
 exports[`IpfsDetail should render a modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
@@ -343,7 +343,7 @@ exports[`IpfsDetail should render a modal 1`] = `
 exports[`IpfsDetail should render a modal without a wallet alias 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
@@ -675,7 +675,7 @@ exports[`IpfsDetail should render a modal without a wallet alias 1`] = `
 exports[`IpfsDetail should render as confirmed 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"

--- a/src/domains/transaction/components/IpfsDetail/__snapshots__/IpfsDetail.test.tsx.snap
+++ b/src/domains/transaction/components/IpfsDetail/__snapshots__/IpfsDetail.test.tsx.snap
@@ -5,14 +5,14 @@ exports[`IpfsDetail should not render if not open 1`] = `<DocumentFragment />`;
 exports[`IpfsDetail should render a modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxhCb pcYUy absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxhCb pcYUy absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div
@@ -343,14 +343,14 @@ exports[`IpfsDetail should render a modal 1`] = `
 exports[`IpfsDetail should render a modal without a wallet alias 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxhCb pcYUy absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxhCb pcYUy absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div
@@ -675,14 +675,14 @@ exports[`IpfsDetail should render a modal without a wallet alias 1`] = `
 exports[`IpfsDetail should render as confirmed 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxhCb pcYUy absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxhCb pcYUy absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div

--- a/src/domains/transaction/components/MultiPaymentDetail/__snapshots__/MultiPaymentDetail.test.tsx.snap
+++ b/src/domains/transaction/components/MultiPaymentDetail/__snapshots__/MultiPaymentDetail.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`MultiPaymentDetail should not render if not open 1`] = `<DocumentFragme
 exports[`MultiPaymentDetail should render a modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
@@ -481,7 +481,7 @@ exports[`MultiPaymentDetail should render a modal 1`] = `
 exports[`MultiPaymentDetail should render with recipients 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"

--- a/src/domains/transaction/components/MultiPaymentDetail/__snapshots__/MultiPaymentDetail.test.tsx.snap
+++ b/src/domains/transaction/components/MultiPaymentDetail/__snapshots__/MultiPaymentDetail.test.tsx.snap
@@ -5,14 +5,14 @@ exports[`MultiPaymentDetail should not render if not open 1`] = `<DocumentFragme
 exports[`MultiPaymentDetail should render a modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxiKw cTRlJa absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxiKw cTRlJa absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div
@@ -481,14 +481,14 @@ exports[`MultiPaymentDetail should render a modal 1`] = `
 exports[`MultiPaymentDetail should render with recipients 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxiKw cTRlJa absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxiKw cTRlJa absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div

--- a/src/domains/transaction/components/MultiSignatureDetail/__snapshots__/MultiSignatureDetail.test.tsx.snap
+++ b/src/domains/transaction/components/MultiSignatureDetail/__snapshots__/MultiSignatureDetail.test.tsx.snap
@@ -634,14 +634,14 @@ exports[`MultiSignatureDetail should render 3rd step 1`] = `
 exports[`MultiSignatureDetail should render a modal and get to step 3 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxhCb pcYUy absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxhCb pcYUy absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div
@@ -1127,14 +1127,14 @@ exports[`MultiSignatureDetail should render a modal and get to step 3 1`] = `
 exports[`MultiSignatureDetail should render a modal and go back 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxhCb pcYUy absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxhCb pcYUy absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div

--- a/src/domains/transaction/components/MultiSignatureDetail/__snapshots__/MultiSignatureDetail.test.tsx.snap
+++ b/src/domains/transaction/components/MultiSignatureDetail/__snapshots__/MultiSignatureDetail.test.tsx.snap
@@ -634,7 +634,7 @@ exports[`MultiSignatureDetail should render 3rd step 1`] = `
 exports[`MultiSignatureDetail should render a modal and get to step 3 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
@@ -1127,7 +1127,7 @@ exports[`MultiSignatureDetail should render a modal and get to step 3 1`] = `
 exports[`MultiSignatureDetail should render a modal and go back 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"

--- a/src/domains/transaction/components/SecondSignatureDetail/__snapshots__/SecondSignatureDetail.test.tsx.snap
+++ b/src/domains/transaction/components/SecondSignatureDetail/__snapshots__/SecondSignatureDetail.test.tsx.snap
@@ -5,14 +5,14 @@ exports[`SecondSignatureDetail should not render if not open 1`] = `<DocumentFra
 exports[`SecondSignatureDetail should render a modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxiKw cTRlJa absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxiKw cTRlJa absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div
@@ -311,14 +311,14 @@ exports[`SecondSignatureDetail should render a modal 1`] = `
 exports[`SecondSignatureDetail should render a modal without a wallet alias 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxiKw cTRlJa absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxiKw cTRlJa absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div
@@ -611,14 +611,14 @@ exports[`SecondSignatureDetail should render a modal without a wallet alias 1`] 
 exports[`SecondSignatureDetail should render as confirmed 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxiKw cTRlJa absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxiKw cTRlJa absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div

--- a/src/domains/transaction/components/SecondSignatureDetail/__snapshots__/SecondSignatureDetail.test.tsx.snap
+++ b/src/domains/transaction/components/SecondSignatureDetail/__snapshots__/SecondSignatureDetail.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`SecondSignatureDetail should not render if not open 1`] = `<DocumentFra
 exports[`SecondSignatureDetail should render a modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
@@ -311,7 +311,7 @@ exports[`SecondSignatureDetail should render a modal 1`] = `
 exports[`SecondSignatureDetail should render a modal without a wallet alias 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
@@ -611,7 +611,7 @@ exports[`SecondSignatureDetail should render a modal without a wallet alias 1`] 
 exports[`SecondSignatureDetail should render as confirmed 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"

--- a/src/domains/transaction/components/TransactionDetailModal/__snapshots__/TransactionDetailModal.test.tsx.snap
+++ b/src/domains/transaction/components/TransactionDetailModal/__snapshots__/TransactionDetailModal.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`TransactionDetailModal should not render if not open 1`] = `<DocumentFr
 exports[`TransactionDetailModal should render a delegate registration modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
@@ -345,7 +345,7 @@ exports[`TransactionDetailModal should render a delegate registration modal 1`] 
 exports[`TransactionDetailModal should render a delegate resignation modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
@@ -685,7 +685,7 @@ exports[`TransactionDetailModal should render a delegate resignation modal 1`] =
 exports[`TransactionDetailModal should render a entity modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
@@ -992,7 +992,7 @@ exports[`TransactionDetailModal should render a entity modal 1`] = `
 exports[`TransactionDetailModal should render a ipfs modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
@@ -1331,7 +1331,7 @@ exports[`TransactionDetailModal should render a ipfs modal 1`] = `
 exports[`TransactionDetailModal should render a multi payment modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
@@ -1808,7 +1808,7 @@ exports[`TransactionDetailModal should render a multi payment modal 1`] = `
 exports[`TransactionDetailModal should render a multi signature modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
@@ -2302,7 +2302,7 @@ exports[`TransactionDetailModal should render a multi signature modal 1`] = `
 exports[`TransactionDetailModal should render a second signature modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
@@ -2609,7 +2609,7 @@ exports[`TransactionDetailModal should render a second signature modal 1`] = `
 exports[`TransactionDetailModal should render a transfer modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
@@ -3041,7 +3041,7 @@ exports[`TransactionDetailModal should render a transfer modal 1`] = `
 exports[`TransactionDetailModal should render a unvote modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
@@ -3500,7 +3500,7 @@ exports[`TransactionDetailModal should render a unvote modal 1`] = `
 exports[`TransactionDetailModal should render a vote modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"

--- a/src/domains/transaction/components/TransactionDetailModal/__snapshots__/TransactionDetailModal.test.tsx.snap
+++ b/src/domains/transaction/components/TransactionDetailModal/__snapshots__/TransactionDetailModal.test.tsx.snap
@@ -5,14 +5,14 @@ exports[`TransactionDetailModal should not render if not open 1`] = `<DocumentFr
 exports[`TransactionDetailModal should render a delegate registration modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxhCb pcYUy absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxhCb pcYUy absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div
@@ -345,14 +345,14 @@ exports[`TransactionDetailModal should render a delegate registration modal 1`] 
 exports[`TransactionDetailModal should render a delegate resignation modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxhCb pcYUy absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxhCb pcYUy absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div
@@ -685,14 +685,14 @@ exports[`TransactionDetailModal should render a delegate resignation modal 1`] =
 exports[`TransactionDetailModal should render a entity modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxhCb pcYUy absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxhCb pcYUy absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div
@@ -992,14 +992,14 @@ exports[`TransactionDetailModal should render a entity modal 1`] = `
 exports[`TransactionDetailModal should render a ipfs modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxhCb pcYUy absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxhCb pcYUy absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div
@@ -1331,14 +1331,14 @@ exports[`TransactionDetailModal should render a ipfs modal 1`] = `
 exports[`TransactionDetailModal should render a multi payment modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxhCb pcYUy absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxhCb pcYUy absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div
@@ -1808,14 +1808,14 @@ exports[`TransactionDetailModal should render a multi payment modal 1`] = `
 exports[`TransactionDetailModal should render a multi signature modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxhCb pcYUy absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxhCb pcYUy absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div
@@ -2302,14 +2302,14 @@ exports[`TransactionDetailModal should render a multi signature modal 1`] = `
 exports[`TransactionDetailModal should render a second signature modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxhCb pcYUy absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxhCb pcYUy absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div
@@ -2609,14 +2609,14 @@ exports[`TransactionDetailModal should render a second signature modal 1`] = `
 exports[`TransactionDetailModal should render a transfer modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxhCb pcYUy absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxhCb pcYUy absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div
@@ -3041,14 +3041,14 @@ exports[`TransactionDetailModal should render a transfer modal 1`] = `
 exports[`TransactionDetailModal should render a unvote modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxhCb pcYUy absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxhCb pcYUy absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div
@@ -3500,14 +3500,14 @@ exports[`TransactionDetailModal should render a unvote modal 1`] = `
 exports[`TransactionDetailModal should render a vote modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxhCb pcYUy absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxhCb pcYUy absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div

--- a/src/domains/transaction/components/TransferDetail/__snapshots__/TransferDetail.test.tsx.snap
+++ b/src/domains/transaction/components/TransferDetail/__snapshots__/TransferDetail.test.tsx.snap
@@ -5,14 +5,14 @@ exports[`TransferDetail should not render if not open 1`] = `<DocumentFragment /
 exports[`TransferDetail should render a modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxiKw cTRlJa absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxiKw cTRlJa absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div
@@ -436,14 +436,14 @@ exports[`TransferDetail should render a modal 1`] = `
 exports[`TransferDetail should render as confirmed 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxiKw cTRlJa absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxiKw cTRlJa absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div
@@ -867,14 +867,14 @@ exports[`TransferDetail should render as confirmed 1`] = `
 exports[`TransferDetail should render as not is sent 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxiKw cTRlJa absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxiKw cTRlJa absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div
@@ -1298,14 +1298,14 @@ exports[`TransferDetail should render as not is sent 1`] = `
 exports[`TransferDetail should render with wallet alias 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxiKw cTRlJa absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxiKw cTRlJa absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div

--- a/src/domains/transaction/components/TransferDetail/__snapshots__/TransferDetail.test.tsx.snap
+++ b/src/domains/transaction/components/TransferDetail/__snapshots__/TransferDetail.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`TransferDetail should not render if not open 1`] = `<DocumentFragment /
 exports[`TransferDetail should render a modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
@@ -436,7 +436,7 @@ exports[`TransferDetail should render a modal 1`] = `
 exports[`TransferDetail should render as confirmed 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
@@ -867,7 +867,7 @@ exports[`TransferDetail should render as confirmed 1`] = `
 exports[`TransferDetail should render as not is sent 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
@@ -1298,7 +1298,7 @@ exports[`TransferDetail should render as not is sent 1`] = `
 exports[`TransferDetail should render with wallet alias 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"

--- a/src/domains/transaction/components/VoteDetail/__snapshots__/VoteDetail.test.tsx.snap
+++ b/src/domains/transaction/components/VoteDetail/__snapshots__/VoteDetail.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`VoteDetail should not render if not open 1`] = `<DocumentFragment />`;
 exports[`VoteDetail should render a modal with unvotes 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
@@ -403,7 +403,7 @@ exports[`VoteDetail should render a modal with unvotes 1`] = `
 exports[`VoteDetail should render a modal with votes 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
@@ -801,7 +801,7 @@ exports[`VoteDetail should render a modal with votes 1`] = `
 exports[`VoteDetail should render a modal with votes and unvotes 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"

--- a/src/domains/transaction/components/VoteDetail/__snapshots__/VoteDetail.test.tsx.snap
+++ b/src/domains/transaction/components/VoteDetail/__snapshots__/VoteDetail.test.tsx.snap
@@ -5,14 +5,14 @@ exports[`VoteDetail should not render if not open 1`] = `<DocumentFragment />`;
 exports[`VoteDetail should render a modal with unvotes 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxiKw cTRlJa absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxiKw cTRlJa absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div
@@ -403,14 +403,14 @@ exports[`VoteDetail should render a modal with unvotes 1`] = `
 exports[`VoteDetail should render a modal with votes 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxiKw cTRlJa absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxiKw cTRlJa absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div
@@ -801,14 +801,14 @@ exports[`VoteDetail should render a modal with votes 1`] = `
 exports[`VoteDetail should render a modal with votes and unvotes 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxiKw cTRlJa absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxiKw cTRlJa absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div

--- a/src/domains/wallet/components/DeleteWallet/__snapshots__/DeleteWallet.test.tsx.snap
+++ b/src/domains/wallet/components/DeleteWallet/__snapshots__/DeleteWallet.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`DeleteWallet should not render if not open 1`] = `<DocumentFragment />`
 exports[`DeleteWallet should render a modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"

--- a/src/domains/wallet/components/DeleteWallet/__snapshots__/DeleteWallet.test.tsx.snap
+++ b/src/domains/wallet/components/DeleteWallet/__snapshots__/DeleteWallet.test.tsx.snap
@@ -5,14 +5,14 @@ exports[`DeleteWallet should not render if not open 1`] = `<DocumentFragment />`
 exports[`DeleteWallet should render a modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxiKw cTRlJa absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxiKw cTRlJa absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div

--- a/src/domains/wallet/components/LedgerWallet/__snapshots__/LedgerWallet.test.tsx.snap
+++ b/src/domains/wallet/components/LedgerWallet/__snapshots__/LedgerWallet.test.tsx.snap
@@ -5,14 +5,14 @@ exports[`LedgerWallet should not render if not open 1`] = `<DocumentFragment />`
 exports[`LedgerWallet should render a modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxiKw cTRlJa absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxiKw cTRlJa absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div

--- a/src/domains/wallet/components/LedgerWallet/__snapshots__/LedgerWallet.test.tsx.snap
+++ b/src/domains/wallet/components/LedgerWallet/__snapshots__/LedgerWallet.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`LedgerWallet should not render if not open 1`] = `<DocumentFragment />`
 exports[`LedgerWallet should render a modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"

--- a/src/domains/wallet/components/ReceiveFunds/__snapshots__/ReceiveFunds.test.tsx.snap
+++ b/src/domains/wallet/components/ReceiveFunds/__snapshots__/ReceiveFunds.test.tsx.snap
@@ -5,14 +5,14 @@ exports[`ReceiveFunds should not render if not open 1`] = `<DocumentFragment />`
 exports[`ReceiveFunds should not render qrcode without an address 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxhCb pcYUy absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxhCb pcYUy absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div
@@ -130,14 +130,14 @@ exports[`ReceiveFunds should not render qrcode without an address 1`] = `
 exports[`ReceiveFunds should render with a wallet name 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxhCb pcYUy absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxhCb pcYUy absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div
@@ -286,14 +286,14 @@ exports[`ReceiveFunds should render with a wallet name 1`] = `
 exports[`ReceiveFunds should render without a wallet name 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxhCb pcYUy absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxhCb pcYUy absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div

--- a/src/domains/wallet/components/ReceiveFunds/__snapshots__/ReceiveFunds.test.tsx.snap
+++ b/src/domains/wallet/components/ReceiveFunds/__snapshots__/ReceiveFunds.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`ReceiveFunds should not render if not open 1`] = `<DocumentFragment />`
 exports[`ReceiveFunds should not render qrcode without an address 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
@@ -130,7 +130,7 @@ exports[`ReceiveFunds should not render qrcode without an address 1`] = `
 exports[`ReceiveFunds should render with a wallet name 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
@@ -286,7 +286,7 @@ exports[`ReceiveFunds should render with a wallet name 1`] = `
 exports[`ReceiveFunds should render without a wallet name 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"

--- a/src/domains/wallet/components/SearchWallet/__snapshots__/SearchWallet.test.tsx.snap
+++ b/src/domains/wallet/components/SearchWallet/__snapshots__/SearchWallet.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`SearchWallet should render 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"

--- a/src/domains/wallet/components/SearchWallet/__snapshots__/SearchWallet.test.tsx.snap
+++ b/src/domains/wallet/components/SearchWallet/__snapshots__/SearchWallet.test.tsx.snap
@@ -3,14 +3,14 @@
 exports[`SearchWallet should render 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxhUy cowKBD absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxhUy cowKBD absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div

--- a/src/domains/wallet/components/SignMessage/__snapshots__/SignMessage.test.tsx.snap
+++ b/src/domains/wallet/components/SignMessage/__snapshots__/SignMessage.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`SignMessage should render 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
@@ -207,7 +207,7 @@ exports[`SignMessage should render 1`] = `
 exports[`SignMessage should sign message 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"

--- a/src/domains/wallet/components/SignMessage/__snapshots__/SignMessage.test.tsx.snap
+++ b/src/domains/wallet/components/SignMessage/__snapshots__/SignMessage.test.tsx.snap
@@ -3,14 +3,14 @@
 exports[`SignMessage should render 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-fznyAO ioJhAT absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-fznyAO ioJhAT absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div
@@ -207,14 +207,14 @@ exports[`SignMessage should render 1`] = `
 exports[`SignMessage should sign message 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-fznyAO ioJhAT absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-fznyAO ioJhAT absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div

--- a/src/domains/wallet/components/UpdateWalletName/__snapshots__/UpdateWalletName.test.tsx.snap
+++ b/src/domains/wallet/components/UpdateWalletName/__snapshots__/UpdateWalletName.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`UpdateWalletName should not render if not open 1`] = `<DocumentFragment
 exports[`UpdateWalletName should render a modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
@@ -106,7 +106,7 @@ exports[`UpdateWalletName should render a modal 1`] = `
 exports[`UpdateWalletName should render form input with existing name 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
@@ -207,7 +207,7 @@ exports[`UpdateWalletName should render form input with existing name 1`] = `
 exports[`UpdateWalletName should show error message when name consists only of whitespace 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
@@ -315,7 +315,7 @@ exports[`UpdateWalletName should show error message when name consists only of w
 exports[`UpdateWalletName should show error message when name exceeds 42 characters 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"

--- a/src/domains/wallet/components/UpdateWalletName/__snapshots__/UpdateWalletName.test.tsx.snap
+++ b/src/domains/wallet/components/UpdateWalletName/__snapshots__/UpdateWalletName.test.tsx.snap
@@ -5,14 +5,14 @@ exports[`UpdateWalletName should not render if not open 1`] = `<DocumentFragment
 exports[`UpdateWalletName should render a modal 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-fzpans hGJZle absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-fzpans hGJZle absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div
@@ -106,14 +106,14 @@ exports[`UpdateWalletName should render a modal 1`] = `
 exports[`UpdateWalletName should render form input with existing name 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-fzpans hGJZle absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-fzpans hGJZle absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background undefined"
       data-testid="modal__inner"
     >
       <div
@@ -207,14 +207,14 @@ exports[`UpdateWalletName should render form input with existing name 1`] = `
 exports[`UpdateWalletName should show error message when name consists only of whitespace 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-fzpans hGJZle absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-fzpans hGJZle absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div
@@ -315,14 +315,14 @@ exports[`UpdateWalletName should show error message when name consists only of w
 exports[`UpdateWalletName should show error message when name exceeds 42 characters 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-fzpans hGJZle absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-fzpans hGJZle absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div

--- a/src/domains/wallet/components/VerifyMessage/__snapshots__/VerifyMessage.test.tsx.snap
+++ b/src/domains/wallet/components/VerifyMessage/__snapshots__/VerifyMessage.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`VerifyMessage should render 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
@@ -188,7 +188,7 @@ exports[`VerifyMessage should render 1`] = `
 exports[`VerifyMessage should render the non verify address content 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"

--- a/src/domains/wallet/components/VerifyMessage/__snapshots__/VerifyMessage.test.tsx.snap
+++ b/src/domains/wallet/components/VerifyMessage/__snapshots__/VerifyMessage.test.tsx.snap
@@ -3,14 +3,14 @@
 exports[`VerifyMessage should render 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-fznyAO ioJhAT absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-fznyAO ioJhAT absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div
@@ -188,14 +188,14 @@ exports[`VerifyMessage should render 1`] = `
 exports[`VerifyMessage should render the non verify address content 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-fznyAO ioJhAT absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-fznyAO ioJhAT absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div

--- a/src/domains/wallet/components/VerifyMessageStatus/__snapshots__/VerifyMessageStatus.test.tsx.snap
+++ b/src/domains/wallet/components/VerifyMessageStatus/__snapshots__/VerifyMessageStatus.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`VerifyMessageStatus should render verify message error 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
@@ -64,7 +64,7 @@ exports[`VerifyMessageStatus should render verify message error 1`] = `
 exports[`VerifyMessageStatus should render verify message success 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"

--- a/src/domains/wallet/components/VerifyMessageStatus/__snapshots__/VerifyMessageStatus.test.tsx.snap
+++ b/src/domains/wallet/components/VerifyMessageStatus/__snapshots__/VerifyMessageStatus.test.tsx.snap
@@ -3,14 +3,14 @@
 exports[`VerifyMessageStatus should render verify message error 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxiKw cTRlJa absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxiKw cTRlJa absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div
@@ -64,14 +64,14 @@ exports[`VerifyMessageStatus should render verify message error 1`] = `
 exports[`VerifyMessageStatus should render verify message success 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxiKw cTRlJa absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxiKw cTRlJa absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div

--- a/src/domains/wallet/components/WalletUpdate/__snapshots__/WalletUpdate.test.tsx.snap
+++ b/src/domains/wallet/components/WalletUpdate/__snapshots__/WalletUpdate.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`WalletUpdate should not render if not open 1`] = `<DocumentFragment />`
 exports[`WalletUpdate should render 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
+    class="fixed inset-0 z-50 flex items-center justify-center w-full h-full overflow-y-scroll"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"

--- a/src/domains/wallet/components/WalletUpdate/__snapshots__/WalletUpdate.test.tsx.snap
+++ b/src/domains/wallet/components/WalletUpdate/__snapshots__/WalletUpdate.test.tsx.snap
@@ -5,14 +5,14 @@ exports[`WalletUpdate should not render if not open 1`] = `<DocumentFragment />`
 exports[`WalletUpdate should render 1`] = `
 <DocumentFragment>
   <div
-    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll"
+    class="fixed inset-0 z-50 w-full h-full overflow-y-scroll flex items-center justify-center"
   >
     <div
       class="fixed z-50 w-full h-full bg-black opacity-50"
       data-testid="modal__overlay"
     />
     <div
-      class="sc-AxiKw cTRlJa absolute top-0 left-0 right-0 z-50 flex flex-col p-10 mx-auto mt-24 mb-24 overflow-hidden rounded-xl bg-theme-background"
+      class="sc-AxiKw cTRlJa absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto mb-24 overflow-hidden rounded-xl bg-theme-background "
       data-testid="modal__inner"
     >
       <div


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
* If the modal content fits in the window, the modal is vertically centered;
* If the modal content exceeds window height, a top offset is added (current behavior).

![2020-10-06-205943_1117x974_scrot](https://user-images.githubusercontent.com/22020168/95242366-bf331c80-0817-11eb-9382-ee8994b65fe9.png)
![2020-10-06-210328_1121x974_scrot](https://user-images.githubusercontent.com/22020168/95242374-c22e0d00-0817-11eb-9ddd-2f77a63657ff.png)
![2020-10-06-210314_1106x966_scrot](https://user-images.githubusercontent.com/22020168/95242384-c4906700-0817-11eb-8b71-ba8ed5c6ac68.png)

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
