### PR TITLE
fix: remove duplicated import

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -36,19 +36,17 @@ const __DEV__ = process.env.NODE_ENV !== "production";
 
 const Main = () => {
 	const [showSplash, setShowSplash] = useState(true);
-	const { pathname } = useLocation();
+	const location = useLocation();
 	const { theme, setTheme } = useThemeContext();
 	const { env, persist } = useEnvironmentContext();
 	const isOnline = useNetworkStatus();
 	const { start, runAll } = useEnvSynchronizer();
-	useDeeplink();
 
-	const location = useLocation();
 	const pathname = (location as any).location?.pathname || location.pathname;
-
 	const nativeTheme = electron.remote.nativeTheme;
-
 	const useDarkMode = React.useMemo(() => theme === "dark", [theme]);
+
+	useDeeplink();
 
 	useEffect(() => {
 		if (!showSplash) {

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -29,7 +29,6 @@ import { Theme } from "types";
 import { middlewares, RouterView, routes } from "../router";
 import { EnvironmentProvider, ThemeProvider, useEnvironmentContext, useThemeContext } from "./contexts";
 import { useDeeplink, useEnvSynchronizer, useNetworkStatus } from "./hooks";
-import { useNetworkStatus } from "./hooks";
 import { i18n } from "./i18n";
 import { httpClient } from "./services";
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
- Remove a duplicated import for `useNetworkStatus` hook

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
