### PR TITLE
refactor: hide buttons while waiting for ledger confirmation

### DIFF
--- a/src/domains/transaction/pages/SendIpfs/SendIpfs.tsx
+++ b/src/domains/transaction/pages/SendIpfs/SendIpfs.tsx
@@ -165,37 +165,52 @@ export const SendIpfs = () => {
 							<div className="flex justify-end mt-10 space-x-2">
 								{activeTab < 4 && (
 									<>
-										<Button
-											disabled={activeTab === 1}
-											data-testid="SendIpfs__button--back"
-											variant="plain"
-											onClick={handleBack}
-										>
-											{t("COMMON.BACK")}
-										</Button>
-
 										{activeTab < 3 && (
-											<Button
-												data-testid="SendIpfs__button--continue"
-												disabled={!formState.isValid || formState.isSubmitting}
-												onClick={handleNext}
-											>
-												{formState.isSubmitting ? <Spinner size="sm" /> : t("COMMON.CONTINUE")}
-											</Button>
+											<>
+												<Button
+													disabled={activeTab === 1}
+													data-testid="SendIpfs__button--back"
+													variant="plain"
+													onClick={handleBack}
+												>
+													{t("COMMON.BACK")}
+												</Button>
+												<Button
+													data-testid="SendIpfs__button--continue"
+													disabled={!formState.isValid || formState.isSubmitting}
+													onClick={handleNext}
+												>
+													{formState.isSubmitting ? (
+														<Spinner size="sm" />
+													) : (
+														t("COMMON.CONTINUE")
+													)}
+												</Button>
+											</>
 										)}
 
-										{activeTab === 3 && (
-											<Button
-												type="submit"
-												data-testid="SendIpfs__button--submit"
-												disabled={!formState.isValid || formState.isSubmitting}
-											>
-												{formState.isSubmitting ? (
-													<Spinner size="sm" />
-												) : (
-													t("TRANSACTION.SIGN_CONTINUE")
-												)}
-											</Button>
+										{activeTab === 3 && !activeWallet.isLedger() && (
+											<>
+												<Button
+													data-testid="SendIpfs__button--back"
+													variant="plain"
+													onClick={handleBack}
+												>
+													{t("COMMON.BACK")}
+												</Button>
+
+												<Button
+													type="submit"
+													data-testid="SendIpfs__button--submit"
+													disabled={!formState.isValid || formState.isSubmitting}
+												>
+													{formState.isSubmitting ? (
+														<Spinner size="sm" />
+													) : (
+														t("TRANSACTION.SIGN_CONTINUE")
+													)}
+												</Button>
+											</>
 										)}
 									</>
 								)}

--- a/src/domains/transaction/pages/SendTransfer/SendTransfer.tsx
+++ b/src/domains/transaction/pages/SendTransfer/SendTransfer.tsx
@@ -225,39 +225,46 @@ export const SendTransfer = () => {
 							<div className="flex justify-end mt-10 space-x-3">
 								{activeTab < 4 && (
 									<>
-										<Button
-											disabled={activeTab === 1}
-											data-testid="SendTransfer__button--back"
-											variant="plain"
-											onClick={handleBack}
-										>
-											{t("COMMON.BACK")}
-										</Button>
-
 										{activeTab < 3 && (
-											<Button
-												data-testid="SendTransfer__button--continue"
-												disabled={!isValid || isSubmitting}
-												onClick={handleNext}
-											>
-												{isSubmitting ? <Spinner size="sm" /> : t("COMMON.CONTINUE")}
-											</Button>
+											<>
+												<Button
+													disabled={activeTab === 1}
+													data-testid="SendTransfer__button--back"
+													variant="plain"
+													onClick={handleBack}
+												>
+													{t("COMMON.BACK")}
+												</Button>
+												<Button
+													data-testid="SendTransfer__button--continue"
+													disabled={!isValid || isSubmitting}
+													onClick={handleNext}
+												>
+													{isSubmitting ? <Spinner size="sm" /> : t("COMMON.CONTINUE")}
+												</Button>
+											</>
 										)}
 
-										{activeTab === 3 && (
-											<Button
-												type="submit"
-												data-testid="SendTransfer__button--submit"
-												disabled={!isValid || isSubmitting}
-												className="space-x-2"
-											>
-												<Icon name="Send" width={20} height={20} />
-												{isSubmitting && !wallet?.isLedger() ? (
-													<Spinner size="sm" />
-												) : (
-													<span>{t("COMMON.SEND")}</span>
-												)}
-											</Button>
+										{activeTab === 3 && !wallet?.isLedger() && (
+											<>
+												<Button
+													data-testid="SendTransfer__button--back"
+													variant="plain"
+													onClick={handleBack}
+												>
+													{t("COMMON.BACK")}
+												</Button>
+
+												<Button
+													type="submit"
+													data-testid="SendTransfer__button--submit"
+													disabled={!isValid || isSubmitting}
+													className="space-x-2"
+												>
+													<Icon name="Send" width={20} height={20} />
+													{isSubmitting ? <Spinner size="sm" /> : t("COMMON.SEND")}
+												</Button>
+											</>
 										)}
 									</>
 								)}

--- a/src/domains/transaction/pages/SendTransfer/__snapshots__/SendTransfer.test.tsx.snap
+++ b/src/domains/transaction/pages/SendTransfer/__snapshots__/SendTransfer.test.tsx.snap
@@ -1229,9 +1229,7 @@ exports[`SendTransfer should error if wrong mnemonic 1`] = `
                         send.svg
                       </svg>
                     </div>
-                    <span>
-                      Send
-                    </span>
+                    Send
                   </button>
                 </div>
               </div>

--- a/src/domains/transaction/pages/SendVote/SendVote.tsx
+++ b/src/domains/transaction/pages/SendVote/SendVote.tsx
@@ -290,39 +290,54 @@ export const SendVote = () => {
 							<div className="flex justify-end mt-10 space-x-3">
 								{activeTab < 4 && (
 									<>
-										<Button
-											disabled={activeTab === 3 ? formState.isSubmitting : false}
-											variant="plain"
-											onClick={handleBack}
-											data-testid="SendVote__button--back"
-										>
-											{t("COMMON.BACK")}
-										</Button>
-
 										{activeTab < 3 && (
-											<Button
-												disabled={!formState.isValid || formState.isSubmitting}
-												onClick={handleNext}
-												data-testid="SendVote__button--continue"
-											>
-												{formState.isSubmitting ? <Spinner size="sm" /> : t("COMMON.CONTINUE")}
-											</Button>
+											<>
+												<Button
+													disabled={activeTab === 3 ? formState.isSubmitting : false}
+													variant="plain"
+													onClick={handleBack}
+													data-testid="SendVote__button--back"
+												>
+													{t("COMMON.BACK")}
+												</Button>
+												<Button
+													disabled={!formState.isValid || formState.isSubmitting}
+													onClick={handleNext}
+													data-testid="SendVote__button--continue"
+												>
+													{formState.isSubmitting ? (
+														<Spinner size="sm" />
+													) : (
+														t("COMMON.CONTINUE")
+													)}
+												</Button>
+											</>
 										)}
 
-										{activeTab === 3 && (
-											<Button
-												type="submit"
-												data-testid="SendVote__button--submit"
-												disabled={!formState.isValid || formState.isSubmitting}
-												className="space-x-2"
-											>
-												<Icon name="Send" width={20} height={20} />
-												{formState.isSubmitting ? (
-													<Spinner size="sm" />
-												) : (
-													<span>{t("COMMON.SEND")}</span>
-												)}
-											</Button>
+										{activeTab === 3 && !activeWallet.isLedger() && (
+											<>
+												<Button
+													disabled={formState.isSubmitting}
+													variant="plain"
+													onClick={handleBack}
+													data-testid="SendVote__button--back"
+												>
+													{t("COMMON.BACK")}
+												</Button>
+												<Button
+													type="submit"
+													data-testid="SendVote__button--submit"
+													disabled={!formState.isValid || formState.isSubmitting}
+													className="space-x-2"
+												>
+													<Icon name="Send" width={20} height={20} />
+													{formState.isSubmitting ? (
+														<Spinner size="sm" />
+													) : (
+														<span>{t("COMMON.SEND")}</span>
+													)}
+												</Button>
+											</>
 										)}
 									</>
 								)}

--- a/src/domains/transaction/pages/SendVote/SendVote.tsx
+++ b/src/domains/transaction/pages/SendVote/SendVote.tsx
@@ -293,7 +293,7 @@ export const SendVote = () => {
 										{activeTab < 3 && (
 											<>
 												<Button
-													disabled={activeTab === 3 ? formState.isSubmitting : false}
+													disabled={formState.isSubmitting}
 													variant="plain"
 													onClick={handleBack}
 													data-testid="SendVote__button--back"


### PR DESCRIPTION
## Summary

Hide back and continue buttons in the transactions page.

- [x] Transfer
- [x] IPFS
- [x] Vote

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
