### PR TITLE
refactor: reduce line height in `WalletVote` and `WalletRegistrations` component

### DIFF
--- a/src/domains/wallet/pages/WalletDetails/__snapshots__/WalletDetails.test.tsx.snap
+++ b/src/domains/wallet/pages/WalletDetails/__snapshots__/WalletDetails.test.tsx.snap
@@ -531,9 +531,11 @@ exports[`WalletDetails should not fail if the votes have not yet been synchroniz
                     class="flex justify-between flex-1"
                   >
                     <div
-                      class="flex flex-col mr-4 font-semibold text-theme-text"
+                      class="flex flex-col mr-4 font-semibold text-theme-text leading-snug"
                     >
-                      <span>
+                      <span
+                        class="mr-2"
+                      >
                         You have not yet voted for a Delegate
                       </span>
                       <div
@@ -609,7 +611,7 @@ exports[`WalletDetails should not fail if the votes have not yet been synchroniz
                     class="flex justify-between flex-1"
                   >
                     <div
-                      class="flex flex-col mr-4 font-semibold text-theme-text"
+                      class="flex flex-col mr-4 font-semibold text-theme-text leading-snug"
                     >
                       <span
                         class="mr-2"
@@ -2049,9 +2051,11 @@ exports[`WalletDetails should not render the bottom sheet menu when there is onl
                     class="flex justify-between flex-1"
                   >
                     <div
-                      class="flex flex-col mr-4 font-semibold text-theme-text"
+                      class="flex flex-col mr-4 font-semibold text-theme-text leading-snug"
                     >
-                      <span>
+                      <span
+                        class="mr-2"
+                      >
                         You have not yet voted for a Delegate
                       </span>
                       <div
@@ -2127,7 +2131,7 @@ exports[`WalletDetails should not render the bottom sheet menu when there is onl
                     class="flex justify-between flex-1"
                   >
                     <div
-                      class="flex flex-col mr-4 font-semibold text-theme-text"
+                      class="flex flex-col mr-4 font-semibold text-theme-text leading-snug"
                     >
                       <span
                         class="mr-2"
@@ -3126,7 +3130,7 @@ exports[`WalletDetails should open detail modal on transaction row click 1`] = `
                     class="flex justify-between flex-1"
                   >
                     <div
-                      class="flex flex-col mr-4 font-semibold text-theme-text"
+                      class="flex flex-col mr-4 font-semibold text-theme-text leading-snug"
                     >
                       <span
                         class="mr-2"
@@ -4667,7 +4671,7 @@ exports[`WalletDetails should remove wallet name 1`] = `
                     class="flex justify-between flex-1"
                   >
                     <div
-                      class="flex flex-col mr-4 font-semibold text-theme-text"
+                      class="flex flex-col mr-4 font-semibold text-theme-text leading-snug"
                     >
                       <span
                         class="mr-2"
@@ -6210,7 +6214,7 @@ exports[`WalletDetails should render 1`] = `
                     class="flex justify-between flex-1"
                   >
                     <div
-                      class="flex flex-col mr-4 font-semibold text-theme-text"
+                      class="flex flex-col mr-4 font-semibold text-theme-text leading-snug"
                     >
                       <span
                         class="mr-2"
@@ -7663,9 +7667,11 @@ exports[`WalletDetails should render when wallet hasn't voted 1`] = `
                     class="flex justify-between flex-1"
                   >
                     <div
-                      class="flex flex-col mr-4 font-semibold text-theme-text"
+                      class="flex flex-col mr-4 font-semibold text-theme-text leading-snug"
                     >
-                      <span>
+                      <span
+                        class="mr-2"
+                      >
                         You have not yet voted for a Delegate
                       </span>
                       <div
@@ -7741,7 +7747,7 @@ exports[`WalletDetails should render when wallet hasn't voted 1`] = `
                     class="flex justify-between flex-1"
                   >
                     <div
-                      class="flex flex-col mr-4 font-semibold text-theme-text"
+                      class="flex flex-col mr-4 font-semibold text-theme-text leading-snug"
                     >
                       <span
                         class="mr-2"
@@ -9194,9 +9200,11 @@ exports[`WalletDetails should render when wallet not found for votes 1`] = `
                     class="flex justify-between flex-1"
                   >
                     <div
-                      class="flex flex-col mr-4 font-semibold text-theme-text"
+                      class="flex flex-col mr-4 font-semibold text-theme-text leading-snug"
                     >
-                      <span>
+                      <span
+                        class="mr-2"
+                      >
                         You have not yet voted for a Delegate
                       </span>
                       <div
@@ -9272,7 +9280,7 @@ exports[`WalletDetails should render when wallet not found for votes 1`] = `
                     class="flex justify-between flex-1"
                   >
                     <div
-                      class="flex flex-col mr-4 font-semibold text-theme-text"
+                      class="flex flex-col mr-4 font-semibold text-theme-text leading-snug"
                     >
                       <span
                         class="mr-2"
@@ -10819,7 +10827,7 @@ exports[`WalletDetails should star and unstar a wallet 1`] = `
                     class="flex justify-between flex-1"
                   >
                     <div
-                      class="flex flex-col mr-4 font-semibold text-theme-text"
+                      class="flex flex-col mr-4 font-semibold text-theme-text leading-snug"
                     >
                       <span
                         class="mr-2"
@@ -12362,7 +12370,7 @@ exports[`WalletDetails should update wallet name 1`] = `
                     class="flex justify-between flex-1"
                   >
                     <div
-                      class="flex flex-col mr-4 font-semibold text-theme-text"
+                      class="flex flex-col mr-4 font-semibold text-theme-text leading-snug"
                     >
                       <span
                         class="mr-2"

--- a/src/domains/wallet/pages/WalletDetails/__snapshots__/WalletDetails.test.tsx.snap
+++ b/src/domains/wallet/pages/WalletDetails/__snapshots__/WalletDetails.test.tsx.snap
@@ -531,7 +531,7 @@ exports[`WalletDetails should not fail if the votes have not yet been synchroniz
                     class="flex justify-between flex-1"
                   >
                     <div
-                      class="flex flex-col mr-4 font-semibold text-theme-text leading-snug"
+                      class="flex flex-col mr-4 font-semibold leading-snug text-theme-text"
                     >
                       <span
                         class="mr-2"
@@ -611,7 +611,7 @@ exports[`WalletDetails should not fail if the votes have not yet been synchroniz
                     class="flex justify-between flex-1"
                   >
                     <div
-                      class="flex flex-col mr-4 font-semibold text-theme-text leading-snug"
+                      class="flex flex-col mr-4 font-semibold leading-snug text-theme-text"
                     >
                       <span
                         class="mr-2"
@@ -2051,7 +2051,7 @@ exports[`WalletDetails should not render the bottom sheet menu when there is onl
                     class="flex justify-between flex-1"
                   >
                     <div
-                      class="flex flex-col mr-4 font-semibold text-theme-text leading-snug"
+                      class="flex flex-col mr-4 font-semibold leading-snug text-theme-text"
                     >
                       <span
                         class="mr-2"
@@ -2131,7 +2131,7 @@ exports[`WalletDetails should not render the bottom sheet menu when there is onl
                     class="flex justify-between flex-1"
                   >
                     <div
-                      class="flex flex-col mr-4 font-semibold text-theme-text leading-snug"
+                      class="flex flex-col mr-4 font-semibold leading-snug text-theme-text"
                     >
                       <span
                         class="mr-2"
@@ -3130,7 +3130,7 @@ exports[`WalletDetails should open detail modal on transaction row click 1`] = `
                     class="flex justify-between flex-1"
                   >
                     <div
-                      class="flex flex-col mr-4 font-semibold text-theme-text leading-snug"
+                      class="flex flex-col mr-4 font-semibold leading-snug text-theme-text"
                     >
                       <span
                         class="mr-2"
@@ -4671,7 +4671,7 @@ exports[`WalletDetails should remove wallet name 1`] = `
                     class="flex justify-between flex-1"
                   >
                     <div
-                      class="flex flex-col mr-4 font-semibold text-theme-text leading-snug"
+                      class="flex flex-col mr-4 font-semibold leading-snug text-theme-text"
                     >
                       <span
                         class="mr-2"
@@ -6214,7 +6214,7 @@ exports[`WalletDetails should render 1`] = `
                     class="flex justify-between flex-1"
                   >
                     <div
-                      class="flex flex-col mr-4 font-semibold text-theme-text leading-snug"
+                      class="flex flex-col mr-4 font-semibold leading-snug text-theme-text"
                     >
                       <span
                         class="mr-2"
@@ -7667,7 +7667,7 @@ exports[`WalletDetails should render when wallet hasn't voted 1`] = `
                     class="flex justify-between flex-1"
                   >
                     <div
-                      class="flex flex-col mr-4 font-semibold text-theme-text leading-snug"
+                      class="flex flex-col mr-4 font-semibold leading-snug text-theme-text"
                     >
                       <span
                         class="mr-2"
@@ -7747,7 +7747,7 @@ exports[`WalletDetails should render when wallet hasn't voted 1`] = `
                     class="flex justify-between flex-1"
                   >
                     <div
-                      class="flex flex-col mr-4 font-semibold text-theme-text leading-snug"
+                      class="flex flex-col mr-4 font-semibold leading-snug text-theme-text"
                     >
                       <span
                         class="mr-2"
@@ -9200,7 +9200,7 @@ exports[`WalletDetails should render when wallet not found for votes 1`] = `
                     class="flex justify-between flex-1"
                   >
                     <div
-                      class="flex flex-col mr-4 font-semibold text-theme-text leading-snug"
+                      class="flex flex-col mr-4 font-semibold leading-snug text-theme-text"
                     >
                       <span
                         class="mr-2"
@@ -9280,7 +9280,7 @@ exports[`WalletDetails should render when wallet not found for votes 1`] = `
                     class="flex justify-between flex-1"
                   >
                     <div
-                      class="flex flex-col mr-4 font-semibold text-theme-text leading-snug"
+                      class="flex flex-col mr-4 font-semibold leading-snug text-theme-text"
                     >
                       <span
                         class="mr-2"
@@ -10827,7 +10827,7 @@ exports[`WalletDetails should star and unstar a wallet 1`] = `
                     class="flex justify-between flex-1"
                   >
                     <div
-                      class="flex flex-col mr-4 font-semibold text-theme-text leading-snug"
+                      class="flex flex-col mr-4 font-semibold leading-snug text-theme-text"
                     >
                       <span
                         class="mr-2"
@@ -12370,7 +12370,7 @@ exports[`WalletDetails should update wallet name 1`] = `
                     class="flex justify-between flex-1"
                   >
                     <div
-                      class="flex flex-col mr-4 font-semibold text-theme-text leading-snug"
+                      class="flex flex-col mr-4 font-semibold leading-snug text-theme-text"
                     >
                       <span
                         class="mr-2"

--- a/src/domains/wallet/pages/WalletDetails/components/WalletRegistrations/WalletRegistrations.tsx
+++ b/src/domains/wallet/pages/WalletDetails/components/WalletRegistrations/WalletRegistrations.tsx
@@ -64,7 +64,7 @@ export const WalletRegistrations = ({
 					</div>
 
 					<div className="flex justify-between flex-1">
-						<div className="flex flex-col mr-4 font-semibold text-theme-text leading-snug">
+						<div className="flex flex-col mr-4 font-semibold leading-snug text-theme-text">
 							<span className="mr-2">
 								{t("WALLETS.PAGE_WALLET_DETAILS.REGISTRATIONS.EMPTY_DESCRIPTION")}
 							</span>

--- a/src/domains/wallet/pages/WalletDetails/components/WalletRegistrations/WalletRegistrations.tsx
+++ b/src/domains/wallet/pages/WalletDetails/components/WalletRegistrations/WalletRegistrations.tsx
@@ -64,7 +64,7 @@ export const WalletRegistrations = ({
 					</div>
 
 					<div className="flex justify-between flex-1">
-						<div className="flex flex-col mr-4 font-semibold text-theme-text">
+						<div className="flex flex-col mr-4 font-semibold text-theme-text leading-snug">
 							<span className="mr-2">
 								{t("WALLETS.PAGE_WALLET_DETAILS.REGISTRATIONS.EMPTY_DESCRIPTION")}
 							</span>

--- a/src/domains/wallet/pages/WalletDetails/components/WalletRegistrations/WalletRegistrationsSkeleton.tsx
+++ b/src/domains/wallet/pages/WalletDetails/components/WalletRegistrations/WalletRegistrationsSkeleton.tsx
@@ -19,7 +19,7 @@ export const WalletRegistrationsSkeleton = () => (
 		</div>
 
 		<div className="ml-auto">
-			<Skeleton height={48} width={100} />
+			<Skeleton height={44} width={100} />
 		</div>
 	</div>
 );

--- a/src/domains/wallet/pages/WalletDetails/components/WalletRegistrations/__snapshots__/WalletRegistrations.test.tsx.snap
+++ b/src/domains/wallet/pages/WalletDetails/components/WalletRegistrations/__snapshots__/WalletRegistrations.test.tsx.snap
@@ -47,7 +47,7 @@ exports[`WalletRegistrations should render empty mode 1`] = `
         class="flex justify-between flex-1"
       >
         <div
-          class="flex flex-col mr-4 font-semibold text-theme-text"
+          class="flex flex-col mr-4 font-semibold text-theme-text leading-snug"
         >
           <span
             class="mr-2"
@@ -469,7 +469,7 @@ exports[`WalletRegistrations should render loading state 1`] = `
           >
             <span
               class="react-loading-skeleton css-1vmnjpn-skeletonStyles-Skeleton"
-              style="width: 100px; height: 48px;"
+              style="width: 100px; height: 44px;"
             >
               ‌
             </span>

--- a/src/domains/wallet/pages/WalletDetails/components/WalletRegistrations/__snapshots__/WalletRegistrations.test.tsx.snap
+++ b/src/domains/wallet/pages/WalletDetails/components/WalletRegistrations/__snapshots__/WalletRegistrations.test.tsx.snap
@@ -47,7 +47,7 @@ exports[`WalletRegistrations should render empty mode 1`] = `
         class="flex justify-between flex-1"
       >
         <div
-          class="flex flex-col mr-4 font-semibold text-theme-text leading-snug"
+          class="flex flex-col mr-4 font-semibold leading-snug text-theme-text"
         >
           <span
             class="mr-2"

--- a/src/domains/wallet/pages/WalletDetails/components/WalletVote/WalletVote.tsx
+++ b/src/domains/wallet/pages/WalletDetails/components/WalletVote/WalletVote.tsx
@@ -45,8 +45,8 @@ export const WalletVote = ({ votes, maxVotes, isLoading, onButtonClick }: Wallet
 					</div>
 
 					<div className="flex justify-between flex-1">
-						<div className="flex flex-col mr-4 font-semibold text-theme-text">
-							<span>{t("WALLETS.PAGE_WALLET_DETAILS.VOTES.EMPTY_DESCRIPTION")}</span>
+						<div className="flex flex-col mr-4 font-semibold text-theme-text leading-snug">
+							<span className="mr-2">{t("WALLETS.PAGE_WALLET_DETAILS.VOTES.EMPTY_DESCRIPTION")}</span>
 
 							<div className="mr-auto">
 								<Link

--- a/src/domains/wallet/pages/WalletDetails/components/WalletVote/WalletVote.tsx
+++ b/src/domains/wallet/pages/WalletDetails/components/WalletVote/WalletVote.tsx
@@ -45,7 +45,7 @@ export const WalletVote = ({ votes, maxVotes, isLoading, onButtonClick }: Wallet
 					</div>
 
 					<div className="flex justify-between flex-1">
-						<div className="flex flex-col mr-4 font-semibold text-theme-text leading-snug">
+						<div className="flex flex-col mr-4 font-semibold leading-snug text-theme-text">
 							<span className="mr-2">{t("WALLETS.PAGE_WALLET_DETAILS.VOTES.EMPTY_DESCRIPTION")}</span>
 
 							<div className="mr-auto">

--- a/src/domains/wallet/pages/WalletDetails/components/WalletVote/WalletVoteSkeleton.tsx
+++ b/src/domains/wallet/pages/WalletDetails/components/WalletVote/WalletVoteSkeleton.tsx
@@ -19,7 +19,7 @@ export const WalletVoteSkeleton = () => (
 		</div>
 
 		<div className="ml-auto">
-			<Skeleton height={48} width={100} />
+			<Skeleton height={44} width={100} />
 		</div>
 	</div>
 );

--- a/src/domains/wallet/pages/WalletDetails/components/WalletVote/__snapshots__/WalletVote.test.tsx.snap
+++ b/src/domains/wallet/pages/WalletDetails/components/WalletVote/__snapshots__/WalletVote.test.tsx.snap
@@ -576,7 +576,7 @@ exports[`WalletVote should render the maximum votes 1`] = `
         class="flex justify-between flex-1"
       >
         <div
-          class="flex flex-col mr-4 font-semibold text-theme-text leading-snug"
+          class="flex flex-col mr-4 font-semibold leading-snug text-theme-text"
         >
           <span
             class="mr-2"
@@ -665,7 +665,7 @@ exports[`WalletVote should render without votes 1`] = `
         class="flex justify-between flex-1"
       >
         <div
-          class="flex flex-col mr-4 font-semibold text-theme-text leading-snug"
+          class="flex flex-col mr-4 font-semibold leading-snug text-theme-text"
         >
           <span
             class="mr-2"

--- a/src/domains/wallet/pages/WalletDetails/components/WalletVote/__snapshots__/WalletVote.test.tsx.snap
+++ b/src/domains/wallet/pages/WalletDetails/components/WalletVote/__snapshots__/WalletVote.test.tsx.snap
@@ -198,7 +198,7 @@ exports[`WalletVote should render loading state 1`] = `
           >
             <span
               class="react-loading-skeleton css-1vmnjpn-skeletonStyles-Skeleton"
-              style="width: 100px; height: 48px;"
+              style="width: 100px; height: 44px;"
             >
               ‌
             </span>
@@ -576,9 +576,11 @@ exports[`WalletVote should render the maximum votes 1`] = `
         class="flex justify-between flex-1"
       >
         <div
-          class="flex flex-col mr-4 font-semibold text-theme-text"
+          class="flex flex-col mr-4 font-semibold text-theme-text leading-snug"
         >
-          <span>
+          <span
+            class="mr-2"
+          >
             You have not yet voted for a Delegate
           </span>
           <div
@@ -663,9 +665,11 @@ exports[`WalletVote should render without votes 1`] = `
         class="flex justify-between flex-1"
       >
         <div
-          class="flex flex-col mr-4 font-semibold text-theme-text"
+          class="flex flex-col mr-4 font-semibold text-theme-text leading-snug"
         >
-          <span>
+          <span
+            class="mr-2"
+          >
             You have not yet voted for a Delegate
           </span>
           <div


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Reduces the line-height in the empty state of both components, so that in all different states the components content has an equal height and therefore doesn't cause any layout shifts when the state changes.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
