### PR TITLE
refactor: `SelectNetwork` UX adjustments

### DIFF
--- a/src/domains/network/components/SelectNetwork/SelectNetwork.test.tsx
+++ b/src/domains/network/components/SelectNetwork/SelectNetwork.test.tsx
@@ -216,7 +216,7 @@ describe("SelectNetwork", () => {
 			fireEvent.mouseDown(getByTestId("NetworkIcon-ARK-ark.mainnet"));
 		});
 
-		expect(getByTestId("SelectNetworkInput__network")).toHaveAttribute("aria-label", "ARK");
+		await waitFor(() => expect(getByTestId("SelectNetworkInput__network")).toHaveAttribute("aria-label", "ARK"));
 
 		act(() => {
 			fireEvent.focus(getByTestId("SelectNetworkInput__input"));
@@ -228,7 +228,7 @@ describe("SelectNetwork", () => {
 			fireEvent.mouseDown(getByTestId("NetworkIcon-ARK-ark.mainnet"));
 		});
 
-		expect(getByTestId("SelectNetworkInput__network")).not.toHaveAttribute("aria-label");
+		await waitFor(() => expect(getByTestId("SelectNetworkInput__network")).not.toHaveAttribute("aria-label"));
 	});
 
 	it("should return empty if the item has not defined", () => {

--- a/src/domains/network/components/SelectNetwork/SelectNetwork.tsx
+++ b/src/domains/network/components/SelectNetwork/SelectNetwork.tsx
@@ -85,8 +85,15 @@ export const SelectNetwork = ({
 	}, [selectItem, selected]);
 
 	const toggleSelection = (item: Network) => {
-		if (item.id() === selectedItem?.id()) return reset();
-		return selectItem(item);
+		if (item.id() === selectedItem?.id()) {
+			setTimeout(() => {
+				reset();
+				openMenu();
+			}, 0);
+			return;
+		}
+		selectItem(item);
+		closeMenu();
 	};
 
 	const inputTypeAhead = React.useMemo(() => {
@@ -128,12 +135,8 @@ export const SelectNetwork = ({
 						placeholder,
 						onFocus: openMenu,
 						onBlur: () => {
-							if (inputValue && items.length > 0) {
-								selectItem(items[0]);
-								closeMenu();
-							} else {
-								reset();
-							}
+							if (inputValue && items.length > 0) selectItem(items[0]);
+							else reset();
 						},
 						onKeyDown: (event: any) => {
 							if (event.key === "Tab" || event.key === "Enter") {
@@ -166,7 +169,6 @@ export const SelectNetwork = ({
 									disabled,
 									onMouseDown: () => {
 										toggleSelection(item);
-										closeMenu();
 									},
 								})}
 							>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Instead of clearing network options when the user deselects network by selection icon, keep network options open.
Example of previous behavior:
![image (7)](https://user-images.githubusercontent.com/22020168/98689111-440fd980-2374-11eb-9593-2d24b274c70d.png)

After:
![image (6)](https://user-images.githubusercontent.com/22020168/98689035-293d6500-2374-11eb-9c39-ddda8920234d.png)


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
