### PR TITLE
fix: remove sticky position of titles in notifications

### DIFF
--- a/src/app/components/Notifications/Notifications.tsx
+++ b/src/app/components/Notifications/Notifications.tsx
@@ -38,7 +38,7 @@ export const Notifications = ({ profile, onNotificationAction, onTransactionClic
 		<NotificationsWrapper ref={wrapperRef as React.MutableRefObject<any>} data-testid="NotificationsWrapper">
 			{plugins.length > 0 && (
 				<>
-					<div className="sticky z-10 py-4 pl-4 pr-8 mb-2 -mx-4 text-sm font-bold text-theme-neutral -top-5">
+					<div className="z-10 py-4 pl-4 pr-8 mb-2 -mx-4 text-sm font-bold text-theme-neutral -top-5">
 						{t("COMMON.NOTIFICATIONS.PLUGINS_TITLE")}
 					</div>
 					<Table hideHeader columns={[{ Header: "-", className: "hidden" }]} data={plugins}>
@@ -56,7 +56,7 @@ export const Notifications = ({ profile, onNotificationAction, onTransactionClic
 
 			{transactions.length > 0 && (
 				<div className="mt-4">
-					<div className="sticky z-10 py-1 pl-4 pr-8 -mx-4 text-sm font-bold text-theme-neutral -top-5">
+					<div className="z-10 py-1 pl-4 pr-8 -mx-4 text-sm font-bold text-theme-neutral -top-5">
 						{t("COMMON.NOTIFICATIONS.TRANSACTIONS_TITLE")}
 					</div>
 					<Table hideHeader columns={[{ Header: "-", className: "hidden" }]} data={transactions}>

--- a/src/app/components/Notifications/__snapshots__/Notifications.test.tsx.snap
+++ b/src/app/components/Notifications/__snapshots__/Notifications.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`Notifications should emit transactionClick event 1`] = `
     data-testid="NotificationsWrapper"
   >
     <div
-      class="sticky z-10 py-4 pl-4 pr-8 mb-2 -mx-4 text-sm font-bold text-theme-neutral -top-5"
+      class="z-10 py-4 pl-4 pr-8 mb-2 -mx-4 text-sm font-bold text-theme-neutral -top-5"
     >
       Plugins
     </div>
@@ -97,7 +97,7 @@ exports[`Notifications should emit transactionClick event 1`] = `
       class="mt-4"
     >
       <div
-        class="sticky z-10 py-1 pl-4 pr-8 -mx-4 text-sm font-bold text-theme-neutral -top-5"
+        class="z-10 py-1 pl-4 pr-8 -mx-4 text-sm font-bold text-theme-neutral -top-5"
       >
         Transactions
       </div>
@@ -308,7 +308,7 @@ exports[`Notifications should render with plugins 1`] = `
     data-testid="NotificationsWrapper"
   >
     <div
-      class="sticky z-10 py-4 pl-4 pr-8 mb-2 -mx-4 text-sm font-bold text-theme-neutral -top-5"
+      class="z-10 py-4 pl-4 pr-8 mb-2 -mx-4 text-sm font-bold text-theme-neutral -top-5"
     >
       Plugins
     </div>
@@ -398,7 +398,7 @@ exports[`Notifications should render with plugins 1`] = `
       class="mt-4"
     >
       <div
-        class="sticky z-10 py-1 pl-4 pr-8 -mx-4 text-sm font-bold text-theme-neutral -top-5"
+        class="z-10 py-1 pl-4 pr-8 -mx-4 text-sm font-bold text-theme-neutral -top-5"
       >
         Transactions
       </div>
@@ -570,7 +570,7 @@ exports[`Notifications should render with transactions and plugins 1`] = `
     data-testid="NotificationsWrapper"
   >
     <div
-      class="sticky z-10 py-4 pl-4 pr-8 mb-2 -mx-4 text-sm font-bold text-theme-neutral -top-5"
+      class="z-10 py-4 pl-4 pr-8 mb-2 -mx-4 text-sm font-bold text-theme-neutral -top-5"
     >
       Plugins
     </div>
@@ -660,7 +660,7 @@ exports[`Notifications should render with transactions and plugins 1`] = `
       class="mt-4"
     >
       <div
-        class="sticky z-10 py-1 pl-4 pr-8 -mx-4 text-sm font-bold text-theme-neutral -top-5"
+        class="z-10 py-1 pl-4 pr-8 -mx-4 text-sm font-bold text-theme-neutral -top-5"
       >
         Transactions
       </div>

--- a/src/app/components/Notifications/__snapshots__/NotificationsDropdown.test.tsx.snap
+++ b/src/app/components/Notifications/__snapshots__/NotificationsDropdown.test.tsx.snap
@@ -53,7 +53,7 @@ exports[`Notifications should open and close transaction details modal 1`] = `
                 data-testid="NotificationsWrapper"
               >
                 <div
-                  class="sticky z-10 py-4 pl-4 pr-8 mb-2 -mx-4 text-sm font-bold text-theme-neutral -top-5"
+                  class="z-10 py-4 pl-4 pr-8 mb-2 -mx-4 text-sm font-bold text-theme-neutral -top-5"
                 >
                   Plugins
                 </div>
@@ -143,7 +143,7 @@ exports[`Notifications should open and close transaction details modal 1`] = `
                   class="mt-4"
                 >
                   <div
-                    class="sticky z-10 py-1 pl-4 pr-8 -mx-4 text-sm font-bold text-theme-neutral -top-5"
+                    class="z-10 py-1 pl-4 pr-8 -mx-4 text-sm font-bold text-theme-neutral -top-5"
                   >
                     Transactions
                   </div>
@@ -738,7 +738,7 @@ exports[`Notifications should open and close transaction details modal 2`] = `
                 data-testid="NotificationsWrapper"
               >
                 <div
-                  class="sticky z-10 py-4 pl-4 pr-8 mb-2 -mx-4 text-sm font-bold text-theme-neutral -top-5"
+                  class="z-10 py-4 pl-4 pr-8 mb-2 -mx-4 text-sm font-bold text-theme-neutral -top-5"
                 >
                   Plugins
                 </div>
@@ -828,7 +828,7 @@ exports[`Notifications should open and close transaction details modal 2`] = `
                   class="mt-4"
                 >
                   <div
-                    class="sticky z-10 py-1 pl-4 pr-8 -mx-4 text-sm font-bold text-theme-neutral -top-5"
+                    class="z-10 py-1 pl-4 pr-8 -mx-4 text-sm font-bold text-theme-neutral -top-5"
                   >
                     Transactions
                   </div>
@@ -1052,7 +1052,7 @@ exports[`Notifications should render with transactions and plugins 1`] = `
                 data-testid="NotificationsWrapper"
               >
                 <div
-                  class="sticky z-10 py-4 pl-4 pr-8 mb-2 -mx-4 text-sm font-bold text-theme-neutral -top-5"
+                  class="z-10 py-4 pl-4 pr-8 mb-2 -mx-4 text-sm font-bold text-theme-neutral -top-5"
                 >
                   Plugins
                 </div>
@@ -1142,7 +1142,7 @@ exports[`Notifications should render with transactions and plugins 1`] = `
                   class="mt-4"
                 >
                   <div
-                    class="sticky z-10 py-1 pl-4 pr-8 -mx-4 text-sm font-bold text-theme-neutral -top-5"
+                    class="z-10 py-1 pl-4 pr-8 -mx-4 text-sm font-bold text-theme-neutral -top-5"
                   >
                     Transactions
                   </div>


### PR DESCRIPTION
## Summary

An element with `position: sticky;` is positioned based on the user's scroll position.

![Peek 2020-10-30 15-12](https://user-images.githubusercontent.com/1894191/97742749-7a6f6e00-1ac3-11eb-9317-c7d0f6414877.gif)

## Checklist

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged
