### PR TITLE
fix: adjust fallback to guarantee step is valid

### DIFF
--- a/src/app/components/Input/utils.ts
+++ b/src/app/components/Input/utils.ts
@@ -10,4 +10,4 @@ const isStepDivisible = ({ min, max, step }: RangeInput) => {
 };
 
 export const sanitizeStep = ({ min, max, step }: RangeInput): number =>
-	isStepDivisible({ min, max, step }) ? step : max / 100;
+	isStepDivisible({ min, max, step }) ? step : (max - min) / 100;


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

`max / 100` alone does not guarantee that the step satisfies in fact the condition, that the difference between `max` and `min` must be divisible by `step`.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
