### PR TITLE
refactor: toggle asset selection on `SelectNetwork`

### DIFF
--- a/src/domains/network/components/SelectNetwork/SelectNetwork.test.tsx
+++ b/src/domains/network/components/SelectNetwork/SelectNetwork.test.tsx
@@ -203,6 +203,34 @@ describe("SelectNetwork", () => {
 		expect(getByTestId("SelectNetworkInput__network")).toHaveAttribute("aria-label", "ARK");
 	});
 
+	it("should toggle selection by clicking on network icon", async () => {
+		const { getByTestId } = render(<SelectNetwork networks={availableNetworksMock} />);
+
+		act(() => {
+			fireEvent.focus(getByTestId("SelectNetworkInput__input"));
+		});
+
+		await waitFor(() => expect(getByTestId("NetworkIcon-ARK-ark.mainnet")).toBeTruthy());
+
+		act(() => {
+			fireEvent.mouseDown(getByTestId("NetworkIcon-ARK-ark.mainnet"));
+		});
+
+		expect(getByTestId("SelectNetworkInput__network")).toHaveAttribute("aria-label", "ARK");
+
+		act(() => {
+			fireEvent.focus(getByTestId("SelectNetworkInput__input"));
+		});
+
+		await waitFor(() => expect(getByTestId("NetworkIcon-ARK-ark.mainnet")).toBeTruthy());
+
+		act(() => {
+			fireEvent.mouseDown(getByTestId("NetworkIcon-ARK-ark.mainnet"));
+		});
+
+		expect(getByTestId("SelectNetworkInput__network")).not.toHaveAttribute("aria-label");
+	});
+
 	it("should return empty if the item has not defined", () => {
 		expect(itemToString(null)).toBe("");
 	});

--- a/src/domains/network/components/SelectNetwork/SelectNetwork.tsx
+++ b/src/domains/network/components/SelectNetwork/SelectNetwork.tsx
@@ -84,6 +84,11 @@ export const SelectNetwork = ({
 		selectItem(selected || null);
 	}, [selectItem, selected]);
 
+	const toggleSelection = (item: Network) => {
+		if (item.id() === selectedItem?.id()) return reset();
+		return selectItem(item);
+	};
+
 	const inputTypeAhead = React.useMemo(() => {
 		if (inputValue && items.length) {
 			return [inputValue, items[0].extra?.displayName?.slice(inputValue.length)].join("");
@@ -160,7 +165,7 @@ export const SelectNetwork = ({
 									index,
 									disabled,
 									onMouseDown: () => {
-										selectItem(item);
+										toggleSelection(item);
 										closeMenu();
 									},
 								})}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
 Deselect network when clicking on selected asset option
![image (3)](https://user-images.githubusercontent.com/22020168/98604355-2e56d180-22ec-11eb-9531-f1ad768925a1.png)

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
