### PR TITLE
perf: avoid slow object merging in `useReducer`

### DIFF
--- a/src/domains/dashboard/pages/Dashboard/Dashboard.tsx
+++ b/src/domains/dashboard/pages/Dashboard/Dashboard.tsx
@@ -40,7 +40,7 @@ export const Dashboard = ({ balances }: DashboardProps) => {
 	// @ts-ignore
 	const [dashboardConfiguration, setDashboardConfiguration] = useReducer(
 		(state: DashboardConfiguration, newState: Record<string, any>) => {
-			for(const [key, value] of Object.entries(newState)) {
+			for (const [key, value] of Object.entries(newState)) {
 				// @ts-ignore
 				state[key] = value;
 			}

--- a/src/domains/dashboard/pages/Dashboard/Dashboard.tsx
+++ b/src/domains/dashboard/pages/Dashboard/Dashboard.tsx
@@ -37,8 +37,16 @@ export const Dashboard = ({ balances }: DashboardProps) => {
 		),
 	};
 
+	// @ts-ignore
 	const [dashboardConfiguration, setDashboardConfiguration] = useReducer(
-		(state: DashboardConfiguration, newState: Record<string, any>) => ({ ...state, ...newState }),
+		(state: DashboardConfiguration, newState: Record<string, any>) => {
+			for(const [key, value] of Object.entries(newState)) {
+				// @ts-ignore
+				state[key] = value;
+			}
+
+			return state;
+		},
 		activeProfile.settings().get(ProfileSetting.DashboardConfiguration) || {
 			...defaultDashboardConfiguration,
 			viewType: "grid",

--- a/src/domains/dashboard/pages/Dashboard/__snapshots__/Dashboard.test.tsx.snap
+++ b/src/domains/dashboard/pages/Dashboard/__snapshots__/Dashboard.test.tsx.snap
@@ -9148,7 +9148,7 @@ exports[`Dashboard should hide transaction view 1`] = `
         </div>
       </div>
       <div
-        class="Section__SectionWrapper-sc-8cjvre-0 bryymu flex-1"
+        class="Section__SectionWrapper-sc-8cjvre-0 bryymu"
       >
         <div
           class="container py-16 mx-auto px-14"
@@ -9811,6 +9811,874 @@ exports[`Dashboard should hide transaction view 1`] = `
               </div>
             </div>
           </div>
+        </div>
+      </div>
+      <div
+        class="Section__SectionWrapper-sc-8cjvre-0 bryymu flex-1"
+      >
+        <div
+          class="container py-16 mx-auto px-14"
+        >
+          <div
+            class="relative flex justify-between"
+          >
+            <div
+              class="mb-8 text-4xl font-bold"
+            >
+              Transactions History
+            </div>
+            <div
+              class="mt-6"
+              data-testid="FilterTransactions"
+            >
+              <div
+                class="relative"
+                data-testid="dropdown__toggle"
+              >
+                <div
+                  class="flex items-center space-x-2 cursor-pointer"
+                  data-testid="FilterTransactionsToggle"
+                >
+                  <div
+                    class="font-semibold"
+                  >
+                    <span
+                      class="text-theme-neutral-500"
+                    >
+                      Type: 
+                    </span>
+                    <span
+                      class="text-theme-neutral-600"
+                    >
+                      All
+                    </span>
+                  </div>
+                  <div
+                    class="sc-AxirZ bkWcEv bg-theme-primary-100 text-theme-primary-600 p-1 rounded-xl"
+                    height="9"
+                    width="9"
+                  >
+                    <svg>
+                      chevron-down.svg
+                    </svg>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="mb-8"
+          >
+            <div
+              class="sc-fzqNJr ccJDok w-full"
+            >
+              <button
+                aria-selected="true"
+                class="sc-fzqBZW kvyVsY"
+                data-testid="tabs__tab-button-all"
+              >
+                All History
+              </button>
+              <button
+                aria-selected="false"
+                class="sc-fzqBZW kvyVsY"
+                data-testid="tabs__tab-button-received"
+              >
+                Incoming
+              </button>
+              <button
+                aria-selected="false"
+                class="sc-fzqBZW kvyVsY"
+                data-testid="tabs__tab-button-sent"
+              >
+                Outgoing
+              </button>
+            </div>
+          </div>
+          <div
+            class="relative"
+            data-testid="TransactionTable"
+          >
+            <div
+              class="sc-AxheI gYpVUW -mt-3"
+              role="table"
+            >
+              <table
+                cellpadding="0"
+                class="table-auto"
+              >
+                <thead>
+                  <tr
+                    class="border-b border-theme-neutral-300 dark:border-theme-neutral-800"
+                    role="row"
+                  >
+                    <th
+                      class="relative text-sm text-left select-none text-theme-neutral border-theme-neutral-300 dark:text-theme-neutral-dark dark:border-theme-neutral-800 m-0 p-3 first:pl-0 last:pr-0 font-semibold hasBorder w-1"
+                      colspan="1"
+                      data-testid="table__th--0"
+                      role="columnheader"
+                    >
+                      <div
+                        class="flex flex-inline align-top "
+                      >
+                        <div>
+                          ID
+                        </div>
+                      </div>
+                    </th>
+                    <th
+                      class="relative text-sm text-left select-none text-theme-neutral border-theme-neutral-300 dark:text-theme-neutral-dark dark:border-theme-neutral-800 m-0 p-3 first:pl-0 last:pr-0 font-semibold hasBorder w-50 min-w-50"
+                      colspan="1"
+                      data-testid="table__th--1"
+                      role="columnheader"
+                      style="cursor: pointer;"
+                      title="Toggle SortBy"
+                    >
+                      <div
+                        class="flex flex-inline align-top "
+                      >
+                        <div>
+                          Date
+                        </div>
+                        <div
+                          class="flex items-center ml-2 text-theme-neutral dark:text-theme-neutral-dark"
+                          data-testid="table__Sort"
+                        >
+                          <div
+                            class="sc-AxirZ jMwzyA"
+                            height="12"
+                            width="15"
+                          >
+                            <svg>
+                              sort.svg
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </th>
+                    <th
+                      class="relative text-sm text-left select-none text-theme-neutral border-theme-neutral-300 dark:text-theme-neutral-dark dark:border-theme-neutral-800 m-0 p-3 first:pl-0 last:pr-0 font-semibold hasBorder w-96 min-w-96"
+                      colspan="1"
+                      data-testid="table__th--2"
+                      role="columnheader"
+                    >
+                      <div
+                        class="flex flex-inline align-top ml-25"
+                      >
+                        <div>
+                          Recipient
+                        </div>
+                      </div>
+                    </th>
+                    <th
+                      class="relative text-sm text-left select-none text-theme-neutral border-theme-neutral-300 dark:text-theme-neutral-dark dark:border-theme-neutral-800 m-0 p-3 first:pl-0 last:pr-0 font-semibold hasBorder "
+                      colspan="1"
+                      data-testid="table__th--3"
+                      role="columnheader"
+                    >
+                      <div
+                        class="flex flex-inline align-top justify-center"
+                      >
+                        <div>
+                          Info
+                        </div>
+                      </div>
+                    </th>
+                    <th
+                      class="relative text-sm text-left select-none text-theme-neutral border-theme-neutral-300 dark:text-theme-neutral-dark dark:border-theme-neutral-800 m-0 p-3 first:pl-0 last:pr-0 font-semibold hasBorder w-1"
+                      colspan="1"
+                      data-testid="table__th--4"
+                      role="columnheader"
+                    >
+                      <div
+                        class="flex flex-inline align-top justify-center"
+                      >
+                        <div>
+                          Status
+                        </div>
+                      </div>
+                    </th>
+                    <th
+                      class="relative text-sm text-left select-none text-theme-neutral border-theme-neutral-300 dark:text-theme-neutral-dark dark:border-theme-neutral-800 m-0 p-3 first:pl-0 last:pr-0 font-semibold hasBorder "
+                      colspan="1"
+                      data-testid="table__th--5"
+                      role="columnheader"
+                      style="cursor: pointer;"
+                      title="Toggle SortBy"
+                    >
+                      <div
+                        class="flex flex-inline align-top justify-end"
+                      >
+                        <div>
+                          Amount
+                        </div>
+                        <div
+                          class="flex items-center ml-2 text-theme-neutral dark:text-theme-neutral-dark"
+                          data-testid="table__Sort"
+                        >
+                          <div
+                            class="sc-AxirZ jMwzyA"
+                            height="12"
+                            width="15"
+                          >
+                            <svg>
+                              sort.svg
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </th>
+                    <th
+                      class="relative text-sm text-left select-none text-theme-neutral border-theme-neutral-300 dark:text-theme-neutral-dark dark:border-theme-neutral-800 m-0 p-3 first:pl-0 last:pr-0 font-semibold hasBorder w-24 min-w-24"
+                      colspan="1"
+                      data-testid="table__th--6"
+                      role="columnheader"
+                    >
+                      <div
+                        class="flex flex-inline align-top justify-end float-right"
+                      >
+                        <div>
+                          Currency
+                        </div>
+                      </div>
+                    </th>
+                  </tr>
+                </thead>
+                <tbody
+                  role="rowgroup"
+                >
+                  <tr
+                    class="sc-AxmLO kbgHZc group"
+                    data-testid="TableRow"
+                  >
+                    <td>
+                      <div
+                        class="sc-Axmtr gaELvy"
+                      >
+                        <a
+                          class="sc-fznyAO fvIzri inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+                          data-testid="TransactionRow__ID"
+                          rel="noopener noreferrer"
+                          to="https://dexplorer.ark.io/transaction/8f913b6b719e7767d49861c0aec79ced212767645cb793d75d2f1b89abb49877"
+                        >
+                          <div
+                            class="sc-AxirZ iQaTP"
+                            height="1em"
+                            width="1em"
+                          >
+                            <svg>
+                              id.svg
+                            </svg>
+                          </div>
+                        </a>
+                      </div>
+                    </td>
+                    <td>
+                      <div
+                        class="sc-Axmtr eisuEY text-theme-secondary-text"
+                      >
+                        <span
+                          class="whitespace-no-wrap"
+                          data-testid="TransactionRow__timestamp"
+                        >
+                          23 Jul 2020 08:03:20
+                        </span>
+                      </div>
+                    </td>
+                    <td>
+                      <div
+                        class="sc-Axmtr eisuEY space-x-4"
+                      >
+                        <div
+                          class="flex items-center -space-x-1"
+                          data-testid="TransactionRowMode"
+                        >
+                          <div
+                            class="sc-AxhUy iDenJW border-theme-success-200 text-theme-success-600 dark:border-theme-success-600"
+                          >
+                            <div
+                              class="sc-AxirZ iQaTP"
+                              data-testid="TransactionRowMode__Received"
+                              height="1em"
+                              width="1em"
+                            >
+                              <svg>
+                                received.svg
+                              </svg>
+                            </div>
+                          </div>
+                          <div
+                            class="Avatar__AvatarWrapper-sc-1vsy2s2-0 eHceTZ"
+                            data-testid="Avatar"
+                          >
+                            <div
+                              class="w-full h-full"
+                            >
+                              <img
+                                alt="D5pVkhZbSb4UNXvfmF6j7zdau8yGxfKwSv"
+                                src="data:image/svg+xml;utf8,<svg version=\\"1.1\\" xmlns=\\"http://www.w3.org/2000/svg\\" class=\\"picasso\\" width=\\"100\\" height=\\"100\\" viewBox=\\"0 0 100 100\\"><style>.picasso circle{mix-blend-mode:soft-light;}</style><rect fill=\\"rgb(33, 150, 243)\\" width=\\"100\\" height=\\"100\\"/><circle r=\\"40\\" cx=\\"80\\" cy=\\"30\\" fill=\\"rgb(255, 87, 34)\\"/><circle r=\\"60\\" cx=\\"70\\" cy=\\"50\\" fill=\\"rgb(156, 39, 176)\\"/><circle r=\\"55\\" cx=\\"100\\" cy=\\"70\\" fill=\\"rgb(0, 150, 136)\\"/></svg>"
+                                title="D5pVkhZbSb4UNXvfmF6j7zdau8yGxfKwSv"
+                              />
+                            </div>
+                          </div>
+                        </div>
+                        <div
+                          class="inline-flex items-center"
+                        >
+                          <span
+                            class="sc-fzoLsD fqEnxe text-theme-text truncate font-semibold text-base"
+                            data-testid="address__wallet-address"
+                          >
+                            D5pVkh … xfKwSv
+                          </span>
+                        </div>
+                      </div>
+                    </td>
+                    <td>
+                      <div
+                        class="sc-Axmtr eisuEY justify-center"
+                      >
+                        <div
+                          class="inline-flex space-x-1 align-middle"
+                          data-testid="TransactionRowInfo"
+                        />
+                      </div>
+                    </td>
+                    <td
+                      class="w-16"
+                    >
+                      <div
+                        class="sc-Axmtr eisuEY justify-center"
+                      >
+                        <div
+                          class="inline-flex p-1 align-middle"
+                          data-testid="TransactionRowConfirmation"
+                        >
+                          <div
+                            class="sc-AxirZ hmuEJr text-theme-success"
+                            data-testid="TransactionRowConfirmation__confirmed"
+                            height="22"
+                            width="22"
+                          >
+                            <svg>
+                              status-ok.svg
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </td>
+                    <td>
+                      <div
+                        class="sc-Axmtr eisuEY justify-end"
+                      >
+                        <div
+                          class="sc-fzozJi bXfNeq whitespace-no-wrap"
+                          color="success"
+                          data-testid="TransactionRowAmount"
+                        >
+                          <span
+                            data-testid="Amount"
+                          >
+                            + 400,000 DARK
+                          </span>
+                        </div>
+                      </div>
+                    </td>
+                    <td>
+                      <div
+                        class="sc-Axmtr exQntG justify-end"
+                      >
+                        <span
+                          class="whitespace-no-wrap"
+                          data-testid="TransactionRow__currency"
+                        >
+                          <span
+                            class="text-theme-secondary-text"
+                            data-testid="TransactionRowAmount"
+                          >
+                            0 BTC
+                          </span>
+                        </span>
+                      </div>
+                    </td>
+                  </tr>
+                  <tr
+                    class="sc-AxmLO kbgHZc group"
+                    data-testid="TableRow"
+                  >
+                    <td>
+                      <div
+                        class="sc-Axmtr gaELvy"
+                      >
+                        <a
+                          class="sc-fznyAO fvIzri inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+                          data-testid="TransactionRow__ID"
+                          rel="noopener noreferrer"
+                          to="https://dexplorer.ark.io/transaction/0d8d12d7980bf0183ef015e5938e56c44c3db4d3695cefd16ccec4a7bfd8a2cf"
+                        >
+                          <div
+                            class="sc-AxirZ iQaTP"
+                            height="1em"
+                            width="1em"
+                          >
+                            <svg>
+                              id.svg
+                            </svg>
+                          </div>
+                        </a>
+                      </div>
+                    </td>
+                    <td>
+                      <div
+                        class="sc-Axmtr eisuEY text-theme-secondary-text"
+                      >
+                        <span
+                          class="whitespace-no-wrap"
+                          data-testid="TransactionRow__timestamp"
+                        >
+                          23 Jul 2020 08:01:52
+                        </span>
+                      </div>
+                    </td>
+                    <td>
+                      <div
+                        class="sc-Axmtr eisuEY space-x-4"
+                      >
+                        <div
+                          class="flex items-center -space-x-1"
+                          data-testid="TransactionRowMode"
+                        >
+                          <div
+                            class="sc-AxhUy iDenJW border-theme-success-200 text-theme-success-600 dark:border-theme-success-600"
+                          >
+                            <div
+                              class="sc-AxirZ iQaTP"
+                              data-testid="TransactionRowMode__Received"
+                              height="1em"
+                              width="1em"
+                            >
+                              <svg>
+                                received.svg
+                              </svg>
+                            </div>
+                          </div>
+                          <div
+                            class="Avatar__AvatarWrapper-sc-1vsy2s2-0 eHceTZ"
+                            data-testid="Avatar"
+                          >
+                            <div
+                              class="w-full h-full"
+                            >
+                              <img
+                                alt="DKY5eyQUKKYyaCfPp6MUv3Y4FW6EbNF53A"
+                                src="data:image/svg+xml;utf8,<svg version=\\"1.1\\" xmlns=\\"http://www.w3.org/2000/svg\\" class=\\"picasso\\" width=\\"100\\" height=\\"100\\" viewBox=\\"0 0 100 100\\"><style>.picasso circle{mix-blend-mode:soft-light;}</style><rect fill=\\"rgb(244, 67, 54)\\" width=\\"100\\" height=\\"100\\"/><circle r=\\"45\\" cx=\\"70\\" cy=\\"60\\" fill=\\"rgb(0, 188, 212)\\"/><circle r=\\"35\\" cx=\\"60\\" cy=\\"40\\" fill=\\"rgb(76, 175, 80)\\"/><circle r=\\"60\\" cx=\\"40\\" cy=\\"70\\" fill=\\"rgb(0, 150, 136)\\"/></svg>"
+                                title="DKY5eyQUKKYyaCfPp6MUv3Y4FW6EbNF53A"
+                              />
+                            </div>
+                          </div>
+                        </div>
+                        <div
+                          class="inline-flex items-center"
+                        >
+                          <span
+                            class="sc-fzoLsD fqEnxe text-theme-text truncate font-semibold text-base"
+                            data-testid="address__wallet-address"
+                          >
+                            DKY5ey … bNF53A
+                          </span>
+                        </div>
+                      </div>
+                    </td>
+                    <td>
+                      <div
+                        class="sc-Axmtr eisuEY justify-center"
+                      >
+                        <div
+                          class="inline-flex space-x-1 align-middle"
+                          data-testid="TransactionRowInfo"
+                        />
+                      </div>
+                    </td>
+                    <td
+                      class="w-16"
+                    >
+                      <div
+                        class="sc-Axmtr eisuEY justify-center"
+                      >
+                        <div
+                          class="inline-flex p-1 align-middle"
+                          data-testid="TransactionRowConfirmation"
+                        >
+                          <div
+                            class="sc-AxirZ hmuEJr text-theme-success"
+                            data-testid="TransactionRowConfirmation__confirmed"
+                            height="22"
+                            width="22"
+                          >
+                            <svg>
+                              status-ok.svg
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </td>
+                    <td>
+                      <div
+                        class="sc-Axmtr eisuEY justify-end"
+                      >
+                        <div
+                          class="sc-fzozJi bXfNeq whitespace-no-wrap"
+                          color="success"
+                          data-testid="TransactionRowAmount"
+                        >
+                          <span
+                            data-testid="Amount"
+                          >
+                            + 50,000 DARK
+                          </span>
+                        </div>
+                      </div>
+                    </td>
+                    <td>
+                      <div
+                        class="sc-Axmtr exQntG justify-end"
+                      >
+                        <span
+                          class="whitespace-no-wrap"
+                          data-testid="TransactionRow__currency"
+                        >
+                          <span
+                            class="text-theme-secondary-text"
+                            data-testid="TransactionRowAmount"
+                          >
+                            0 BTC
+                          </span>
+                        </span>
+                      </div>
+                    </td>
+                  </tr>
+                  <tr
+                    class="sc-AxmLO kbgHZc group"
+                    data-testid="TableRow"
+                  >
+                    <td>
+                      <div
+                        class="sc-Axmtr gaELvy"
+                      >
+                        <a
+                          class="sc-fznyAO fvIzri inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+                          data-testid="TransactionRow__ID"
+                          rel="noopener noreferrer"
+                          to="https://dexplorer.ark.io/transaction/8f913b6b719e7767d49861c0aec79ced212767645cb793d75d2f1b89abb49877"
+                        >
+                          <div
+                            class="sc-AxirZ iQaTP"
+                            height="1em"
+                            width="1em"
+                          >
+                            <svg>
+                              id.svg
+                            </svg>
+                          </div>
+                        </a>
+                      </div>
+                    </td>
+                    <td>
+                      <div
+                        class="sc-Axmtr eisuEY text-theme-secondary-text"
+                      >
+                        <span
+                          class="whitespace-no-wrap"
+                          data-testid="TransactionRow__timestamp"
+                        >
+                          23 Jul 2020 08:03:20
+                        </span>
+                      </div>
+                    </td>
+                    <td>
+                      <div
+                        class="sc-Axmtr eisuEY space-x-4"
+                      >
+                        <div
+                          class="flex items-center -space-x-1"
+                          data-testid="TransactionRowMode"
+                        >
+                          <div
+                            class="sc-AxhUy iDenJW border-theme-success-200 text-theme-success-600 dark:border-theme-success-600"
+                          >
+                            <div
+                              class="sc-AxirZ iQaTP"
+                              data-testid="TransactionRowMode__Received"
+                              height="1em"
+                              width="1em"
+                            >
+                              <svg>
+                                received.svg
+                              </svg>
+                            </div>
+                          </div>
+                          <div
+                            class="Avatar__AvatarWrapper-sc-1vsy2s2-0 eHceTZ"
+                            data-testid="Avatar"
+                          >
+                            <div
+                              class="w-full h-full"
+                            >
+                              <img
+                                alt="D5pVkhZbSb4UNXvfmF6j7zdau8yGxfKwSv"
+                                src="data:image/svg+xml;utf8,<svg version=\\"1.1\\" xmlns=\\"http://www.w3.org/2000/svg\\" class=\\"picasso\\" width=\\"100\\" height=\\"100\\" viewBox=\\"0 0 100 100\\"><style>.picasso circle{mix-blend-mode:soft-light;}</style><rect fill=\\"rgb(33, 150, 243)\\" width=\\"100\\" height=\\"100\\"/><circle r=\\"40\\" cx=\\"80\\" cy=\\"30\\" fill=\\"rgb(255, 87, 34)\\"/><circle r=\\"60\\" cx=\\"70\\" cy=\\"50\\" fill=\\"rgb(156, 39, 176)\\"/><circle r=\\"55\\" cx=\\"100\\" cy=\\"70\\" fill=\\"rgb(0, 150, 136)\\"/></svg>"
+                                title="D5pVkhZbSb4UNXvfmF6j7zdau8yGxfKwSv"
+                              />
+                            </div>
+                          </div>
+                        </div>
+                        <div
+                          class="inline-flex items-center"
+                        >
+                          <span
+                            class="sc-fzoLsD fqEnxe text-theme-text truncate font-semibold text-base"
+                            data-testid="address__wallet-address"
+                          >
+                            D5pVkh … xfKwSv
+                          </span>
+                        </div>
+                      </div>
+                    </td>
+                    <td>
+                      <div
+                        class="sc-Axmtr eisuEY justify-center"
+                      >
+                        <div
+                          class="inline-flex space-x-1 align-middle"
+                          data-testid="TransactionRowInfo"
+                        />
+                      </div>
+                    </td>
+                    <td
+                      class="w-16"
+                    >
+                      <div
+                        class="sc-Axmtr eisuEY justify-center"
+                      >
+                        <div
+                          class="inline-flex p-1 align-middle"
+                          data-testid="TransactionRowConfirmation"
+                        >
+                          <div
+                            class="sc-AxirZ hmuEJr text-theme-success"
+                            data-testid="TransactionRowConfirmation__confirmed"
+                            height="22"
+                            width="22"
+                          >
+                            <svg>
+                              status-ok.svg
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </td>
+                    <td>
+                      <div
+                        class="sc-Axmtr eisuEY justify-end"
+                      >
+                        <div
+                          class="sc-fzozJi bXfNeq whitespace-no-wrap"
+                          color="success"
+                          data-testid="TransactionRowAmount"
+                        >
+                          <span
+                            data-testid="Amount"
+                          >
+                            + 400,000 DARK
+                          </span>
+                        </div>
+                      </div>
+                    </td>
+                    <td>
+                      <div
+                        class="sc-Axmtr exQntG justify-end"
+                      >
+                        <span
+                          class="whitespace-no-wrap"
+                          data-testid="TransactionRow__currency"
+                        >
+                          <span
+                            class="text-theme-secondary-text"
+                            data-testid="TransactionRowAmount"
+                          >
+                            0 BTC
+                          </span>
+                        </span>
+                      </div>
+                    </td>
+                  </tr>
+                  <tr
+                    class="sc-AxmLO kbgHZc group"
+                    data-testid="TableRow"
+                  >
+                    <td>
+                      <div
+                        class="sc-Axmtr gaELvy"
+                      >
+                        <a
+                          class="sc-fznyAO fvIzri inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+                          data-testid="TransactionRow__ID"
+                          rel="noopener noreferrer"
+                          to="https://dexplorer.ark.io/transaction/0d8d12d7980bf0183ef015e5938e56c44c3db4d3695cefd16ccec4a7bfd8a2cf"
+                        >
+                          <div
+                            class="sc-AxirZ iQaTP"
+                            height="1em"
+                            width="1em"
+                          >
+                            <svg>
+                              id.svg
+                            </svg>
+                          </div>
+                        </a>
+                      </div>
+                    </td>
+                    <td>
+                      <div
+                        class="sc-Axmtr eisuEY text-theme-secondary-text"
+                      >
+                        <span
+                          class="whitespace-no-wrap"
+                          data-testid="TransactionRow__timestamp"
+                        >
+                          23 Jul 2020 08:01:52
+                        </span>
+                      </div>
+                    </td>
+                    <td>
+                      <div
+                        class="sc-Axmtr eisuEY space-x-4"
+                      >
+                        <div
+                          class="flex items-center -space-x-1"
+                          data-testid="TransactionRowMode"
+                        >
+                          <div
+                            class="sc-AxhUy iDenJW border-theme-success-200 text-theme-success-600 dark:border-theme-success-600"
+                          >
+                            <div
+                              class="sc-AxirZ iQaTP"
+                              data-testid="TransactionRowMode__Received"
+                              height="1em"
+                              width="1em"
+                            >
+                              <svg>
+                                received.svg
+                              </svg>
+                            </div>
+                          </div>
+                          <div
+                            class="Avatar__AvatarWrapper-sc-1vsy2s2-0 eHceTZ"
+                            data-testid="Avatar"
+                          >
+                            <div
+                              class="w-full h-full"
+                            >
+                              <img
+                                alt="DKY5eyQUKKYyaCfPp6MUv3Y4FW6EbNF53A"
+                                src="data:image/svg+xml;utf8,<svg version=\\"1.1\\" xmlns=\\"http://www.w3.org/2000/svg\\" class=\\"picasso\\" width=\\"100\\" height=\\"100\\" viewBox=\\"0 0 100 100\\"><style>.picasso circle{mix-blend-mode:soft-light;}</style><rect fill=\\"rgb(244, 67, 54)\\" width=\\"100\\" height=\\"100\\"/><circle r=\\"45\\" cx=\\"70\\" cy=\\"60\\" fill=\\"rgb(0, 188, 212)\\"/><circle r=\\"35\\" cx=\\"60\\" cy=\\"40\\" fill=\\"rgb(76, 175, 80)\\"/><circle r=\\"60\\" cx=\\"40\\" cy=\\"70\\" fill=\\"rgb(0, 150, 136)\\"/></svg>"
+                                title="DKY5eyQUKKYyaCfPp6MUv3Y4FW6EbNF53A"
+                              />
+                            </div>
+                          </div>
+                        </div>
+                        <div
+                          class="inline-flex items-center"
+                        >
+                          <span
+                            class="sc-fzoLsD fqEnxe text-theme-text truncate font-semibold text-base"
+                            data-testid="address__wallet-address"
+                          >
+                            DKY5ey … bNF53A
+                          </span>
+                        </div>
+                      </div>
+                    </td>
+                    <td>
+                      <div
+                        class="sc-Axmtr eisuEY justify-center"
+                      >
+                        <div
+                          class="inline-flex space-x-1 align-middle"
+                          data-testid="TransactionRowInfo"
+                        />
+                      </div>
+                    </td>
+                    <td
+                      class="w-16"
+                    >
+                      <div
+                        class="sc-Axmtr eisuEY justify-center"
+                      >
+                        <div
+                          class="inline-flex p-1 align-middle"
+                          data-testid="TransactionRowConfirmation"
+                        >
+                          <div
+                            class="sc-AxirZ hmuEJr text-theme-success"
+                            data-testid="TransactionRowConfirmation__confirmed"
+                            height="22"
+                            width="22"
+                          >
+                            <svg>
+                              status-ok.svg
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </td>
+                    <td>
+                      <div
+                        class="sc-Axmtr eisuEY justify-end"
+                      >
+                        <div
+                          class="sc-fzozJi bXfNeq whitespace-no-wrap"
+                          color="success"
+                          data-testid="TransactionRowAmount"
+                        >
+                          <span
+                            data-testid="Amount"
+                          >
+                            + 50,000 DARK
+                          </span>
+                        </div>
+                      </div>
+                    </td>
+                    <td>
+                      <div
+                        class="sc-Axmtr exQntG justify-end"
+                      >
+                        <span
+                          class="whitespace-no-wrap"
+                          data-testid="TransactionRow__currency"
+                        >
+                          <span
+                            class="text-theme-secondary-text"
+                            data-testid="TransactionRowAmount"
+                          >
+                            0 BTC
+                          </span>
+                        </span>
+                      </div>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+          <button
+            class="sc-AxhCb bEccyr w-full mt-10 mb-5"
+            color="primary"
+            data-testid="transactions__fetch-more-button"
+            type="button"
+          >
+            View More
+          </button>
         </div>
       </div>
     </div>
@@ -21026,6 +21894,157 @@ exports[`Dashboard should select an option in the wallets display type 1`] = `
         <div
           class="container py-16 mx-auto px-14"
         >
+          <div
+            class="-mb-2 text-4xl font-bold"
+          >
+            Portfolio Chart
+          </div>
+          <div
+            class="recharts-responsive-container mb-16"
+            id="undefined"
+            style="width: 100%; height: 260px;"
+          >
+            <div
+              class="sc-fzoXWK hCbUwo text-theme-neutral-300 dark:text-theme-neutral-800 pb"
+              data-testid="line-chart-wrapper"
+            >
+              <div>
+                <div
+                  class="flex space-x-3"
+                >
+                  <div
+                    class="pt-4 text-sm font-semibold cursor-pointer text-theme-secondary-text"
+                  >
+                    <div
+                      class="flex items-center"
+                    >
+                      <div
+                        class="my-auto text-base"
+                      >
+                        Period: 22 Jun - 28 Jun
+                      </div>
+                      <div
+                        class="my-auto ml-1"
+                      >
+                        <div
+                          class="sc-AxirZ iQaTP"
+                          height="1em"
+                          width="1em"
+                        >
+                          <svg>
+                            chevron-down.svg
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="flex justify-end flex-1 space-x-3"
+                  >
+                    <div
+                      class="my-auto text-sm text-base text-theme-secondary-text"
+                    >
+                      28 Jun, 2020
+                    </div>
+                    <div
+                      class="flex items-center justify-end p-4 pt-4 pr-0 min-w-32"
+                    >
+                      <div
+                        class="mr-2 border-2 rounded-full w-2 h-2 inline-block align-middle border-theme-warning-600"
+                      />
+                      <div
+                        class="inline-block text-sm text-base font-semibold text-theme-secondary-text"
+                      >
+                        <span>
+                          2.16 - 
+                        </span>
+                        BTC
+                      </div>
+                    </div>
+                    <div
+                      class="flex items-center justify-end p-4 pt-4 pr-0 min-w-32"
+                    >
+                      <div
+                        class="mr-2 border-2 rounded-full w-2 h-2 inline-block align-middle border-theme-success-600"
+                      />
+                      <div
+                        class="inline-block text-sm text-base font-semibold text-theme-secondary-text"
+                      >
+                        <span>
+                          8,000 - 
+                        </span>
+                        USD
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="active-dot"
+              >
+                <svg
+                  class="text-theme-undefined"
+                  fill="currentColor"
+                  height="50"
+                  stroke="currentColor"
+                  width="50"
+                  x="-25"
+                  y="-25"
+                >
+                  chart-active-dot.svg
+                </svg>
+              </div>
+            </div>
+            <div />
+          </div>
+          <div
+            class="pt-6 mb-2 border-b border-dashed border-theme-neutral-300 dark:border-theme-neutral-800"
+          />
+          <div>
+            <div
+              class="flex space-x-3"
+            >
+              <div
+                class="py-4 text-lg font-bold text-theme-neutral-800"
+              >
+                Total Portfolio
+              </div>
+              <div
+                class="flex justify-end flex-1 space-x-3"
+              >
+                <div
+                  class="flex items-center justify-end py-4 pl-6 pr-0"
+                  data-testid="item-percentage"
+                >
+                  <div
+                    class="mr-2 border-2 rounded-full w-2 h-2 inline-block align-middle border-theme-danger-400"
+                  />
+                  <div
+                    class="inline-block text-sm text-base font-semibold text-theme-secondary-text"
+                  >
+                    <span>
+                      ARK - 100%
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="flex -space-x-1"
+            >
+              <div
+                class="h-1 rounded-sm bg-theme-danger-400"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="Section__SectionWrapper-sc-8cjvre-0 bryymu"
+      >
+        <div
+          class="container py-16 mx-auto px-14"
+        >
           <div>
             <div
               class="flex items-center justify-between mb-8"
@@ -24980,7 +25999,7 @@ exports[`Dashboard should toggle network selection from network filters 1`] = `
                           class="group"
                         >
                           <div
-                            class="LayoutControls__ControlButton-j2iwgi-0 gyDdjy"
+                            class="LayoutControls__ControlButton-j2iwgi-0 iyqmGf"
                           >
                             <div
                               class="sc-AxirZ eEbZjj"
@@ -25531,34 +26550,66 @@ exports[`Dashboard should toggle network selection from network filters 1`] = `
                       >
                         <div
                           class="w-64 inline-block w-full"
-                          data-testid="WalletCard__blank"
+                          data-testid="WalletCard__AdVSe37niA3uFUPgCgMUH2tMsHF4LpLoiX"
                         >
                           <div
-                            class="sc-fzpmMD itnXim h-48"
+                            class="sc-fzpmMD fKkTYv h-48"
                             data-testid="Card"
                           >
                             <div
-                              class="flex flex-col justify-between h-full p-4"
+                              class="relative flex flex-col justify-between h-full p-4"
                             >
                               <div
-                                class="flex -space-x-2"
+                                class="flex items-center space-x-4"
                               >
                                 <div
-                                  class="sc-AxhUy iDenJW bg-theme-background border-theme-primary-contrast dark:border-theme-neutral-800"
+                                  class="-space-x-2 whitespace-no-wrap"
+                                >
+                                  <div
+                                    aria-label="ARK"
+                                    class="sc-AxhUy iDenJW border-theme-danger-light text-theme-danger-400"
+                                    data-testid="NetworkIcon-ARK-ark.mainnet"
+                                  >
+                                    <div
+                                      class="sc-AxirZ eEbZjj"
+                                      data-testid="NetworkIcon__icon"
+                                      height="20"
+                                      width="20"
+                                    >
+                                      <svg>
+                                        ark.svg
+                                      </svg>
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="Avatar__AvatarWrapper-sc-1vsy2s2-0 eHceTZ"
+                                    data-testid="Avatar"
+                                  >
+                                    <div
+                                      class="w-full h-full"
+                                    >
+                                      <img
+                                        alt="AdVSe37niA3uFUPgCgMUH2tMsHF4LpLoiX"
+                                        src="data:image/svg+xml;utf8,<svg version=\\"1.1\\" xmlns=\\"http://www.w3.org/2000/svg\\" class=\\"picasso\\" width=\\"100\\" height=\\"100\\" viewBox=\\"0 0 100 100\\"><style>.picasso circle{mix-blend-mode:soft-light;}</style><rect fill=\\"rgb(156, 39, 176)\\" width=\\"100\\" height=\\"100\\"/><circle r=\\"40\\" cx=\\"10\\" cy=\\"40\\" fill=\\"rgb(0, 150, 136)\\"/><circle r=\\"45\\" cx=\\"70\\" cy=\\"60\\" fill=\\"rgb(33, 150, 243)\\"/><circle r=\\"60\\" cx=\\"0\\" cy=\\"70\\" fill=\\"rgb(3, 169, 244)\\"/></svg>"
+                                        title="AdVSe37niA3uFUPgCgMUH2tMsHF4LpLoiX"
+                                      />
+                                    </div>
+                                  </div>
+                                </div>
+                                <span
+                                  class="font-semibold truncate text-theme-secondary-text"
                                 />
-                                <div
-                                  class="sc-AxhUy iDenJW bg-theme-background border-theme-primary-contrast dark:border-theme-neutral-800"
-                                />
-                              </div>
-                              <div
-                                class="mt-auto text-lg font-bold text-theme-primary-contrast dark:text-theme-neutral-800"
-                              >
-                                Balance
                               </div>
                               <span
-                                class="mt-1 text-xs font-semibold truncate text-theme-primary-contrast dark:text-theme-neutral-800"
+                                class="mt-auto text-lg font-bold text-theme-text"
+                                data-testid="Amount"
                               >
-                                Address
+                                50,114.21127898 ARK
+                              </span>
+                              <span
+                                class="mt-1 text-xs font-semibold truncate text-theme-secondary-text"
+                              >
+                                AdVSe37niA3uFUPgCgMUH2tMsHF4LpLoiX
                               </span>
                             </div>
                             <div


### PR DESCRIPTION
Only works for keys at the root but shouldn't be an issue with how the reducer is used. Ideally `useReducer` wouldn't even be used for this case.