### PR TITLE
fix: prevent wrapping label and date in `TransactionRow`

### DIFF
--- a/src/app/components/Notifications/__snapshots__/NotificationTransactionItem.test.tsx.snap
+++ b/src/app/components/Notifications/__snapshots__/NotificationTransactionItem.test.tsx.snap
@@ -62,7 +62,7 @@ exports[`Notifications should render notification item 1`] = `
             class="sc-AxiKw jxgwWm justify-end"
           >
             <div
-              class="sc-AxhUy dVEcwV"
+              class="sc-AxhUy dVEcwV whitespace-no-wrap"
               color="success"
               data-testid="TransactionRowAmount"
             >

--- a/src/app/components/Notifications/__snapshots__/Notifications.test.tsx.snap
+++ b/src/app/components/Notifications/__snapshots__/Notifications.test.tsx.snap
@@ -170,7 +170,7 @@ exports[`Notifications should emit transactionClick event 1`] = `
                   class="sc-AxiKw jxgwWm justify-end"
                 >
                   <div
-                    class="sc-AxhUy dVEcwV"
+                    class="sc-AxhUy dVEcwV whitespace-no-wrap"
                     color="success"
                     data-testid="TransactionRowAmount"
                   >
@@ -241,7 +241,7 @@ exports[`Notifications should emit transactionClick event 1`] = `
                   class="sc-AxiKw jxgwWm justify-end"
                 >
                   <div
-                    class="sc-AxhUy dVEcwV"
+                    class="sc-AxhUy dVEcwV whitespace-no-wrap"
                     color="success"
                     data-testid="TransactionRowAmount"
                   >
@@ -471,7 +471,7 @@ exports[`Notifications should render with plugins 1`] = `
                   class="sc-AxiKw jxgwWm justify-end"
                 >
                   <div
-                    class="sc-AxhUy dVEcwV"
+                    class="sc-AxhUy dVEcwV whitespace-no-wrap"
                     color="success"
                     data-testid="TransactionRowAmount"
                   >
@@ -542,7 +542,7 @@ exports[`Notifications should render with plugins 1`] = `
                   class="sc-AxiKw jxgwWm justify-end"
                 >
                   <div
-                    class="sc-AxhUy dVEcwV"
+                    class="sc-AxhUy dVEcwV whitespace-no-wrap"
                     color="success"
                     data-testid="TransactionRowAmount"
                   >
@@ -733,7 +733,7 @@ exports[`Notifications should render with transactions and plugins 1`] = `
                   class="sc-AxiKw jxgwWm justify-end"
                 >
                   <div
-                    class="sc-AxhUy dVEcwV"
+                    class="sc-AxhUy dVEcwV whitespace-no-wrap"
                     color="success"
                     data-testid="TransactionRowAmount"
                   >
@@ -804,7 +804,7 @@ exports[`Notifications should render with transactions and plugins 1`] = `
                   class="sc-AxiKw jxgwWm justify-end"
                 >
                   <div
-                    class="sc-AxhUy dVEcwV"
+                    class="sc-AxhUy dVEcwV whitespace-no-wrap"
                     color="success"
                     data-testid="TransactionRowAmount"
                   >

--- a/src/app/components/Notifications/__snapshots__/NotificationsDropdown.test.tsx.snap
+++ b/src/app/components/Notifications/__snapshots__/NotificationsDropdown.test.tsx.snap
@@ -216,7 +216,7 @@ exports[`Notifications should open and close transaction details modal 1`] = `
                               class="sc-AxiKw jxgwWm justify-end"
                             >
                               <div
-                                class="sc-AxhUy dVEcwV"
+                                class="sc-AxhUy dVEcwV whitespace-no-wrap"
                                 color="success"
                                 data-testid="TransactionRowAmount"
                               >
@@ -287,7 +287,7 @@ exports[`Notifications should open and close transaction details modal 1`] = `
                               class="sc-AxiKw jxgwWm justify-end"
                             >
                               <div
-                                class="sc-AxhUy dVEcwV"
+                                class="sc-AxhUy dVEcwV whitespace-no-wrap"
                                 color="success"
                                 data-testid="TransactionRowAmount"
                               >
@@ -901,7 +901,7 @@ exports[`Notifications should open and close transaction details modal 2`] = `
                               class="sc-AxiKw jxgwWm justify-end"
                             >
                               <div
-                                class="sc-AxhUy dVEcwV"
+                                class="sc-AxhUy dVEcwV whitespace-no-wrap"
                                 color="success"
                                 data-testid="TransactionRowAmount"
                               >
@@ -972,7 +972,7 @@ exports[`Notifications should open and close transaction details modal 2`] = `
                               class="sc-AxiKw jxgwWm justify-end"
                             >
                               <div
-                                class="sc-AxhUy dVEcwV"
+                                class="sc-AxhUy dVEcwV whitespace-no-wrap"
                                 color="success"
                                 data-testid="TransactionRowAmount"
                               >
@@ -1215,7 +1215,7 @@ exports[`Notifications should render with transactions and plugins 1`] = `
                               class="sc-AxiKw jxgwWm justify-end"
                             >
                               <div
-                                class="sc-AxhUy dVEcwV"
+                                class="sc-AxhUy dVEcwV whitespace-no-wrap"
                                 color="success"
                                 data-testid="TransactionRowAmount"
                               >
@@ -1286,7 +1286,7 @@ exports[`Notifications should render with transactions and plugins 1`] = `
                               class="sc-AxiKw jxgwWm justify-end"
                             >
                               <div
-                                class="sc-AxhUy dVEcwV"
+                                class="sc-AxhUy dVEcwV whitespace-no-wrap"
                                 color="success"
                                 data-testid="TransactionRowAmount"
                               >

--- a/src/domains/dashboard/components/Transactions/__snapshots__/Transactions.test.tsx.snap
+++ b/src/domains/dashboard/components/Transactions/__snapshots__/Transactions.test.tsx.snap
@@ -233,6 +233,7 @@ exports[`Transactions should render with transactions 1`] = `
                 class="sc-AxhCb udmdB text-theme-secondary-text"
               >
                 <span
+                  class="whitespace-no-wrap"
                   data-testid="TransactionRow__timestamp"
                 >
                   31 Jul 2020 16:34:41
@@ -341,7 +342,7 @@ exports[`Transactions should render with transactions 1`] = `
                 class="sc-AxhCb udmdB justify-end"
               >
                 <div
-                  class="sc-AxgMl iBQFZY"
+                  class="sc-AxgMl iBQFZY whitespace-no-wrap"
                   color="danger"
                   data-testid="TransactionRowAmount"
                 >
@@ -391,6 +392,7 @@ exports[`Transactions should render with transactions 1`] = `
                 class="sc-AxhCb udmdB text-theme-secondary-text"
               >
                 <span
+                  class="whitespace-no-wrap"
                   data-testid="TransactionRow__timestamp"
                 >
                   31 Jul 2020 16:34:41
@@ -499,7 +501,7 @@ exports[`Transactions should render with transactions 1`] = `
                 class="sc-AxhCb udmdB justify-end"
               >
                 <div
-                  class="sc-AxgMl iBQFZY"
+                  class="sc-AxgMl iBQFZY whitespace-no-wrap"
                   color="danger"
                   data-testid="TransactionRowAmount"
                 >
@@ -549,6 +551,7 @@ exports[`Transactions should render with transactions 1`] = `
                 class="sc-AxhCb udmdB text-theme-secondary-text"
               >
                 <span
+                  class="whitespace-no-wrap"
                   data-testid="TransactionRow__timestamp"
                 >
                   31 Jul 2020 16:34:41
@@ -673,7 +676,7 @@ exports[`Transactions should render with transactions 1`] = `
                 class="sc-AxhCb udmdB justify-end"
               >
                 <div
-                  class="sc-AxgMl iBQFZY"
+                  class="sc-AxgMl iBQFZY whitespace-no-wrap"
                   color="danger"
                   data-testid="TransactionRowAmount"
                 >
@@ -723,6 +726,7 @@ exports[`Transactions should render with transactions 1`] = `
                 class="sc-AxhCb udmdB text-theme-secondary-text"
               >
                 <span
+                  class="whitespace-no-wrap"
                   data-testid="TransactionRow__timestamp"
                 >
                   31 Jul 2020 16:34:41
@@ -847,7 +851,7 @@ exports[`Transactions should render with transactions 1`] = `
                 class="sc-AxhCb udmdB justify-end"
               >
                 <div
-                  class="sc-AxgMl iBQFZY"
+                  class="sc-AxgMl iBQFZY whitespace-no-wrap"
                   color="danger"
                   data-testid="TransactionRowAmount"
                 >

--- a/src/domains/dashboard/pages/Dashboard/__snapshots__/Dashboard.test.tsx.snap
+++ b/src/domains/dashboard/pages/Dashboard/__snapshots__/Dashboard.test.tsx.snap
@@ -19728,6 +19728,7 @@ exports[`Dashboard should select an option in the wallets display type 1`] = `
                         class="sc-Axmtr jaatA-D text-theme-secondary-text"
                       >
                         <span
+                          class="whitespace-no-wrap"
                           data-testid="TransactionRow__timestamp"
                         >
                           23 Jul 2020 08:03:20
@@ -19821,7 +19822,7 @@ exports[`Dashboard should select an option in the wallets display type 1`] = `
                         class="sc-Axmtr jaatA-D justify-end"
                       >
                         <div
-                          class="sc-fzozJi bXfNeq"
+                          class="sc-fzozJi bXfNeq whitespace-no-wrap"
                           color="success"
                           data-testid="TransactionRowAmount"
                         >
@@ -19882,6 +19883,7 @@ exports[`Dashboard should select an option in the wallets display type 1`] = `
                         class="sc-Axmtr jaatA-D text-theme-secondary-text"
                       >
                         <span
+                          class="whitespace-no-wrap"
                           data-testid="TransactionRow__timestamp"
                         >
                           23 Jul 2020 08:01:52
@@ -19975,7 +19977,7 @@ exports[`Dashboard should select an option in the wallets display type 1`] = `
                         class="sc-Axmtr jaatA-D justify-end"
                       >
                         <div
-                          class="sc-fzozJi bXfNeq"
+                          class="sc-fzozJi bXfNeq whitespace-no-wrap"
                           color="success"
                           data-testid="TransactionRowAmount"
                         >
@@ -20036,6 +20038,7 @@ exports[`Dashboard should select an option in the wallets display type 1`] = `
                         class="sc-Axmtr jaatA-D text-theme-secondary-text"
                       >
                         <span
+                          class="whitespace-no-wrap"
                           data-testid="TransactionRow__timestamp"
                         >
                           23 Jul 2020 08:03:20
@@ -20129,7 +20132,7 @@ exports[`Dashboard should select an option in the wallets display type 1`] = `
                         class="sc-Axmtr jaatA-D justify-end"
                       >
                         <div
-                          class="sc-fzozJi bXfNeq"
+                          class="sc-fzozJi bXfNeq whitespace-no-wrap"
                           color="success"
                           data-testid="TransactionRowAmount"
                         >
@@ -20190,6 +20193,7 @@ exports[`Dashboard should select an option in the wallets display type 1`] = `
                         class="sc-Axmtr jaatA-D text-theme-secondary-text"
                       >
                         <span
+                          class="whitespace-no-wrap"
                           data-testid="TransactionRow__timestamp"
                         >
                           23 Jul 2020 08:01:52
@@ -20283,7 +20287,7 @@ exports[`Dashboard should select an option in the wallets display type 1`] = `
                         class="sc-Axmtr jaatA-D justify-end"
                       >
                         <div
-                          class="sc-fzozJi bXfNeq"
+                          class="sc-fzozJi bXfNeq whitespace-no-wrap"
                           color="success"
                           data-testid="TransactionRowAmount"
                         >

--- a/src/domains/dashboard/pages/Dashboard/__snapshots__/Dashboard.test.tsx.snap
+++ b/src/domains/dashboard/pages/Dashboard/__snapshots__/Dashboard.test.tsx.snap
@@ -3040,6 +3040,7 @@ exports[`Dashboard should fetch more transactions 1`] = `
                         class="sc-Axmtr cSXHUn text-theme-secondary-text"
                       >
                         <span
+                          class="whitespace-no-wrap"
                           data-testid="TransactionRow__timestamp"
                         >
                           23 Jul 2020 08:03:20
@@ -3133,7 +3134,7 @@ exports[`Dashboard should fetch more transactions 1`] = `
                         class="sc-Axmtr cSXHUn justify-end"
                       >
                         <div
-                          class="sc-fzozJi bXfNeq"
+                          class="sc-fzozJi bXfNeq whitespace-no-wrap"
                           color="success"
                           data-testid="TransactionRowAmount"
                         >
@@ -3194,6 +3195,7 @@ exports[`Dashboard should fetch more transactions 1`] = `
                         class="sc-Axmtr cSXHUn text-theme-secondary-text"
                       >
                         <span
+                          class="whitespace-no-wrap"
                           data-testid="TransactionRow__timestamp"
                         >
                           23 Jul 2020 08:01:52
@@ -3287,7 +3289,7 @@ exports[`Dashboard should fetch more transactions 1`] = `
                         class="sc-Axmtr cSXHUn justify-end"
                       >
                         <div
-                          class="sc-fzozJi bXfNeq"
+                          class="sc-fzozJi bXfNeq whitespace-no-wrap"
                           color="success"
                           data-testid="TransactionRowAmount"
                         >
@@ -3348,6 +3350,7 @@ exports[`Dashboard should fetch more transactions 1`] = `
                         class="sc-Axmtr cSXHUn text-theme-secondary-text"
                       >
                         <span
+                          class="whitespace-no-wrap"
                           data-testid="TransactionRow__timestamp"
                         >
                           23 Jul 2020 08:03:20
@@ -3441,7 +3444,7 @@ exports[`Dashboard should fetch more transactions 1`] = `
                         class="sc-Axmtr cSXHUn justify-end"
                       >
                         <div
-                          class="sc-fzozJi bXfNeq"
+                          class="sc-fzozJi bXfNeq whitespace-no-wrap"
                           color="success"
                           data-testid="TransactionRowAmount"
                         >
@@ -3502,6 +3505,7 @@ exports[`Dashboard should fetch more transactions 1`] = `
                         class="sc-Axmtr cSXHUn text-theme-secondary-text"
                       >
                         <span
+                          class="whitespace-no-wrap"
                           data-testid="TransactionRow__timestamp"
                         >
                           23 Jul 2020 08:01:52
@@ -3595,7 +3599,7 @@ exports[`Dashboard should fetch more transactions 1`] = `
                         class="sc-Axmtr cSXHUn justify-end"
                       >
                         <div
-                          class="sc-fzozJi bXfNeq"
+                          class="sc-fzozJi bXfNeq whitespace-no-wrap"
                           color="success"
                           data-testid="TransactionRowAmount"
                         >
@@ -3656,6 +3660,7 @@ exports[`Dashboard should fetch more transactions 1`] = `
                         class="sc-Axmtr cSXHUn text-theme-secondary-text"
                       >
                         <span
+                          class="whitespace-no-wrap"
                           data-testid="TransactionRow__timestamp"
                         >
                           23 Jul 2020 08:03:20
@@ -3749,7 +3754,7 @@ exports[`Dashboard should fetch more transactions 1`] = `
                         class="sc-Axmtr cSXHUn justify-end"
                       >
                         <div
-                          class="sc-fzozJi bXfNeq"
+                          class="sc-fzozJi bXfNeq whitespace-no-wrap"
                           color="success"
                           data-testid="TransactionRowAmount"
                         >
@@ -3810,6 +3815,7 @@ exports[`Dashboard should fetch more transactions 1`] = `
                         class="sc-Axmtr cSXHUn text-theme-secondary-text"
                       >
                         <span
+                          class="whitespace-no-wrap"
                           data-testid="TransactionRow__timestamp"
                         >
                           23 Jul 2020 08:01:52
@@ -3903,7 +3909,7 @@ exports[`Dashboard should fetch more transactions 1`] = `
                         class="sc-Axmtr cSXHUn justify-end"
                       >
                         <div
-                          class="sc-fzozJi bXfNeq"
+                          class="sc-fzozJi bXfNeq whitespace-no-wrap"
                           color="success"
                           data-testid="TransactionRowAmount"
                         >
@@ -3964,6 +3970,7 @@ exports[`Dashboard should fetch more transactions 1`] = `
                         class="sc-Axmtr cSXHUn text-theme-secondary-text"
                       >
                         <span
+                          class="whitespace-no-wrap"
                           data-testid="TransactionRow__timestamp"
                         >
                           23 Jul 2020 08:03:20
@@ -4057,7 +4064,7 @@ exports[`Dashboard should fetch more transactions 1`] = `
                         class="sc-Axmtr cSXHUn justify-end"
                       >
                         <div
-                          class="sc-fzozJi bXfNeq"
+                          class="sc-fzozJi bXfNeq whitespace-no-wrap"
                           color="success"
                           data-testid="TransactionRowAmount"
                         >
@@ -4118,6 +4125,7 @@ exports[`Dashboard should fetch more transactions 1`] = `
                         class="sc-Axmtr cSXHUn text-theme-secondary-text"
                       >
                         <span
+                          class="whitespace-no-wrap"
                           data-testid="TransactionRow__timestamp"
                         >
                           23 Jul 2020 08:01:52
@@ -4211,7 +4219,7 @@ exports[`Dashboard should fetch more transactions 1`] = `
                         class="sc-Axmtr cSXHUn justify-end"
                       >
                         <div
-                          class="sc-fzozJi bXfNeq"
+                          class="sc-fzozJi bXfNeq whitespace-no-wrap"
                           color="success"
                           data-testid="TransactionRowAmount"
                         >
@@ -5442,6 +5450,7 @@ exports[`Dashboard should hide portfolio view 1`] = `
                         class="sc-Axmtr cSXHUn text-theme-secondary-text"
                       >
                         <span
+                          class="whitespace-no-wrap"
                           data-testid="TransactionRow__timestamp"
                         >
                           23 Jul 2020 08:03:20
@@ -5535,7 +5544,7 @@ exports[`Dashboard should hide portfolio view 1`] = `
                         class="sc-Axmtr cSXHUn justify-end"
                       >
                         <div
-                          class="sc-fzozJi bXfNeq"
+                          class="sc-fzozJi bXfNeq whitespace-no-wrap"
                           color="success"
                           data-testid="TransactionRowAmount"
                         >
@@ -5596,6 +5605,7 @@ exports[`Dashboard should hide portfolio view 1`] = `
                         class="sc-Axmtr cSXHUn text-theme-secondary-text"
                       >
                         <span
+                          class="whitespace-no-wrap"
                           data-testid="TransactionRow__timestamp"
                         >
                           23 Jul 2020 08:01:52
@@ -5689,7 +5699,7 @@ exports[`Dashboard should hide portfolio view 1`] = `
                         class="sc-Axmtr cSXHUn justify-end"
                       >
                         <div
-                          class="sc-fzozJi bXfNeq"
+                          class="sc-fzozJi bXfNeq whitespace-no-wrap"
                           color="success"
                           data-testid="TransactionRowAmount"
                         >
@@ -5750,6 +5760,7 @@ exports[`Dashboard should hide portfolio view 1`] = `
                         class="sc-Axmtr cSXHUn text-theme-secondary-text"
                       >
                         <span
+                          class="whitespace-no-wrap"
                           data-testid="TransactionRow__timestamp"
                         >
                           23 Jul 2020 08:03:20
@@ -5843,7 +5854,7 @@ exports[`Dashboard should hide portfolio view 1`] = `
                         class="sc-Axmtr cSXHUn justify-end"
                       >
                         <div
-                          class="sc-fzozJi bXfNeq"
+                          class="sc-fzozJi bXfNeq whitespace-no-wrap"
                           color="success"
                           data-testid="TransactionRowAmount"
                         >
@@ -5904,6 +5915,7 @@ exports[`Dashboard should hide portfolio view 1`] = `
                         class="sc-Axmtr cSXHUn text-theme-secondary-text"
                       >
                         <span
+                          class="whitespace-no-wrap"
                           data-testid="TransactionRow__timestamp"
                         >
                           23 Jul 2020 08:01:52
@@ -5997,7 +6009,7 @@ exports[`Dashboard should hide portfolio view 1`] = `
                         class="sc-Axmtr cSXHUn justify-end"
                       >
                         <div
-                          class="sc-fzozJi bXfNeq"
+                          class="sc-fzozJi bXfNeq whitespace-no-wrap"
                           color="success"
                           data-testid="TransactionRowAmount"
                         >
@@ -8035,6 +8047,7 @@ exports[`Dashboard should open detail modal on transaction row click 1`] = `
                         class="sc-Axmtr cSXHUn text-theme-secondary-text"
                       >
                         <span
+                          class="whitespace-no-wrap"
                           data-testid="TransactionRow__timestamp"
                         >
                           23 Jul 2020 08:03:20
@@ -8128,7 +8141,7 @@ exports[`Dashboard should open detail modal on transaction row click 1`] = `
                         class="sc-Axmtr cSXHUn justify-end"
                       >
                         <div
-                          class="sc-fzozJi bXfNeq"
+                          class="sc-fzozJi bXfNeq whitespace-no-wrap"
                           color="success"
                           data-testid="TransactionRowAmount"
                         >
@@ -8189,6 +8202,7 @@ exports[`Dashboard should open detail modal on transaction row click 1`] = `
                         class="sc-Axmtr cSXHUn text-theme-secondary-text"
                       >
                         <span
+                          class="whitespace-no-wrap"
                           data-testid="TransactionRow__timestamp"
                         >
                           23 Jul 2020 08:01:52
@@ -8282,7 +8296,7 @@ exports[`Dashboard should open detail modal on transaction row click 1`] = `
                         class="sc-Axmtr cSXHUn justify-end"
                       >
                         <div
-                          class="sc-fzozJi bXfNeq"
+                          class="sc-fzozJi bXfNeq whitespace-no-wrap"
                           color="success"
                           data-testid="TransactionRowAmount"
                         >
@@ -8343,6 +8357,7 @@ exports[`Dashboard should open detail modal on transaction row click 1`] = `
                         class="sc-Axmtr cSXHUn text-theme-secondary-text"
                       >
                         <span
+                          class="whitespace-no-wrap"
                           data-testid="TransactionRow__timestamp"
                         >
                           23 Jul 2020 08:03:20
@@ -8436,7 +8451,7 @@ exports[`Dashboard should open detail modal on transaction row click 1`] = `
                         class="sc-Axmtr cSXHUn justify-end"
                       >
                         <div
-                          class="sc-fzozJi bXfNeq"
+                          class="sc-fzozJi bXfNeq whitespace-no-wrap"
                           color="success"
                           data-testid="TransactionRowAmount"
                         >
@@ -8497,6 +8512,7 @@ exports[`Dashboard should open detail modal on transaction row click 1`] = `
                         class="sc-Axmtr cSXHUn text-theme-secondary-text"
                       >
                         <span
+                          class="whitespace-no-wrap"
                           data-testid="TransactionRow__timestamp"
                         >
                           23 Jul 2020 08:01:52
@@ -8590,7 +8606,7 @@ exports[`Dashboard should open detail modal on transaction row click 1`] = `
                         class="sc-Axmtr cSXHUn justify-end"
                       >
                         <div
-                          class="sc-fzozJi bXfNeq"
+                          class="sc-fzozJi bXfNeq whitespace-no-wrap"
                           color="success"
                           data-testid="TransactionRowAmount"
                         >
@@ -9631,6 +9647,7 @@ exports[`Dashboard should render 1`] = `
                         class="sc-Axmtr cSXHUn text-theme-secondary-text"
                       >
                         <span
+                          class="whitespace-no-wrap"
                           data-testid="TransactionRow__timestamp"
                         >
                           23 Jul 2020 08:03:20
@@ -9724,7 +9741,7 @@ exports[`Dashboard should render 1`] = `
                         class="sc-Axmtr cSXHUn justify-end"
                       >
                         <div
-                          class="sc-fzozJi bXfNeq"
+                          class="sc-fzozJi bXfNeq whitespace-no-wrap"
                           color="success"
                           data-testid="TransactionRowAmount"
                         >
@@ -9785,6 +9802,7 @@ exports[`Dashboard should render 1`] = `
                         class="sc-Axmtr cSXHUn text-theme-secondary-text"
                       >
                         <span
+                          class="whitespace-no-wrap"
                           data-testid="TransactionRow__timestamp"
                         >
                           23 Jul 2020 08:01:52
@@ -9878,7 +9896,7 @@ exports[`Dashboard should render 1`] = `
                         class="sc-Axmtr cSXHUn justify-end"
                       >
                         <div
-                          class="sc-fzozJi bXfNeq"
+                          class="sc-fzozJi bXfNeq whitespace-no-wrap"
                           color="success"
                           data-testid="TransactionRowAmount"
                         >
@@ -9939,6 +9957,7 @@ exports[`Dashboard should render 1`] = `
                         class="sc-Axmtr cSXHUn text-theme-secondary-text"
                       >
                         <span
+                          class="whitespace-no-wrap"
                           data-testid="TransactionRow__timestamp"
                         >
                           23 Jul 2020 08:03:20
@@ -10032,7 +10051,7 @@ exports[`Dashboard should render 1`] = `
                         class="sc-Axmtr cSXHUn justify-end"
                       >
                         <div
-                          class="sc-fzozJi bXfNeq"
+                          class="sc-fzozJi bXfNeq whitespace-no-wrap"
                           color="success"
                           data-testid="TransactionRowAmount"
                         >
@@ -10093,6 +10112,7 @@ exports[`Dashboard should render 1`] = `
                         class="sc-Axmtr cSXHUn text-theme-secondary-text"
                       >
                         <span
+                          class="whitespace-no-wrap"
                           data-testid="TransactionRow__timestamp"
                         >
                           23 Jul 2020 08:01:52
@@ -10186,7 +10206,7 @@ exports[`Dashboard should render 1`] = `
                         class="sc-Axmtr cSXHUn justify-end"
                       >
                         <div
-                          class="sc-fzozJi bXfNeq"
+                          class="sc-fzozJi bXfNeq whitespace-no-wrap"
                           color="success"
                           data-testid="TransactionRowAmount"
                         >
@@ -11227,6 +11247,7 @@ exports[`Dashboard should render portfolio chart 1`] = `
                         class="sc-Axmtr cSXHUn text-theme-secondary-text"
                       >
                         <span
+                          class="whitespace-no-wrap"
                           data-testid="TransactionRow__timestamp"
                         >
                           23 Jul 2020 08:03:20
@@ -11320,7 +11341,7 @@ exports[`Dashboard should render portfolio chart 1`] = `
                         class="sc-Axmtr cSXHUn justify-end"
                       >
                         <div
-                          class="sc-fzozJi bXfNeq"
+                          class="sc-fzozJi bXfNeq whitespace-no-wrap"
                           color="success"
                           data-testid="TransactionRowAmount"
                         >
@@ -11381,6 +11402,7 @@ exports[`Dashboard should render portfolio chart 1`] = `
                         class="sc-Axmtr cSXHUn text-theme-secondary-text"
                       >
                         <span
+                          class="whitespace-no-wrap"
                           data-testid="TransactionRow__timestamp"
                         >
                           23 Jul 2020 08:01:52
@@ -11474,7 +11496,7 @@ exports[`Dashboard should render portfolio chart 1`] = `
                         class="sc-Axmtr cSXHUn justify-end"
                       >
                         <div
-                          class="sc-fzozJi bXfNeq"
+                          class="sc-fzozJi bXfNeq whitespace-no-wrap"
                           color="success"
                           data-testid="TransactionRowAmount"
                         >
@@ -11535,6 +11557,7 @@ exports[`Dashboard should render portfolio chart 1`] = `
                         class="sc-Axmtr cSXHUn text-theme-secondary-text"
                       >
                         <span
+                          class="whitespace-no-wrap"
                           data-testid="TransactionRow__timestamp"
                         >
                           23 Jul 2020 08:03:20
@@ -11628,7 +11651,7 @@ exports[`Dashboard should render portfolio chart 1`] = `
                         class="sc-Axmtr cSXHUn justify-end"
                       >
                         <div
-                          class="sc-fzozJi bXfNeq"
+                          class="sc-fzozJi bXfNeq whitespace-no-wrap"
                           color="success"
                           data-testid="TransactionRowAmount"
                         >
@@ -11689,6 +11712,7 @@ exports[`Dashboard should render portfolio chart 1`] = `
                         class="sc-Axmtr cSXHUn text-theme-secondary-text"
                       >
                         <span
+                          class="whitespace-no-wrap"
                           data-testid="TransactionRow__timestamp"
                         >
                           23 Jul 2020 08:01:52
@@ -11782,7 +11806,7 @@ exports[`Dashboard should render portfolio chart 1`] = `
                         class="sc-Axmtr cSXHUn justify-end"
                       >
                         <div
-                          class="sc-fzozJi bXfNeq"
+                          class="sc-fzozJi bXfNeq whitespace-no-wrap"
                           color="success"
                           data-testid="TransactionRowAmount"
                         >
@@ -12823,6 +12847,7 @@ exports[`Dashboard should render portfolio percentage bar 1`] = `
                         class="sc-Axmtr cSXHUn text-theme-secondary-text"
                       >
                         <span
+                          class="whitespace-no-wrap"
                           data-testid="TransactionRow__timestamp"
                         >
                           23 Jul 2020 08:03:20
@@ -12916,7 +12941,7 @@ exports[`Dashboard should render portfolio percentage bar 1`] = `
                         class="sc-Axmtr cSXHUn justify-end"
                       >
                         <div
-                          class="sc-fzozJi bXfNeq"
+                          class="sc-fzozJi bXfNeq whitespace-no-wrap"
                           color="success"
                           data-testid="TransactionRowAmount"
                         >
@@ -12977,6 +13002,7 @@ exports[`Dashboard should render portfolio percentage bar 1`] = `
                         class="sc-Axmtr cSXHUn text-theme-secondary-text"
                       >
                         <span
+                          class="whitespace-no-wrap"
                           data-testid="TransactionRow__timestamp"
                         >
                           23 Jul 2020 08:01:52
@@ -13070,7 +13096,7 @@ exports[`Dashboard should render portfolio percentage bar 1`] = `
                         class="sc-Axmtr cSXHUn justify-end"
                       >
                         <div
-                          class="sc-fzozJi bXfNeq"
+                          class="sc-fzozJi bXfNeq whitespace-no-wrap"
                           color="success"
                           data-testid="TransactionRowAmount"
                         >
@@ -13131,6 +13157,7 @@ exports[`Dashboard should render portfolio percentage bar 1`] = `
                         class="sc-Axmtr cSXHUn text-theme-secondary-text"
                       >
                         <span
+                          class="whitespace-no-wrap"
                           data-testid="TransactionRow__timestamp"
                         >
                           23 Jul 2020 08:03:20
@@ -13224,7 +13251,7 @@ exports[`Dashboard should render portfolio percentage bar 1`] = `
                         class="sc-Axmtr cSXHUn justify-end"
                       >
                         <div
-                          class="sc-fzozJi bXfNeq"
+                          class="sc-fzozJi bXfNeq whitespace-no-wrap"
                           color="success"
                           data-testid="TransactionRowAmount"
                         >
@@ -13285,6 +13312,7 @@ exports[`Dashboard should render portfolio percentage bar 1`] = `
                         class="sc-Axmtr cSXHUn text-theme-secondary-text"
                       >
                         <span
+                          class="whitespace-no-wrap"
                           data-testid="TransactionRow__timestamp"
                         >
                           23 Jul 2020 08:01:52
@@ -13378,7 +13406,7 @@ exports[`Dashboard should render portfolio percentage bar 1`] = `
                         class="sc-Axmtr cSXHUn justify-end"
                       >
                         <div
-                          class="sc-fzozJi bXfNeq"
+                          class="sc-fzozJi bXfNeq whitespace-no-wrap"
                           color="success"
                           data-testid="TransactionRowAmount"
                         >
@@ -14419,6 +14447,7 @@ exports[`Dashboard should render wallets 1`] = `
                         class="sc-Axmtr cSXHUn text-theme-secondary-text"
                       >
                         <span
+                          class="whitespace-no-wrap"
                           data-testid="TransactionRow__timestamp"
                         >
                           23 Jul 2020 08:03:20
@@ -14512,7 +14541,7 @@ exports[`Dashboard should render wallets 1`] = `
                         class="sc-Axmtr cSXHUn justify-end"
                       >
                         <div
-                          class="sc-fzozJi bXfNeq"
+                          class="sc-fzozJi bXfNeq whitespace-no-wrap"
                           color="success"
                           data-testid="TransactionRowAmount"
                         >
@@ -14573,6 +14602,7 @@ exports[`Dashboard should render wallets 1`] = `
                         class="sc-Axmtr cSXHUn text-theme-secondary-text"
                       >
                         <span
+                          class="whitespace-no-wrap"
                           data-testid="TransactionRow__timestamp"
                         >
                           23 Jul 2020 08:01:52
@@ -14666,7 +14696,7 @@ exports[`Dashboard should render wallets 1`] = `
                         class="sc-Axmtr cSXHUn justify-end"
                       >
                         <div
-                          class="sc-fzozJi bXfNeq"
+                          class="sc-fzozJi bXfNeq whitespace-no-wrap"
                           color="success"
                           data-testid="TransactionRowAmount"
                         >
@@ -14727,6 +14757,7 @@ exports[`Dashboard should render wallets 1`] = `
                         class="sc-Axmtr cSXHUn text-theme-secondary-text"
                       >
                         <span
+                          class="whitespace-no-wrap"
                           data-testid="TransactionRow__timestamp"
                         >
                           23 Jul 2020 08:03:20
@@ -14820,7 +14851,7 @@ exports[`Dashboard should render wallets 1`] = `
                         class="sc-Axmtr cSXHUn justify-end"
                       >
                         <div
-                          class="sc-fzozJi bXfNeq"
+                          class="sc-fzozJi bXfNeq whitespace-no-wrap"
                           color="success"
                           data-testid="TransactionRowAmount"
                         >
@@ -14881,6 +14912,7 @@ exports[`Dashboard should render wallets 1`] = `
                         class="sc-Axmtr cSXHUn text-theme-secondary-text"
                       >
                         <span
+                          class="whitespace-no-wrap"
                           data-testid="TransactionRow__timestamp"
                         >
                           23 Jul 2020 08:01:52
@@ -14974,7 +15006,7 @@ exports[`Dashboard should render wallets 1`] = `
                         class="sc-Axmtr cSXHUn justify-end"
                       >
                         <div
-                          class="sc-fzozJi bXfNeq"
+                          class="sc-fzozJi bXfNeq whitespace-no-wrap"
                           color="success"
                           data-testid="TransactionRowAmount"
                         >
@@ -17935,6 +17967,7 @@ exports[`Dashboard should show transaction view 1`] = `
                         class="sc-Axmtr cSXHUn text-theme-secondary-text"
                       >
                         <span
+                          class="whitespace-no-wrap"
                           data-testid="TransactionRow__timestamp"
                         >
                           23 Jul 2020 08:03:20
@@ -18028,7 +18061,7 @@ exports[`Dashboard should show transaction view 1`] = `
                         class="sc-Axmtr cSXHUn justify-end"
                       >
                         <div
-                          class="sc-fzozJi bXfNeq"
+                          class="sc-fzozJi bXfNeq whitespace-no-wrap"
                           color="success"
                           data-testid="TransactionRowAmount"
                         >
@@ -18089,6 +18122,7 @@ exports[`Dashboard should show transaction view 1`] = `
                         class="sc-Axmtr cSXHUn text-theme-secondary-text"
                       >
                         <span
+                          class="whitespace-no-wrap"
                           data-testid="TransactionRow__timestamp"
                         >
                           23 Jul 2020 08:01:52
@@ -18182,7 +18216,7 @@ exports[`Dashboard should show transaction view 1`] = `
                         class="sc-Axmtr cSXHUn justify-end"
                       >
                         <div
-                          class="sc-fzozJi bXfNeq"
+                          class="sc-fzozJi bXfNeq whitespace-no-wrap"
                           color="success"
                           data-testid="TransactionRowAmount"
                         >
@@ -18243,6 +18277,7 @@ exports[`Dashboard should show transaction view 1`] = `
                         class="sc-Axmtr cSXHUn text-theme-secondary-text"
                       >
                         <span
+                          class="whitespace-no-wrap"
                           data-testid="TransactionRow__timestamp"
                         >
                           23 Jul 2020 08:03:20
@@ -18336,7 +18371,7 @@ exports[`Dashboard should show transaction view 1`] = `
                         class="sc-Axmtr cSXHUn justify-end"
                       >
                         <div
-                          class="sc-fzozJi bXfNeq"
+                          class="sc-fzozJi bXfNeq whitespace-no-wrap"
                           color="success"
                           data-testid="TransactionRowAmount"
                         >
@@ -18397,6 +18432,7 @@ exports[`Dashboard should show transaction view 1`] = `
                         class="sc-Axmtr cSXHUn text-theme-secondary-text"
                       >
                         <span
+                          class="whitespace-no-wrap"
                           data-testid="TransactionRow__timestamp"
                         >
                           23 Jul 2020 08:01:52
@@ -18490,7 +18526,7 @@ exports[`Dashboard should show transaction view 1`] = `
                         class="sc-Axmtr cSXHUn justify-end"
                       >
                         <div
-                          class="sc-fzozJi bXfNeq"
+                          class="sc-fzozJi bXfNeq whitespace-no-wrap"
                           color="success"
                           data-testid="TransactionRowAmount"
                         >

--- a/src/domains/transaction/components/TransactionTable/SignedTransactionTable/__snapshots__/SignedTransactionTable.test.tsx.snap
+++ b/src/domains/transaction/components/TransactionTable/SignedTransactionTable/__snapshots__/SignedTransactionTable.test.tsx.snap
@@ -288,7 +288,7 @@ exports[`Signed Transaction Table should render 1`] = `
                 class="sc-AxhCb udmdB justify-end"
               >
                 <div
-                  class="sc-AxgMl iBQFZY"
+                  class="sc-AxgMl iBQFZY whitespace-no-wrap"
                   color="danger"
                   data-testid="TransactionRowAmount"
                 >
@@ -436,7 +436,7 @@ exports[`Signed Transaction Table should render 1`] = `
                 class="sc-AxhCb udmdB justify-end"
               >
                 <div
-                  class="sc-AxgMl iBQFZY"
+                  class="sc-AxgMl iBQFZY whitespace-no-wrap"
                   color="danger"
                   data-testid="TransactionRowAmount"
                 >
@@ -584,7 +584,7 @@ exports[`Signed Transaction Table should render 1`] = `
                 class="sc-AxhCb udmdB justify-end"
               >
                 <div
-                  class="sc-AxgMl iBQFZY"
+                  class="sc-AxgMl iBQFZY whitespace-no-wrap"
                   color="danger"
                   data-testid="TransactionRowAmount"
                 >
@@ -732,7 +732,7 @@ exports[`Signed Transaction Table should render 1`] = `
                 class="sc-AxhCb udmdB justify-end"
               >
                 <div
-                  class="sc-AxgMl iBQFZY"
+                  class="sc-AxgMl iBQFZY whitespace-no-wrap"
                   color="danger"
                   data-testid="TransactionRowAmount"
                 >
@@ -880,7 +880,7 @@ exports[`Signed Transaction Table should render 1`] = `
                 class="sc-AxhCb udmdB justify-end"
               >
                 <div
-                  class="sc-AxgMl iBQFZY"
+                  class="sc-AxgMl iBQFZY whitespace-no-wrap"
                   color="danger"
                   data-testid="TransactionRowAmount"
                 >
@@ -1028,7 +1028,7 @@ exports[`Signed Transaction Table should render 1`] = `
                 class="sc-AxhCb udmdB justify-end"
               >
                 <div
-                  class="sc-AxgMl iBQFZY"
+                  class="sc-AxgMl iBQFZY whitespace-no-wrap"
                   color="danger"
                   data-testid="TransactionRowAmount"
                 >
@@ -1341,7 +1341,7 @@ exports[`Signed Transaction Table should show as awaiting confirmations 1`] = `
                 class="sc-AxhCb udmdB justify-end"
               >
                 <div
-                  class="sc-AxgMl iBQFZY"
+                  class="sc-AxgMl iBQFZY whitespace-no-wrap"
                   color="danger"
                   data-testid="TransactionRowAmount"
                 >
@@ -1654,7 +1654,7 @@ exports[`Signed Transaction Table should show as awaiting other wallets signatur
                 class="sc-AxhCb udmdB justify-end"
               >
                 <div
-                  class="sc-AxgMl iBQFZY"
+                  class="sc-AxgMl iBQFZY whitespace-no-wrap"
                   color="danger"
                   data-testid="TransactionRowAmount"
                 >
@@ -1967,7 +1967,7 @@ exports[`Signed Transaction Table should show as awaiting the wallet signature 1
                 class="sc-AxhCb udmdB justify-end"
               >
                 <div
-                  class="sc-AxgMl iBQFZY"
+                  class="sc-AxgMl iBQFZY whitespace-no-wrap"
                   color="danger"
                   data-testid="TransactionRowAmount"
                 >
@@ -2280,7 +2280,7 @@ exports[`Signed Transaction Table should show as final signature 1`] = `
                 class="sc-AxhCb udmdB justify-end"
               >
                 <div
-                  class="sc-AxgMl iBQFZY"
+                  class="sc-AxgMl iBQFZY whitespace-no-wrap"
                   color="danger"
                   data-testid="TransactionRowAmount"
                 >
@@ -2589,7 +2589,7 @@ exports[`Signed Transaction Table should show the sign button 1`] = `
                 class="sc-AxhCb udmdB justify-end"
               >
                 <div
-                  class="sc-AxgMl iBQFZY"
+                  class="sc-AxgMl iBQFZY whitespace-no-wrap"
                   color="danger"
                   data-testid="TransactionRowAmount"
                 >

--- a/src/domains/transaction/components/TransactionTable/TransactionRow/TransactionRow.tsx
+++ b/src/domains/transaction/components/TransactionTable/TransactionRow/TransactionRow.tsx
@@ -66,7 +66,7 @@ export const TransactionRow = ({
 			)}
 
 			<TableCell variant={showExplorerLink ? "middle" : "start"} innerClassName="text-theme-secondary-text">
-				<span data-testid="TransactionRow__timestamp">
+				<span data-testid="TransactionRow__timestamp" className="whitespace-no-wrap">
 					{transaction.timestamp()!.format("DD MMM YYYY HH:mm:ss")}
 				</span>
 			</TableCell>

--- a/src/domains/transaction/components/TransactionTable/TransactionRow/TransactionRowAmount.tsx
+++ b/src/domains/transaction/components/TransactionTable/TransactionRow/TransactionRowAmount.tsx
@@ -27,7 +27,7 @@ export const BaseTransactionRowAmount = ({ isSent, wallet, total, convertedTotal
 	const color = isSent ? "danger" : "success";
 
 	return (
-		<Label data-testid="TransactionRowAmount" color={color}>
+		<Label data-testid="TransactionRowAmount" color={color} className="whitespace-no-wrap">
 			<Amount ticker={wallet?.currency() || ""} value={total} />
 		</Label>
 	);

--- a/src/domains/transaction/components/TransactionTable/__snapshots__/TransactionTable.test.tsx.snap
+++ b/src/domains/transaction/components/TransactionTable/__snapshots__/TransactionTable.test.tsx.snap
@@ -172,6 +172,7 @@ exports[`TransactionTable should render 1`] = `
                 class="sc-AxiKw jHcrVp text-theme-secondary-text"
               >
                 <span
+                  class="whitespace-no-wrap"
                   data-testid="TransactionRow__timestamp"
                 >
                   31 Jul 2020 16:34:41
@@ -280,7 +281,7 @@ exports[`TransactionTable should render 1`] = `
                 class="sc-AxiKw jHcrVp justify-end"
               >
                 <div
-                  class="sc-AxhUy jeEWZG"
+                  class="sc-AxhUy jeEWZG whitespace-no-wrap"
                   color="danger"
                   data-testid="TransactionRowAmount"
                 >
@@ -330,6 +331,7 @@ exports[`TransactionTable should render 1`] = `
                 class="sc-AxiKw jHcrVp text-theme-secondary-text"
               >
                 <span
+                  class="whitespace-no-wrap"
                   data-testid="TransactionRow__timestamp"
                 >
                   31 Jul 2020 16:34:41
@@ -452,7 +454,7 @@ exports[`TransactionTable should render 1`] = `
                 class="sc-AxiKw jHcrVp justify-end"
               >
                 <div
-                  class="sc-AxhUy jeEWZG"
+                  class="sc-AxhUy jeEWZG whitespace-no-wrap"
                   color="danger"
                   data-testid="TransactionRowAmount"
                 >
@@ -603,7 +605,7 @@ exports[`TransactionTable should render compact 1`] = `
                 class="sc-AxiKw jxgwWm justify-end"
               >
                 <div
-                  class="sc-AxhUy jeEWZG"
+                  class="sc-AxhUy jeEWZG whitespace-no-wrap"
                   color="danger"
                   data-testid="TransactionRowAmount"
                 >
@@ -674,7 +676,7 @@ exports[`TransactionTable should render compact 1`] = `
                 class="sc-AxiKw jxgwWm justify-end"
               >
                 <div
-                  class="sc-AxhUy jeEWZG"
+                  class="sc-AxhUy jeEWZG whitespace-no-wrap"
                   color="danger"
                   data-testid="TransactionRowAmount"
                 >
@@ -2989,6 +2991,7 @@ exports[`TransactionTable should render with sign 1`] = `
                 class="sc-AxiKw jHcrVp text-theme-secondary-text"
               >
                 <span
+                  class="whitespace-no-wrap"
                   data-testid="TransactionRow__timestamp"
                 >
                   31 Jul 2020 16:34:41
@@ -3097,7 +3100,7 @@ exports[`TransactionTable should render with sign 1`] = `
                 class="sc-AxiKw jHcrVp justify-end"
               >
                 <div
-                  class="sc-AxhUy jeEWZG"
+                  class="sc-AxhUy jeEWZG whitespace-no-wrap"
                   color="danger"
                   data-testid="TransactionRowAmount"
                 >
@@ -3167,6 +3170,7 @@ exports[`TransactionTable should render with sign 1`] = `
                 class="sc-AxiKw jHcrVp text-theme-secondary-text"
               >
                 <span
+                  class="whitespace-no-wrap"
                   data-testid="TransactionRow__timestamp"
                 >
                   31 Jul 2020 16:34:41
@@ -3289,7 +3293,7 @@ exports[`TransactionTable should render with sign 1`] = `
                 class="sc-AxiKw jHcrVp justify-end"
               >
                 <div
-                  class="sc-AxhUy jeEWZG"
+                  class="sc-AxhUy jeEWZG whitespace-no-wrap"
                   color="danger"
                   data-testid="TransactionRowAmount"
                 >
@@ -3469,6 +3473,7 @@ exports[`TransactionTable should render without explorer link column 1`] = `
                 class="sc-AxiKw ekuVpr text-theme-secondary-text"
               >
                 <span
+                  class="whitespace-no-wrap"
                   data-testid="TransactionRow__timestamp"
                 >
                   31 Jul 2020 16:34:41
@@ -3577,7 +3582,7 @@ exports[`TransactionTable should render without explorer link column 1`] = `
                 class="sc-AxiKw jHcrVp justify-end"
               >
                 <div
-                  class="sc-AxhUy jeEWZG"
+                  class="sc-AxhUy jeEWZG whitespace-no-wrap"
                   color="danger"
                   data-testid="TransactionRowAmount"
                 >
@@ -3604,6 +3609,7 @@ exports[`TransactionTable should render without explorer link column 1`] = `
                 class="sc-AxiKw ekuVpr text-theme-secondary-text"
               >
                 <span
+                  class="whitespace-no-wrap"
                   data-testid="TransactionRow__timestamp"
                 >
                   31 Jul 2020 16:34:41
@@ -3726,7 +3732,7 @@ exports[`TransactionTable should render without explorer link column 1`] = `
                 class="sc-AxiKw jHcrVp justify-end"
               >
                 <div
-                  class="sc-AxhUy jeEWZG"
+                  class="sc-AxhUy jeEWZG whitespace-no-wrap"
                   color="danger"
                   data-testid="TransactionRowAmount"
                 >

--- a/src/domains/wallet/pages/WalletDetails/__snapshots__/WalletDetails.test.tsx.snap
+++ b/src/domains/wallet/pages/WalletDetails/__snapshots__/WalletDetails.test.tsx.snap
@@ -840,6 +840,7 @@ exports[`WalletDetails should not fail if the votes have not yet been synchroniz
                           class="sc-Axmtr cSXHUn text-theme-secondary-text"
                         >
                           <span
+                            class="whitespace-no-wrap"
                             data-testid="TransactionRow__timestamp"
                           >
                             23 Jul 2020 08:03:20
@@ -933,7 +934,7 @@ exports[`WalletDetails should not fail if the votes have not yet been synchroniz
                           class="sc-Axmtr cSXHUn justify-end"
                         >
                           <div
-                            class="sc-fzozJi bXfNeq"
+                            class="sc-fzozJi bXfNeq whitespace-no-wrap"
                             color="success"
                             data-testid="TransactionRowAmount"
                           >
@@ -2357,6 +2358,7 @@ exports[`WalletDetails should not render the bottom sheet menu when there is onl
                           class="sc-Axmtr cSXHUn text-theme-secondary-text"
                         >
                           <span
+                            class="whitespace-no-wrap"
                             data-testid="TransactionRow__timestamp"
                           >
                             23 Jul 2020 08:03:20
@@ -2450,7 +2452,7 @@ exports[`WalletDetails should not render the bottom sheet menu when there is onl
                           class="sc-Axmtr cSXHUn justify-end"
                         >
                           <div
-                            class="sc-fzozJi bXfNeq"
+                            class="sc-fzozJi bXfNeq whitespace-no-wrap"
                             color="success"
                             data-testid="TransactionRowAmount"
                           >
@@ -3351,6 +3353,7 @@ exports[`WalletDetails should open detail modal on transaction row click 1`] = `
                           class="sc-Axmtr cSXHUn text-theme-secondary-text"
                         >
                           <span
+                            class="whitespace-no-wrap"
                             data-testid="TransactionRow__timestamp"
                           >
                             23 Jul 2020 08:03:20
@@ -3444,7 +3447,7 @@ exports[`WalletDetails should open detail modal on transaction row click 1`] = `
                           class="sc-Axmtr cSXHUn justify-end"
                         >
                           <div
-                            class="sc-fzozJi bXfNeq"
+                            class="sc-fzozJi bXfNeq whitespace-no-wrap"
                             color="success"
                             data-testid="TransactionRowAmount"
                           >
@@ -4887,6 +4890,7 @@ exports[`WalletDetails should remove wallet name 1`] = `
                           class="sc-Axmtr cSXHUn text-theme-secondary-text"
                         >
                           <span
+                            class="whitespace-no-wrap"
                             data-testid="TransactionRow__timestamp"
                           >
                             23 Jul 2020 08:03:20
@@ -4980,7 +4984,7 @@ exports[`WalletDetails should remove wallet name 1`] = `
                           class="sc-Axmtr cSXHUn justify-end"
                         >
                           <div
-                            class="sc-fzozJi bXfNeq"
+                            class="sc-fzozJi bXfNeq whitespace-no-wrap"
                             color="success"
                             data-testid="TransactionRowAmount"
                           >
@@ -6425,6 +6429,7 @@ exports[`WalletDetails should render 1`] = `
                           class="sc-Axmtr cSXHUn text-theme-secondary-text"
                         >
                           <span
+                            class="whitespace-no-wrap"
                             data-testid="TransactionRow__timestamp"
                           >
                             23 Jul 2020 08:03:20
@@ -6518,7 +6523,7 @@ exports[`WalletDetails should render 1`] = `
                           class="sc-Axmtr cSXHUn justify-end"
                         >
                           <div
-                            class="sc-fzozJi bXfNeq"
+                            class="sc-fzozJi bXfNeq whitespace-no-wrap"
                             color="success"
                             data-testid="TransactionRowAmount"
                           >
@@ -7955,6 +7960,7 @@ exports[`WalletDetails should render when wallet hasn't voted 1`] = `
                           class="sc-Axmtr cSXHUn text-theme-secondary-text"
                         >
                           <span
+                            class="whitespace-no-wrap"
                             data-testid="TransactionRow__timestamp"
                           >
                             23 Jul 2020 08:03:20
@@ -8048,7 +8054,7 @@ exports[`WalletDetails should render when wallet hasn't voted 1`] = `
                           class="sc-Axmtr cSXHUn justify-end"
                         >
                           <div
-                            class="sc-fzozJi bXfNeq"
+                            class="sc-fzozJi bXfNeq whitespace-no-wrap"
                             color="success"
                             data-testid="TransactionRowAmount"
                           >
@@ -9485,6 +9491,7 @@ exports[`WalletDetails should render when wallet not found for votes 1`] = `
                           class="sc-Axmtr cSXHUn text-theme-secondary-text"
                         >
                           <span
+                            class="whitespace-no-wrap"
                             data-testid="TransactionRow__timestamp"
                           >
                             23 Jul 2020 08:03:20
@@ -9578,7 +9585,7 @@ exports[`WalletDetails should render when wallet not found for votes 1`] = `
                           class="sc-Axmtr cSXHUn justify-end"
                         >
                           <div
-                            class="sc-fzozJi bXfNeq"
+                            class="sc-fzozJi bXfNeq whitespace-no-wrap"
                             color="success"
                             data-testid="TransactionRowAmount"
                           >
@@ -11027,6 +11034,7 @@ exports[`WalletDetails should star and unstar a wallet 1`] = `
                           class="sc-Axmtr cSXHUn text-theme-secondary-text"
                         >
                           <span
+                            class="whitespace-no-wrap"
                             data-testid="TransactionRow__timestamp"
                           >
                             23 Jul 2020 08:03:20
@@ -11120,7 +11128,7 @@ exports[`WalletDetails should star and unstar a wallet 1`] = `
                           class="sc-Axmtr cSXHUn justify-end"
                         >
                           <div
-                            class="sc-fzozJi bXfNeq"
+                            class="sc-fzozJi bXfNeq whitespace-no-wrap"
                             color="success"
                             data-testid="TransactionRowAmount"
                           >
@@ -12565,6 +12573,7 @@ exports[`WalletDetails should update wallet name 1`] = `
                           class="sc-Axmtr cSXHUn text-theme-secondary-text"
                         >
                           <span
+                            class="whitespace-no-wrap"
                             data-testid="TransactionRow__timestamp"
                           >
                             23 Jul 2020 08:03:20
@@ -12658,7 +12667,7 @@ exports[`WalletDetails should update wallet name 1`] = `
                           class="sc-Axmtr cSXHUn justify-end"
                         >
                           <div
-                            class="sc-fzozJi bXfNeq"
+                            class="sc-fzozJi bXfNeq whitespace-no-wrap"
                             color="success"
                             data-testid="TransactionRowAmount"
                           >


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->
Use `whitespace-no-wrap` for date and amount columns in `TransactionRow`
![2020-10-26-173407_404x451_scrot](https://user-images.githubusercontent.com/22020168/97189982-e1ccab80-17ad-11eb-8209-84d02aa3505e.png)

## Summary

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
