### PR TITLE
fix: not show the button to view more if the wallet has no transactions

### DIFF
--- a/src/domains/wallet/pages/WalletDetails/WalletDetails.tsx
+++ b/src/domains/wallet/pages/WalletDetails/WalletDetails.tsx
@@ -215,7 +215,7 @@ export const WalletDetails = ({ txSkeletonRowsLimit }: WalletDetailsProps) => {
 								onRowClick={(row) => setTransactionModalItem(row)}
 							/>
 
-							{hasMore && (
+							{transactions.length > 0 && hasMore && (
 								<Button
 									data-testid="transactions__fetch-more-button"
 									variant="plain"


### PR DESCRIPTION
## Summary

![Screenshot from 2020-10-15 19-29-44](https://user-images.githubusercontent.com/1894191/96193269-36566800-0f1e-11eb-8d30-e45b2ae6bfbc.png)

## Checklist

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged
