### PR TITLE
fix: move `ErrorBoundary` inside the environment provider

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -145,16 +145,16 @@ export const App = () => {
 	);
 
 	return (
-		<ErrorBoundary FallbackComponent={ApplicationError}>
-			<I18nextProvider i18n={i18n}>
-				<EnvironmentProvider env={env}>
+		<I18nextProvider i18n={i18n}>
+			<EnvironmentProvider env={env}>
+				<ErrorBoundary FallbackComponent={ApplicationError}>
 					<ThemeProvider>
 						<LedgerProvider transport={LedgerTransportNodeHID}>
 							<Main />
 						</LedgerProvider>
 					</ThemeProvider>
-				</EnvironmentProvider>
-			</I18nextProvider>
-		</ErrorBoundary>
+				</ErrorBoundary>
+			</EnvironmentProvider>
+		</I18nextProvider>
 	);
 };

--- a/src/domains/error/pages/ApplicationError/ApplicationError.stories.tsx
+++ b/src/domains/error/pages/ApplicationError/ApplicationError.stories.tsx
@@ -6,4 +6,4 @@ export default {
 	title: "Domains / Error / Pages / ApplicationError",
 };
 
-export const Default = () => <ApplicationError />;
+export const Default = () => <ApplicationError resetErrorBoundary={() => alert("reseted")} />;

--- a/src/domains/error/pages/ApplicationError/ApplicationError.test.tsx
+++ b/src/domains/error/pages/ApplicationError/ApplicationError.test.tsx
@@ -1,16 +1,25 @@
 import React from "react";
-import { render } from "testing-library";
+import { act, fireEvent, render } from "testing-library";
 
 import { translations } from "../../i18n";
 import { ApplicationError } from "./ApplicationError";
 
 describe("ApplicationError", () => {
 	it("should render", () => {
-		const { container, asFragment, getByTestId } = render(<ApplicationError />);
+		const onResetErrorBoundary = jest.fn();
+		const { asFragment, container, getByTestId } = render(
+			<ApplicationError resetErrorBoundary={onResetErrorBoundary} />,
+		);
 
 		expect(container).toBeTruthy();
 		expect(getByTestId("ApplicationError__text")).toHaveTextContent(translations.APPLICATION.TITLE);
 		expect(getByTestId("ApplicationError__text")).toHaveTextContent(translations.APPLICATION.DESCRIPTION);
+
+		act(() => {
+			fireEvent.click(getByTestId("ApplicationError__button--reload"));
+		});
+
+		expect(onResetErrorBoundary).toHaveBeenCalled();
 		expect(asFragment()).toMatchSnapshot();
 	});
 });

--- a/src/domains/error/pages/ApplicationError/ApplicationError.tsx
+++ b/src/domains/error/pages/ApplicationError/ApplicationError.tsx
@@ -2,11 +2,12 @@ import { images } from "app/assets/images";
 import { Button } from "app/components/Button";
 import { Page, Section } from "app/components/Layout";
 import React from "react";
+import { FallbackProps } from "react-error-boundary";
 import { useTranslation } from "react-i18next";
 
 const { ErrorBanner } = images.error.pages.ApplicationError;
 
-export const ApplicationError = ({ resetErrorBoundary }: any) => {
+export const ApplicationError = ({ resetErrorBoundary }: FallbackProps) => {
 	const { t } = useTranslation();
 
 	return (
@@ -21,7 +22,7 @@ export const ApplicationError = ({ resetErrorBoundary }: any) => {
 					<p className="text-theme-secondary-text">{t("ERROR.APPLICATION.DESCRIPTION")}</p>
 				</div>
 
-				<Button onClick={resetErrorBoundary} className="mt-8">
+				<Button data-testid="ApplicationError__button--reload" onClick={resetErrorBoundary} className="mt-8">
 					{t("ERROR.APPLICATION.RELOAD")}
 				</Button>
 			</Section>

--- a/src/domains/error/pages/ApplicationError/__snapshots__/ApplicationError.test.tsx.snap
+++ b/src/domains/error/pages/ApplicationError/__snapshots__/ApplicationError.test.tsx.snap
@@ -65,6 +65,7 @@ exports[`ApplicationError should render 1`] = `
           <button
             class="sc-AxjAm colAFb mt-8"
             color="primary"
+            data-testid="ApplicationError__button--reload"
             type="button"
           >
             Reload


### PR DESCRIPTION
## Summary

Task: https://app.clickup.com/t/2aztwr

## Checklist

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged
