### PR TITLE
ui: add missing transitions to modal close button

### DIFF
--- a/src/app/components/DeleteResource/__snapshots__/DeleteResource.test.tsx.snap
+++ b/src/app/components/DeleteResource/__snapshots__/DeleteResource.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`DeleteResource should render with children 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"

--- a/src/app/components/Modal/Modal.tsx
+++ b/src/app/components/Modal/Modal.tsx
@@ -76,7 +76,7 @@ const ModalContent = (props: ModalContentProps) => {
 			className={`absolute left-0 right-0 z-50 flex flex-col p-10 mx-auto overflow-hidden rounded-xl bg-theme-background shadow-2xl ${offsetClass}`}
 			data-testid="modal__inner"
 		>
-			<div className="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400">
+			<div className="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400">
 				<Button
 					data-testid="modal__close-btn"
 					variant="transparent"

--- a/src/app/components/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/src/app/components/Modal/__snapshots__/Modal.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`Modal should closed by the Esc key 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"
@@ -66,7 +66,7 @@ exports[`Modal should render a 3x large one 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"
@@ -116,7 +116,7 @@ exports[`Modal should render a 4x large one 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"
@@ -166,7 +166,7 @@ exports[`Modal should render a 5x large one 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"
@@ -216,7 +216,7 @@ exports[`Modal should render a 5x large one 2`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"
@@ -266,7 +266,7 @@ exports[`Modal should render a large one 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"
@@ -316,7 +316,7 @@ exports[`Modal should render a medium one 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"
@@ -366,7 +366,7 @@ exports[`Modal should render a modal with content 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"
@@ -418,7 +418,7 @@ exports[`Modal should render a modal with description 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"
@@ -474,7 +474,7 @@ exports[`Modal should render a modal with overlay 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"
@@ -526,7 +526,7 @@ exports[`Modal should render a small one 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"
@@ -576,7 +576,7 @@ exports[`Modal should render a xlarge one 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"

--- a/src/app/components/Notifications/__snapshots__/NotificationsDropdown.test.tsx.snap
+++ b/src/app/components/Notifications/__snapshots__/NotificationsDropdown.test.tsx.snap
@@ -319,7 +319,7 @@ exports[`Notifications should open and cancel wallet update notification modal 1
         data-testid="modal__inner"
       >
         <div
-          class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+          class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
         >
           <button
             class="sc-Axmtr jqXAAR w-11 h-11"
@@ -1031,7 +1031,7 @@ exports[`Notifications should open and close transaction details modal 1`] = `
         data-testid="modal__inner"
       >
         <div
-          class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+          class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
         >
           <button
             class="sc-Axmtr jqXAAR w-11 h-11"
@@ -2024,7 +2024,7 @@ exports[`Notifications should open and close wallet update notification modal 1`
         data-testid="modal__inner"
       >
         <div
-          class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+          class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
         >
           <button
             class="sc-Axmtr jqXAAR w-11 h-11"

--- a/src/domains/contact/components/CreateContact/__snapshots__/CreateContact.test.tsx.snap
+++ b/src/domains/contact/components/CreateContact/__snapshots__/CreateContact.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`CreateContact should render create contact modal 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"

--- a/src/domains/contact/components/DeleteContact/__snapshots__/DeleteContact.test.tsx.snap
+++ b/src/domains/contact/components/DeleteContact/__snapshots__/DeleteContact.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`DeleteContact should render a modal 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"

--- a/src/domains/contact/components/UpdateContact/__snapshots__/UpdateContact.test.tsx.snap
+++ b/src/domains/contact/components/UpdateContact/__snapshots__/UpdateContact.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`UpdateContact should render a modal 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"

--- a/src/domains/exchange/components/AddExchange/__snapshots__/AddExchange.test.tsx.snap
+++ b/src/domains/exchange/components/AddExchange/__snapshots__/AddExchange.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`AddExchange should render a modal 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"

--- a/src/domains/news/components/AddAssets/__snapshots__/AddAssets.test.tsx.snap
+++ b/src/domains/news/components/AddAssets/__snapshots__/AddAssets.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`AddAssets should render a modal 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxiKw eyfbzP w-11 h-11"

--- a/src/domains/plugin/components/AddBlacklistPlugin/__snapshots__/AddBlacklistPlugin.test.tsx.snap
+++ b/src/domains/plugin/components/AddBlacklistPlugin/__snapshots__/AddBlacklistPlugin.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`AddBlacklistPlugin should render a modal 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"

--- a/src/domains/plugin/components/BestPlugins/__snapshots__/BestPlugins.test.tsx.snap
+++ b/src/domains/plugin/components/BestPlugins/__snapshots__/BestPlugins.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`BestPlugins should render a modal 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"

--- a/src/domains/plugin/components/BlacklistPlugins/__snapshots__/BlacklistPlugins.test.tsx.snap
+++ b/src/domains/plugin/components/BlacklistPlugins/__snapshots__/BlacklistPlugins.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`BlacklistPlugins should render a modal 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxirZ jFqSPL w-11 h-11"
@@ -197,7 +197,7 @@ exports[`BlacklistPlugins should render a modal with blacklist 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxirZ jFqSPL w-11 h-11"

--- a/src/domains/plugin/components/FeaturedPlugins/__snapshots__/FeaturedPlugins.test.tsx.snap
+++ b/src/domains/plugin/components/FeaturedPlugins/__snapshots__/FeaturedPlugins.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`FeaturedPlugins should render a modal 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"

--- a/src/domains/plugin/components/InstallPlugin/__snapshots__/InstallPlugin.test.tsx.snap
+++ b/src/domains/plugin/components/InstallPlugin/__snapshots__/InstallPlugin.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`InstallPlugin should render 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"

--- a/src/domains/plugin/pages/PluginManager/__snapshots__/PluginManager.test.tsx.snap
+++ b/src/domains/plugin/pages/PluginManager/__snapshots__/PluginManager.test.tsx.snap
@@ -15441,7 +15441,7 @@ exports[`PluginManager should download & install plugin on game 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"
@@ -20179,7 +20179,7 @@ exports[`PluginManager should download & install plugin on home 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"
@@ -22844,7 +22844,7 @@ exports[`PluginManager should install plugin from header install button 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"

--- a/src/domains/plugin/pages/PluginsCategory/__snapshots__/PluginsCategory.test.tsx.snap
+++ b/src/domains/plugin/pages/PluginsCategory/__snapshots__/PluginsCategory.test.tsx.snap
@@ -6416,7 +6416,7 @@ exports[`PluginsCategory should download & install plugin 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"
@@ -7641,7 +7641,7 @@ exports[`PluginsCategory should install plugin from header install button 1`] = 
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"

--- a/src/domains/profile/components/DeleteProfile/__snapshots__/DeleteProfile.test.tsx.snap
+++ b/src/domains/profile/components/DeleteProfile/__snapshots__/DeleteProfile.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`DeleteProfile should render 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"

--- a/src/domains/profile/components/ProfileCreated/__snapshots__/ProfileCreated.test.tsx.snap
+++ b/src/domains/profile/components/ProfileCreated/__snapshots__/ProfileCreated.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`ProfileCreated should render a modal 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"

--- a/src/domains/profile/components/ResetProfile/__snapshots__/ResetProfile.test.tsx.snap
+++ b/src/domains/profile/components/ResetProfile/__snapshots__/ResetProfile.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`ResetProfile should render 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"

--- a/src/domains/profile/components/SignIn/__snapshots__/SignIn.test.tsx.snap
+++ b/src/domains/profile/components/SignIn/__snapshots__/SignIn.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`SignIn should render a modal 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"

--- a/src/domains/profile/pages/MyRegistrations/components/HistoryModal/__snapshots__/HistoryModal.test.tsx.snap
+++ b/src/domains/profile/pages/MyRegistrations/components/HistoryModal/__snapshots__/HistoryModal.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`HistoryModal should render empty state 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxirZ jFqSPL w-11 h-11"
@@ -177,7 +177,7 @@ exports[`HistoryModal should render properly 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxirZ jFqSPL w-11 h-11"

--- a/src/domains/profile/pages/MyRegistrations/components/RepositoryModal/__snapshots__/RepositoryModal.test.tsx.snap
+++ b/src/domains/profile/pages/MyRegistrations/components/RepositoryModal/__snapshots__/RepositoryModal.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`RepositoryModal should render empty state 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"

--- a/src/domains/setting/components/AdvancedMode/__snapshots__/AdvancedMode.test.tsx.snap
+++ b/src/domains/setting/components/AdvancedMode/__snapshots__/AdvancedMode.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`AdvancedMode should render a modal 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"

--- a/src/domains/setting/components/CreatePeer/__snapshots__/CreatePeer.test.tsx.snap
+++ b/src/domains/setting/components/CreatePeer/__snapshots__/CreatePeer.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`CreatePeer should render create peer modal 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"

--- a/src/domains/setting/components/DeletePeer/__snapshots__/DeletePeer.test.tsx.snap
+++ b/src/domains/setting/components/DeletePeer/__snapshots__/DeletePeer.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`DeletePeer should render a modal 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"

--- a/src/domains/setting/components/UpdatePeer/__snapshots__/UpdatePeer.test.tsx.snap
+++ b/src/domains/setting/components/UpdatePeer/__snapshots__/UpdatePeer.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`UpdatePeer should render update peer modal 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"

--- a/src/domains/transaction/components/DelegateRegistrationDetail/__snapshots__/DelegateRegistrationDetail.test.tsx.snap
+++ b/src/domains/transaction/components/DelegateRegistrationDetail/__snapshots__/DelegateRegistrationDetail.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`DelegateRegistrationDetail should render a modal 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxiKw eyfbzP w-11 h-11"
@@ -333,7 +333,7 @@ exports[`DelegateRegistrationDetail should render as confirmed 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxiKw eyfbzP w-11 h-11"

--- a/src/domains/transaction/components/DelegateResignationDetail/__snapshots__/DelegateResignationDetail.test.tsx.snap
+++ b/src/domains/transaction/components/DelegateResignationDetail/__snapshots__/DelegateResignationDetail.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`DelegateResignationDetail should render a modal 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxiKw eyfbzP w-11 h-11"
@@ -333,7 +333,7 @@ exports[`DelegateResignationDetail should render as confirmed 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxiKw eyfbzP w-11 h-11"

--- a/src/domains/transaction/components/EntityDetail/__snapshots__/EntityDetail.test.tsx.snap
+++ b/src/domains/transaction/components/EntityDetail/__snapshots__/EntityDetail.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`EntityDetail should render a business entity resignation modal 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"
@@ -314,7 +314,7 @@ exports[`EntityDetail should render a business entity update modal 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"
@@ -612,7 +612,7 @@ exports[`EntityDetail should render a modal 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"
@@ -910,7 +910,7 @@ exports[`EntityDetail should render a modal without a wallet alias 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"
@@ -1202,7 +1202,7 @@ exports[`EntityDetail should render a module entity registration modal 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"
@@ -1500,7 +1500,7 @@ exports[`EntityDetail should render a module entity resignation modal 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"
@@ -1798,7 +1798,7 @@ exports[`EntityDetail should render a module entity update modal 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"
@@ -2096,7 +2096,7 @@ exports[`EntityDetail should render a plugin entity registration modal 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"
@@ -2394,7 +2394,7 @@ exports[`EntityDetail should render a plugin entity resignation modal 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"
@@ -2692,7 +2692,7 @@ exports[`EntityDetail should render a plugin entity update modal 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"
@@ -2990,7 +2990,7 @@ exports[`EntityDetail should render a product entity registration modal 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"
@@ -3288,7 +3288,7 @@ exports[`EntityDetail should render a product entity resignation modal 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"
@@ -3586,7 +3586,7 @@ exports[`EntityDetail should render a product entity update modal 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"
@@ -3884,7 +3884,7 @@ exports[`EntityDetail should render as confirmed 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"

--- a/src/domains/transaction/components/IpfsDetail/__snapshots__/IpfsDetail.test.tsx.snap
+++ b/src/domains/transaction/components/IpfsDetail/__snapshots__/IpfsDetail.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`IpfsDetail should render a modal 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxiKw eyfbzP w-11 h-11"
@@ -346,7 +346,7 @@ exports[`IpfsDetail should render a modal without a wallet alias 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxiKw eyfbzP w-11 h-11"
@@ -670,7 +670,7 @@ exports[`IpfsDetail should render as confirmed 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxiKw eyfbzP w-11 h-11"

--- a/src/domains/transaction/components/LegacyMagistrateDetail/__snapshots__/LegacyMagistrateDetail.test.tsx.snap
+++ b/src/domains/transaction/components/LegacyMagistrateDetail/__snapshots__/LegacyMagistrateDetail.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`LegacyMagistrateDetail Legacy Bridgechain Transactions should render a 
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"
@@ -312,7 +312,7 @@ exports[`LegacyMagistrateDetail Legacy Bridgechain Transactions should render a 
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"
@@ -610,7 +610,7 @@ exports[`LegacyMagistrateDetail Legacy Bridgechain Transactions should render a 
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"
@@ -908,7 +908,7 @@ exports[`LegacyMagistrateDetail Legacy Business Transactions should render a leg
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"
@@ -1206,7 +1206,7 @@ exports[`LegacyMagistrateDetail Legacy Business Transactions should render a leg
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"
@@ -1504,7 +1504,7 @@ exports[`LegacyMagistrateDetail Legacy Business Transactions should render a leg
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"

--- a/src/domains/transaction/components/MultiPaymentDetail/__snapshots__/MultiPaymentDetail.test.tsx.snap
+++ b/src/domains/transaction/components/MultiPaymentDetail/__snapshots__/MultiPaymentDetail.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`MultiPaymentDetail should render a modal 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"
@@ -397,7 +397,7 @@ exports[`MultiPaymentDetail should render with recipients 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"

--- a/src/domains/transaction/components/MultiSignatureDetail/__snapshots__/MultiSignatureDetail.test.tsx.snap
+++ b/src/domains/transaction/components/MultiSignatureDetail/__snapshots__/MultiSignatureDetail.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`MultiSignatureDetail should fail to broadcast transaction 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"
@@ -434,7 +434,7 @@ exports[`MultiSignatureDetail should not show send button when waiting for confi
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"
@@ -842,7 +842,7 @@ exports[`MultiSignatureDetail should render summary step for ipfs 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"
@@ -1197,7 +1197,7 @@ exports[`MultiSignatureDetail should render summary step for multi payment 1`] =
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"
@@ -1762,7 +1762,7 @@ exports[`MultiSignatureDetail should render summary step for multi signature 1`]
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"
@@ -2087,7 +2087,7 @@ exports[`MultiSignatureDetail should render summary step for transfer 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"
@@ -2495,7 +2495,7 @@ exports[`MultiSignatureDetail should render summary step for unvote 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"
@@ -2912,7 +2912,7 @@ exports[`MultiSignatureDetail should render summary step for vote 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"
@@ -3329,7 +3329,7 @@ exports[`MultiSignatureDetail should show paginator when able to sign 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"
@@ -3757,7 +3757,7 @@ exports[`MultiSignatureDetail should show send button when able to broadcast 1`]
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"
@@ -4177,7 +4177,7 @@ exports[`MultiSignatureDetail should sign transaction after authentication page 
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"

--- a/src/domains/transaction/components/MultiSignatureDetail/__snapshots__/MultiSignatureRegistrationDetail.test.tsx.snap
+++ b/src/domains/transaction/components/MultiSignatureDetail/__snapshots__/MultiSignatureRegistrationDetail.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`MultiSignatureRegistrationDetail should render 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxirZ jFqSPL w-11 h-11"

--- a/src/domains/transaction/components/SearchRecipient/__snapshots__/SearchRecipient.test.tsx.snap
+++ b/src/domains/transaction/components/SearchRecipient/__snapshots__/SearchRecipient.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`SearchRecipient should render a modal 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxirZ jFqSPL w-11 h-11"
@@ -651,7 +651,7 @@ exports[`SearchRecipient should render a modal with custom title and description
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxirZ jFqSPL w-11 h-11"

--- a/src/domains/transaction/components/SecondSignatureDetail/__snapshots__/SecondSignatureDetail.test.tsx.snap
+++ b/src/domains/transaction/components/SecondSignatureDetail/__snapshots__/SecondSignatureDetail.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`SecondSignatureDetail should render a modal 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"
@@ -314,7 +314,7 @@ exports[`SecondSignatureDetail should render a modal without a wallet alias 1`] 
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"
@@ -606,7 +606,7 @@ exports[`SecondSignatureDetail should render as confirmed 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"

--- a/src/domains/transaction/components/TransactionDetailModal/__snapshots__/TransactionDetailModal.test.tsx.snap
+++ b/src/domains/transaction/components/TransactionDetailModal/__snapshots__/TransactionDetailModal.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`TransactionDetailModal should render a delegate registration modal 1`] 
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxiKw eyfbzP w-11 h-11"
@@ -334,7 +334,7 @@ exports[`TransactionDetailModal should render a delegate resignation modal 1`] =
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxiKw eyfbzP w-11 h-11"
@@ -652,7 +652,7 @@ exports[`TransactionDetailModal should render a entity modal 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxiKw eyfbzP w-11 h-11"
@@ -951,7 +951,7 @@ exports[`TransactionDetailModal should render a ipfs modal 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxiKw eyfbzP w-11 h-11"
@@ -1282,7 +1282,7 @@ exports[`TransactionDetailModal should render a legacy magistrate modal 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxiKw eyfbzP w-11 h-11"
@@ -1581,7 +1581,7 @@ exports[`TransactionDetailModal should render a multi payment modal 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxiKw eyfbzP w-11 h-11"
@@ -1963,7 +1963,7 @@ exports[`TransactionDetailModal should render a multi signature modal 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxiKw eyfbzP w-11 h-11"
@@ -2329,7 +2329,7 @@ exports[`TransactionDetailModal should render a second signature modal 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxiKw eyfbzP w-11 h-11"
@@ -2628,7 +2628,7 @@ exports[`TransactionDetailModal should render a transfer modal 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxiKw eyfbzP w-11 h-11"
@@ -3052,7 +3052,7 @@ exports[`TransactionDetailModal should render a unvote modal 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxiKw eyfbzP w-11 h-11"
@@ -3503,7 +3503,7 @@ exports[`TransactionDetailModal should render a vote modal 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxiKw eyfbzP w-11 h-11"

--- a/src/domains/transaction/components/TransferDetail/__snapshots__/TransferDetail.test.tsx.snap
+++ b/src/domains/transaction/components/TransferDetail/__snapshots__/TransferDetail.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`TransferDetail should render a modal 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"
@@ -439,7 +439,7 @@ exports[`TransferDetail should render as confirmed 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"
@@ -864,7 +864,7 @@ exports[`TransferDetail should render as not is sent 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"
@@ -1287,7 +1287,7 @@ exports[`TransferDetail should render with wallet alias 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"

--- a/src/domains/transaction/components/VoteDetail/__snapshots__/VoteDetail.test.tsx.snap
+++ b/src/domains/transaction/components/VoteDetail/__snapshots__/VoteDetail.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`VoteDetail should render a modal with unvotes 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"
@@ -406,7 +406,7 @@ exports[`VoteDetail should render a modal with votes 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"
@@ -796,7 +796,7 @@ exports[`VoteDetail should render a modal with votes and unvotes 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"

--- a/src/domains/wallet/components/DeleteWallet/__snapshots__/DeleteWallet.test.tsx.snap
+++ b/src/domains/wallet/components/DeleteWallet/__snapshots__/DeleteWallet.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`DeleteWallet should render a modal 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"

--- a/src/domains/wallet/components/Ledger/__snapshots__/LedgerWaitingDevice.test.tsx.snap
+++ b/src/domains/wallet/components/Ledger/__snapshots__/LedgerWaitingDevice.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`LedgerWaitingDevice should emit false when closed by button 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"

--- a/src/domains/wallet/components/ReceiveFunds/__snapshots__/ReceiveFunds.test.tsx.snap
+++ b/src/domains/wallet/components/ReceiveFunds/__snapshots__/ReceiveFunds.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`ReceiveFunds should not render qrcode without an address 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxhCb eFOAhf w-11 h-11"
@@ -164,7 +164,7 @@ exports[`ReceiveFunds should render with a wallet name 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxhCb eFOAhf w-11 h-11"
@@ -351,7 +351,7 @@ exports[`ReceiveFunds should render without a wallet name 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxhCb eFOAhf w-11 h-11"

--- a/src/domains/wallet/components/SearchWallet/__snapshots__/SearchWallet.test.tsx.snap
+++ b/src/domains/wallet/components/SearchWallet/__snapshots__/SearchWallet.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`SearchWallet uses fiat value = false should render 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxirZ jFqSPL w-11 h-11"
@@ -279,7 +279,7 @@ exports[`SearchWallet uses fiat value = true should render 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxirZ jFqSPL w-11 h-11"

--- a/src/domains/wallet/components/SignMessage/__snapshots__/SignMessage.test.tsx.snap
+++ b/src/domains/wallet/components/SignMessage/__snapshots__/SignMessage.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`SignMessage should render 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxirZ jFqSPL w-11 h-11"
@@ -218,7 +218,7 @@ exports[`SignMessage should sign message 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxirZ jFqSPL w-11 h-11"

--- a/src/domains/wallet/components/UpdateWalletName/__snapshots__/UpdateWalletName.test.tsx.snap
+++ b/src/domains/wallet/components/UpdateWalletName/__snapshots__/UpdateWalletName.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`UpdateWalletName should render a modal 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"
@@ -112,7 +112,7 @@ exports[`UpdateWalletName should show an error message for duplicate name 1`] = 
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"
@@ -215,7 +215,7 @@ exports[`UpdateWalletName should show an error message for duplicate name 2`] = 
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"
@@ -318,7 +318,7 @@ exports[`UpdateWalletName should show an error message for duplicate name 3`] = 
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"
@@ -421,7 +421,7 @@ exports[`UpdateWalletName should show an error message for duplicate name 4`] = 
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"
@@ -524,7 +524,7 @@ exports[`UpdateWalletName should show error message when name consists only of w
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"
@@ -627,7 +627,7 @@ exports[`UpdateWalletName should show error message when name exceeds 42 charact
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"

--- a/src/domains/wallet/components/VerifyMessage/__snapshots__/VerifyMessage.test.tsx.snap
+++ b/src/domains/wallet/components/VerifyMessage/__snapshots__/VerifyMessage.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`VerifyMessage should render 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxiKw eyfbzP w-11 h-11"
@@ -200,7 +200,7 @@ exports[`VerifyMessage should render the non verify address content 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxiKw eyfbzP w-11 h-11"

--- a/src/domains/wallet/components/VerifyMessageStatus/__snapshots__/VerifyMessageStatus.test.tsx.snap
+++ b/src/domains/wallet/components/VerifyMessageStatus/__snapshots__/VerifyMessageStatus.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`VerifyMessageStatus should render verify message error 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"
@@ -75,7 +75,7 @@ exports[`VerifyMessageStatus should render verify message success 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"

--- a/src/domains/wallet/components/WalletUpdate/__snapshots__/WalletUpdate.test.tsx.snap
+++ b/src/domains/wallet/components/WalletUpdate/__snapshots__/WalletUpdate.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`WalletUpdate should render 1`] = `
       data-testid="modal__inner"
     >
       <div
-        class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 hover:dark:bg-theme-primary-700 hover:dark:text-theme-neutral-400"
+        class="absolute top-0 right-0 z-50 mt-5 mr-5 transition-all duration-100 ease-linear rounded bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-neutral-800 dark:text-theme-neutral-600 dark:hover:bg-theme-neutral-700 dark:hover:text-theme-neutral-400"
       >
         <button
           class="sc-AxjAm cGlMcw w-11 h-11"

--- a/src/domains/wallet/pages/WalletDetails/__snapshots__/WalletDetails.test.tsx.snap
+++ b/src/domains/wallet/pages/WalletDetails/__snapshots__/WalletDetails.test.tsx.snap
@@ -8035,95 +8035,86 @@ exports[`WalletDetails should render when wallet hasn't voted 1`] = `
                   >
                     My Vote
                   </h2>
+                  <span
+                    class="ml-1 text-2xl font-bold text-theme-neutral-500 dark:text-theme-neutral-700"
+                  >
+                    (0/1)
+                  </span>
                 </div>
                 <div
-                  class="flex items-center"
-                  data-testid="WalletVote__skeleton"
+                  class="flex items-center space-x-4"
+                  data-testid="WalletVote__empty"
                 >
                   <div
-                    class="flex items-center mr-4 -space-x-2"
+                    class="flex items-center -space-x-2"
                   >
                     <div
-                      class="sc-AxhUy iDenJW border-transparent"
+                      class="sc-AxhUy iDenJW border-theme-neutral-500 dark:border-theme-neutral-700 text-theme-neutral-500 dark:text-theme-neutral-700"
                     >
-                      <span>
-                        <span
-                          class="flex items-center leading-none"
-                        >
-                          <span
-                            class="react-loading-skeleton css-1vmnjpn-skeletonStyles-Skeleton"
-                            style="width: 44px; height: 44px; border-radius: 50%;"
-                          >
-                            ‌
-                          </span>
-                          ‌
-                        </span>
-                      </span>
+                      <div
+                        class="sc-AxiKw jcWfEX"
+                        height="21"
+                        width="21"
+                      >
+                        <svg>
+                          vote.svg
+                        </svg>
+                      </div>
                     </div>
                     <div
-                      class="sc-AxhUy iDenJW border-transparent"
+                      class="flex -space-x-3"
                     >
-                      <span>
-                        <span
-                          class="flex items-center leading-none"
-                        >
-                          <span
-                            class="react-loading-skeleton css-1vmnjpn-skeletonStyles-Skeleton"
-                            style="width: 44px; height: 44px; border-radius: 50%;"
-                          >
-                            ‌
-                          </span>
-                          ‌
-                        </span>
+                      <span
+                        class="inline-block"
+                      >
+                        <div
+                          class="sc-AxhUy iDenJW border-theme-neutral-500 dark:border-theme-neutral-700"
+                        />
                       </span>
                     </div>
                   </div>
                   <div
-                    class="flex flex-col justify-between h-10"
+                    class="flex justify-between flex-1"
                   >
-                    <span>
+                    <div
+                      class="flex flex-col mr-4 font-semibold leading-snug text-theme-text"
+                    >
                       <span
-                        class="flex items-center leading-none"
+                        class="mr-2"
                       >
-                        <span
-                          class="react-loading-skeleton css-1vmnjpn-skeletonStyles-Skeleton"
-                          style="width: 150px; height: 14px;"
-                        >
-                          ‌
-                        </span>
-                        ‌
+                        You have not yet voted for a Delegate
                       </span>
-                    </span>
-                    <span>
-                      <span
-                        class="flex items-center leading-none"
+                      <div
+                        class="mt-1 mr-auto"
                       >
-                        <span
-                          class="react-loading-skeleton css-1vmnjpn-skeletonStyles-Skeleton"
-                          style="width: 100px; height: 16px;"
+                        <a
+                          class="sc-fznyAO fvIzri inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+                          data-testid="Link"
+                          rel="noopener noreferrer"
+                          to="https://ark.dev/docs/desktop-wallet/user-guides/how-to-vote-unvote"
                         >
-                          ‌
-                        </span>
-                        ‌
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    class="ml-auto"
-                  >
-                    <span>
-                      <span
-                        class="flex items-center leading-none"
-                      >
-                        <span
-                          class="react-loading-skeleton css-1vmnjpn-skeletonStyles-Skeleton"
-                          style="width: 100px; height: 44px;"
-                        >
-                          ‌
-                        </span>
-                        ‌
-                      </span>
-                    </span>
+                          Learn more
+                          <div
+                            class="sc-AxiKw dzBdqj flex-shrink-0 ml-2 text-sm"
+                            data-testid="Link__external"
+                            height="1em"
+                            width="1em"
+                          >
+                            <svg>
+                              redirect.svg
+                            </svg>
+                          </div>
+                        </a>
+                      </div>
+                    </div>
+                    <button
+                      class="sc-AxjAm fCKjFI"
+                      color="primary"
+                      data-testid="WalletVote__button"
+                      type="button"
+                    >
+                      Vote
+                    </button>
                   </div>
                 </div>
               </section>
@@ -8142,95 +8133,78 @@ exports[`WalletDetails should render when wallet hasn't voted 1`] = `
                   >
                     Registrations
                   </h2>
+                  <span
+                    class="ml-1 text-2xl font-bold text-theme-neutral-500 dark:text-theme-neutral-700"
+                  >
+                    (0)
+                  </span>
                 </div>
                 <div
-                  class="flex items-center"
-                  data-testid="WalletRegistrations__skeleton"
+                  class="flex items-center space-x-4"
+                  data-testid="WalletRegistrations__empty"
                 >
                   <div
-                    class="flex items-center mr-4 -space-x-2"
+                    class="flex items-center -space-x-2"
                   >
                     <div
-                      class="sc-AxhUy iDenJW border-transparent"
+                      class="sc-AxhUy iDenJW border-theme-neutral-500 dark:border-theme-neutral-700 text-theme-neutral-500 dark:text-theme-neutral-700"
                     >
-                      <span>
-                        <span
-                          class="flex items-center leading-none"
-                        >
-                          <span
-                            class="react-loading-skeleton css-1vmnjpn-skeletonStyles-Skeleton"
-                            style="width: 44px; height: 44px; border-radius: 50%;"
-                          >
-                            ‌
-                          </span>
-                          ‌
-                        </span>
-                      </span>
+                      <div
+                        class="sc-AxiKw dzBdqj text-xl"
+                        height="1em"
+                        width="1em"
+                      >
+                        <svg>
+                          delegate.svg
+                        </svg>
+                      </div>
                     </div>
                     <div
-                      class="sc-AxhUy iDenJW border-transparent"
+                      class="sc-AxhUy iDenJW border-theme-neutral-500 dark:border-theme-neutral-700"
+                    />
+                  </div>
+                  <div
+                    class="flex justify-between flex-1"
+                  >
+                    <div
+                      class="flex flex-col mr-4 font-semibold leading-snug text-theme-text"
                     >
-                      <span>
-                        <span
-                          class="flex items-center leading-none"
+                      <span
+                        class="mr-2"
+                      >
+                        You have no active registrations
+                      </span>
+                      <div
+                        class="mt-1 mr-auto"
+                      >
+                        <a
+                          class="sc-fznyAO fvIzri inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+                          data-testid="Link"
+                          rel="noopener noreferrer"
+                          to="@TODO"
                         >
-                          <span
-                            class="react-loading-skeleton css-1vmnjpn-skeletonStyles-Skeleton"
-                            style="width: 44px; height: 44px; border-radius: 50%;"
+                          Learn more
+                          <div
+                            class="sc-AxiKw dzBdqj flex-shrink-0 ml-2 text-sm"
+                            data-testid="Link__external"
+                            height="1em"
+                            width="1em"
                           >
-                            ‌
-                          </span>
-                          ‌
-                        </span>
-                      </span>
+                            <svg>
+                              redirect.svg
+                            </svg>
+                          </div>
+                        </a>
+                      </div>
                     </div>
-                  </div>
-                  <div
-                    class="flex flex-col justify-between h-10"
-                  >
-                    <span>
-                      <span
-                        class="flex items-center leading-none"
-                      >
-                        <span
-                          class="react-loading-skeleton css-1vmnjpn-skeletonStyles-Skeleton"
-                          style="width: 150px; height: 14px;"
-                        >
-                          ‌
-                        </span>
-                        ‌
-                      </span>
-                    </span>
-                    <span>
-                      <span
-                        class="flex items-center leading-none"
-                      >
-                        <span
-                          class="react-loading-skeleton css-1vmnjpn-skeletonStyles-Skeleton"
-                          style="width: 100px; height: 16px;"
-                        >
-                          ‌
-                        </span>
-                        ‌
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    class="ml-auto"
-                  >
-                    <span>
-                      <span
-                        class="flex items-center leading-none"
-                      >
-                        <span
-                          class="react-loading-skeleton css-1vmnjpn-skeletonStyles-Skeleton"
-                          style="width: 100px; height: 44px;"
-                        >
-                          ‌
-                        </span>
-                        ‌
-                      </span>
-                    </span>
+                    <button
+                      class="sc-AxjAm fCKjFI"
+                      color="primary"
+                      data-testid="WalletRegistrations__button"
+                      type="button"
+                    >
+                      Register
+                    </button>
                   </div>
                 </div>
               </section>
@@ -8474,200 +8448,155 @@ exports[`WalletDetails should render when wallet hasn't voted 1`] = `
                     role="rowgroup"
                   >
                     <tr
-                      class="sc-AxmLO iVatWU group"
+                      class="sc-AxmLO kbgHZc group"
                       data-testid="TableRow"
                     >
                       <td>
                         <div
-                          class="sc-Axmtr bMGOQy"
+                          class="sc-Axmtr gaELvy"
                         >
-                          <span>
-                            <span
-                              class="flex items-center leading-none"
-                            >
-                              <span
-                                class="react-loading-skeleton css-1vmnjpn-skeletonStyles-Skeleton"
-                                style="width: 16px; height: 16px;"
-                              >
-                                ‌
-                              </span>
-                              ‌
-                            </span>
-                          </span>
-                        </div>
-                      </td>
-                      <td>
-                        <div
-                          class="sc-Axmtr ccwJsU"
-                        >
-                          <span>
-                            <span
-                              class="flex items-center leading-none"
-                            >
-                              <span
-                                class="react-loading-skeleton css-1vmnjpn-skeletonStyles-Skeleton"
-                                style="width: 150px; height: 16px;"
-                              >
-                                ‌
-                              </span>
-                              ‌
-                            </span>
-                          </span>
-                        </div>
-                      </td>
-                      <td>
-                        <div
-                          class="sc-Axmtr ccwJsU"
-                        >
-                          <div
-                            class="flex items-center mr-4 -space-x-1"
+                          <a
+                            class="sc-fznyAO fvIzri inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
+                            data-testid="TransactionRow__ID"
+                            rel="noopener noreferrer"
+                            to="https://dexplorer.ark.io/transaction/8f913b6b719e7767d49861c0aec79ced212767645cb793d75d2f1b89abb49877"
                           >
                             <div
-                              class="sc-AxhUy iDenJW border-transparent"
+                              class="sc-AxiKw dzBdqj"
+                              height="1em"
+                              width="1em"
                             >
-                              <span>
-                                <span
-                                  class="flex items-center leading-none"
-                                >
-                                  <span
-                                    class="react-loading-skeleton css-1vmnjpn-skeletonStyles-Skeleton"
-                                    style="width: 44px; height: 44px; border-radius: 50%;"
-                                  >
-                                    ‌
-                                  </span>
-                                  ‌
-                                </span>
-                              </span>
+                              <svg>
+                                id.svg
+                              </svg>
                             </div>
-                            <div
-                              class="sc-AxhUy iDenJW border-transparent"
-                            >
-                              <span>
-                                <span
-                                  class="flex items-center leading-none"
-                                >
-                                  <span
-                                    class="react-loading-skeleton css-1vmnjpn-skeletonStyles-Skeleton"
-                                    style="width: 44px; height: 44px; border-radius: 50%;"
-                                  >
-                                    ‌
-                                  </span>
-                                  ‌
-                                </span>
-                              </span>
-                            </div>
-                          </div>
-                          <span>
-                            <span
-                              class="flex items-center leading-none"
-                            >
-                              <span
-                                class="react-loading-skeleton css-1vmnjpn-skeletonStyles-Skeleton"
-                                style="width: 143px; height: 16px;"
-                              >
-                                ‌
-                              </span>
-                              ‌
-                            </span>
+                          </a>
+                        </div>
+                      </td>
+                      <td>
+                        <div
+                          class="sc-Axmtr eisuEY text-theme-secondary-text"
+                        >
+                          <span
+                            class="whitespace-no-wrap"
+                            data-testid="TransactionRow__timestamp"
+                          >
+                            23 Jul 2020 08:03:20
                           </span>
                         </div>
                       </td>
                       <td>
                         <div
-                          class="sc-Axmtr ccwJsU justify-center"
+                          class="sc-Axmtr eisuEY space-x-4"
                         >
-                          <span
-                            class="flex items-center space-x-2"
+                          <div
+                            class="flex items-center -space-x-1"
+                            data-testid="TransactionRowMode"
+                          >
+                            <div
+                              class="sc-AxhUy iDenJW border-theme-success-200 text-theme-success-600 dark:border-theme-success-600"
+                            >
+                              <div
+                                class="sc-AxiKw dzBdqj"
+                                data-testid="TransactionRowMode__Received"
+                                height="1em"
+                                width="1em"
+                              >
+                                <svg>
+                                  received.svg
+                                </svg>
+                              </div>
+                            </div>
+                            <div
+                              class="Avatar__AvatarWrapper-sc-1vsy2s2-0 eHceTZ"
+                              data-testid="Avatar"
+                            >
+                              <div
+                                class="w-full h-full"
+                              >
+                                <img
+                                  alt="D5pVkhZbSb4UNXvfmF6j7zdau8yGxfKwSv"
+                                  src="data:image/svg+xml;utf8,<svg version=\\"1.1\\" xmlns=\\"http://www.w3.org/2000/svg\\" class=\\"picasso\\" width=\\"100\\" height=\\"100\\" viewBox=\\"0 0 100 100\\"><style>.picasso circle{mix-blend-mode:soft-light;}</style><rect fill=\\"rgb(33, 150, 243)\\" width=\\"100\\" height=\\"100\\"/><circle r=\\"40\\" cx=\\"80\\" cy=\\"30\\" fill=\\"rgb(255, 87, 34)\\"/><circle r=\\"60\\" cx=\\"70\\" cy=\\"50\\" fill=\\"rgb(156, 39, 176)\\"/><circle r=\\"55\\" cx=\\"100\\" cy=\\"70\\" fill=\\"rgb(0, 150, 136)\\"/></svg>"
+                                  title="D5pVkhZbSb4UNXvfmF6j7zdau8yGxfKwSv"
+                                />
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            class="inline-flex items-center"
+                          >
+                            <span
+                              class="sc-fzoLsD fqEnxe text-theme-text truncate font-semibold text-base"
+                              data-testid="address__wallet-address"
+                            >
+                              D5pVkh … xfKwSv
+                            </span>
+                          </div>
+                        </div>
+                      </td>
+                      <td>
+                        <div
+                          class="sc-Axmtr eisuEY justify-center"
+                        >
+                          <div
+                            class="inline-flex space-x-1 align-middle"
+                            data-testid="TransactionRowInfo"
                           />
                         </div>
                       </td>
-                      <td>
+                      <td
+                        class="w-16"
+                      >
                         <div
-                          class="sc-Axmtr ccwJsU justify-center"
+                          class="sc-Axmtr eisuEY justify-center"
                         >
-                          <span>
-                            <span
-                              class="flex items-center leading-none"
+                          <div
+                            class="inline-flex p-1 align-middle"
+                            data-testid="TransactionRowConfirmation"
+                          >
+                            <div
+                              class="sc-AxiKw fFXzuz text-theme-success"
+                              data-testid="TransactionRowConfirmation__confirmed"
+                              height="22"
+                              width="22"
                             >
-                              <span
-                                class="react-loading-skeleton css-1vmnjpn-skeletonStyles-Skeleton"
-                                style="width: 22px; height: 22px; border-radius: 50%;"
-                              >
-                                ‌
-                              </span>
-                              ‌
-                            </span>
-                          </span>
+                              <svg>
+                                status-ok.svg
+                              </svg>
+                            </div>
+                          </div>
                         </div>
                       </td>
                       <td>
                         <div
-                          class="sc-Axmtr ccwJsU justify-end"
+                          class="sc-Axmtr eisuEY justify-end"
                         >
-                          <span
-                            class="flex items-center px-2 space-x-1 border rounded h-7 border-theme-neutral-300 dark:border-theme-neutral-800"
+                          <div
+                            class="sc-fzozJi bXfNeq whitespace-no-wrap"
+                            color="success"
+                            data-testid="TransactionRowAmount"
                           >
-                            <span>
-                              <span
-                                class="flex items-center leading-none"
-                              >
-                                <span
-                                  class="react-loading-skeleton css-1vmnjpn-skeletonStyles-Skeleton"
-                                  style="width: 127px; height: 16px;"
-                                >
-                                  ‌
-                                </span>
-                                ‌
-                              </span>
+                            <span
+                              data-testid="Amount"
+                            >
+                              + 400,000 DARK
                             </span>
-                            <span>
-                              <span
-                                class="flex items-center leading-none"
-                              >
-                                <span
-                                  class="react-loading-skeleton css-1vmnjpn-skeletonStyles-Skeleton"
-                                  style="width: 35px; height: 16px;"
-                                >
-                                  ‌
-                                </span>
-                                ‌
-                              </span>
-                            </span>
-                          </span>
+                          </div>
                         </div>
                       </td>
                       <td>
                         <div
-                          class="sc-Axmtr ijPrma justify-end"
+                          class="sc-Axmtr exQntG justify-end"
                         >
                           <span
-                            class="flex items-center space-x-1"
+                            class="whitespace-no-wrap"
+                            data-testid="TransactionRow__currency"
                           >
-                            <span>
-                              <span
-                                class="flex items-center leading-none"
-                              >
-                                <span
-                                  class="react-loading-skeleton css-1vmnjpn-skeletonStyles-Skeleton"
-                                  style="width: 95px; height: 16px;"
-                                >
-                                  ‌
-                                </span>
-                                ‌
-                              </span>
-                            </span>
-                            <span>
-                              <span
-                                class="flex items-center leading-none"
-                              >
-                                <span
-                                  class="react-loading-skeleton css-1vmnjpn-skeletonStyles-Skeleton"
-                                  style="width: 35px; height: 16px;"
-                                >
-                                  ‌
-                                </span>
-                                ‌
-                              </span>
+                            <span
+                              class="text-theme-secondary-text"
+                              data-testid="TransactionRowAmount"
+                            >
+                              0 BTC
                             </span>
                           </span>
                         </div>
@@ -8677,6 +8606,14 @@ exports[`WalletDetails should render when wallet hasn't voted 1`] = `
                 </table>
               </div>
             </div>
+            <button
+              class="sc-AxjAm fCKjFI w-full mt-10 mb-5"
+              color="primary"
+              data-testid="transactions__fetch-more-button"
+              type="button"
+            >
+              View More
+            </button>
           </div>
         </div>
       </div>

--- a/src/domains/wallet/pages/WalletDetails/__snapshots__/WalletDetails.test.tsx.snap
+++ b/src/domains/wallet/pages/WalletDetails/__snapshots__/WalletDetails.test.tsx.snap
@@ -8035,86 +8035,95 @@ exports[`WalletDetails should render when wallet hasn't voted 1`] = `
                   >
                     My Vote
                   </h2>
-                  <span
-                    class="ml-1 text-2xl font-bold text-theme-neutral-500 dark:text-theme-neutral-700"
-                  >
-                    (0/1)
-                  </span>
                 </div>
                 <div
-                  class="flex items-center space-x-4"
-                  data-testid="WalletVote__empty"
+                  class="flex items-center"
+                  data-testid="WalletVote__skeleton"
                 >
                   <div
-                    class="flex items-center -space-x-2"
+                    class="flex items-center mr-4 -space-x-2"
                   >
                     <div
-                      class="sc-AxhUy iDenJW border-theme-neutral-500 dark:border-theme-neutral-700 text-theme-neutral-500 dark:text-theme-neutral-700"
+                      class="sc-AxhUy iDenJW border-transparent"
                     >
-                      <div
-                        class="sc-AxiKw jcWfEX"
-                        height="21"
-                        width="21"
-                      >
-                        <svg>
-                          vote.svg
-                        </svg>
-                      </div>
+                      <span>
+                        <span
+                          class="flex items-center leading-none"
+                        >
+                          <span
+                            class="react-loading-skeleton css-1vmnjpn-skeletonStyles-Skeleton"
+                            style="width: 44px; height: 44px; border-radius: 50%;"
+                          >
+                            ‌
+                          </span>
+                          ‌
+                        </span>
+                      </span>
                     </div>
                     <div
-                      class="flex -space-x-3"
+                      class="sc-AxhUy iDenJW border-transparent"
                     >
-                      <span
-                        class="inline-block"
-                      >
-                        <div
-                          class="sc-AxhUy iDenJW border-theme-neutral-500 dark:border-theme-neutral-700"
-                        />
+                      <span>
+                        <span
+                          class="flex items-center leading-none"
+                        >
+                          <span
+                            class="react-loading-skeleton css-1vmnjpn-skeletonStyles-Skeleton"
+                            style="width: 44px; height: 44px; border-radius: 50%;"
+                          >
+                            ‌
+                          </span>
+                          ‌
+                        </span>
                       </span>
                     </div>
                   </div>
                   <div
-                    class="flex justify-between flex-1"
+                    class="flex flex-col justify-between h-10"
                   >
-                    <div
-                      class="flex flex-col mr-4 font-semibold leading-snug text-theme-text"
-                    >
+                    <span>
                       <span
-                        class="mr-2"
+                        class="flex items-center leading-none"
                       >
-                        You have not yet voted for a Delegate
-                      </span>
-                      <div
-                        class="mt-1 mr-auto"
-                      >
-                        <a
-                          class="sc-fznyAO fvIzri inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
-                          data-testid="Link"
-                          rel="noopener noreferrer"
-                          to="https://ark.dev/docs/desktop-wallet/user-guides/how-to-vote-unvote"
+                        <span
+                          class="react-loading-skeleton css-1vmnjpn-skeletonStyles-Skeleton"
+                          style="width: 150px; height: 14px;"
                         >
-                          Learn more
-                          <div
-                            class="sc-AxiKw dzBdqj flex-shrink-0 ml-2 text-sm"
-                            data-testid="Link__external"
-                            height="1em"
-                            width="1em"
-                          >
-                            <svg>
-                              redirect.svg
-                            </svg>
-                          </div>
-                        </a>
-                      </div>
-                    </div>
-                    <button
-                      class="sc-AxjAm fCKjFI"
-                      color="primary"
-                      data-testid="WalletVote__button"
-                      type="button"
-                    >
-                      Vote
-                    </button>
+                          ‌
+                        </span>
+                        ‌
+                      </span>
+                    </span>
+                    <span>
+                      <span
+                        class="flex items-center leading-none"
+                      >
+                        <span
+                          class="react-loading-skeleton css-1vmnjpn-skeletonStyles-Skeleton"
+                          style="width: 100px; height: 16px;"
+                        >
+                          ‌
+                        </span>
+                        ‌
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    class="ml-auto"
+                  >
+                    <span>
+                      <span
+                        class="flex items-center leading-none"
+                      >
+                        <span
+                          class="react-loading-skeleton css-1vmnjpn-skeletonStyles-Skeleton"
+                          style="width: 100px; height: 44px;"
+                        >
+                          ‌
+                        </span>
+                        ‌
+                      </span>
+                    </span>
                   </div>
                 </div>
               </section>
@@ -8133,78 +8142,95 @@ exports[`WalletDetails should render when wallet hasn't voted 1`] = `
                   >
                     Registrations
                   </h2>
-                  <span
-                    class="ml-1 text-2xl font-bold text-theme-neutral-500 dark:text-theme-neutral-700"
-                  >
-                    (0)
-                  </span>
                 </div>
                 <div
-                  class="flex items-center space-x-4"
-                  data-testid="WalletRegistrations__empty"
+                  class="flex items-center"
+                  data-testid="WalletRegistrations__skeleton"
                 >
                   <div
-                    class="flex items-center -space-x-2"
+                    class="flex items-center mr-4 -space-x-2"
                   >
                     <div
-                      class="sc-AxhUy iDenJW border-theme-neutral-500 dark:border-theme-neutral-700 text-theme-neutral-500 dark:text-theme-neutral-700"
+                      class="sc-AxhUy iDenJW border-transparent"
                     >
-                      <div
-                        class="sc-AxiKw dzBdqj text-xl"
-                        height="1em"
-                        width="1em"
-                      >
-                        <svg>
-                          delegate.svg
-                        </svg>
-                      </div>
+                      <span>
+                        <span
+                          class="flex items-center leading-none"
+                        >
+                          <span
+                            class="react-loading-skeleton css-1vmnjpn-skeletonStyles-Skeleton"
+                            style="width: 44px; height: 44px; border-radius: 50%;"
+                          >
+                            ‌
+                          </span>
+                          ‌
+                        </span>
+                      </span>
                     </div>
                     <div
-                      class="sc-AxhUy iDenJW border-theme-neutral-500 dark:border-theme-neutral-700"
-                    />
+                      class="sc-AxhUy iDenJW border-transparent"
+                    >
+                      <span>
+                        <span
+                          class="flex items-center leading-none"
+                        >
+                          <span
+                            class="react-loading-skeleton css-1vmnjpn-skeletonStyles-Skeleton"
+                            style="width: 44px; height: 44px; border-radius: 50%;"
+                          >
+                            ‌
+                          </span>
+                          ‌
+                        </span>
+                      </span>
+                    </div>
                   </div>
                   <div
-                    class="flex justify-between flex-1"
+                    class="flex flex-col justify-between h-10"
                   >
-                    <div
-                      class="flex flex-col mr-4 font-semibold leading-snug text-theme-text"
-                    >
+                    <span>
                       <span
-                        class="mr-2"
+                        class="flex items-center leading-none"
                       >
-                        You have no active registrations
-                      </span>
-                      <div
-                        class="mt-1 mr-auto"
-                      >
-                        <a
-                          class="sc-fznyAO fvIzri inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
-                          data-testid="Link"
-                          rel="noopener noreferrer"
-                          to="@TODO"
+                        <span
+                          class="react-loading-skeleton css-1vmnjpn-skeletonStyles-Skeleton"
+                          style="width: 150px; height: 14px;"
                         >
-                          Learn more
-                          <div
-                            class="sc-AxiKw dzBdqj flex-shrink-0 ml-2 text-sm"
-                            data-testid="Link__external"
-                            height="1em"
-                            width="1em"
-                          >
-                            <svg>
-                              redirect.svg
-                            </svg>
-                          </div>
-                        </a>
-                      </div>
-                    </div>
-                    <button
-                      class="sc-AxjAm fCKjFI"
-                      color="primary"
-                      data-testid="WalletRegistrations__button"
-                      type="button"
-                    >
-                      Register
-                    </button>
+                          ‌
+                        </span>
+                        ‌
+                      </span>
+                    </span>
+                    <span>
+                      <span
+                        class="flex items-center leading-none"
+                      >
+                        <span
+                          class="react-loading-skeleton css-1vmnjpn-skeletonStyles-Skeleton"
+                          style="width: 100px; height: 16px;"
+                        >
+                          ‌
+                        </span>
+                        ‌
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    class="ml-auto"
+                  >
+                    <span>
+                      <span
+                        class="flex items-center leading-none"
+                      >
+                        <span
+                          class="react-loading-skeleton css-1vmnjpn-skeletonStyles-Skeleton"
+                          style="width: 100px; height: 44px;"
+                        >
+                          ‌
+                        </span>
+                        ‌
+                      </span>
+                    </span>
                   </div>
                 </div>
               </section>
@@ -8448,155 +8474,200 @@ exports[`WalletDetails should render when wallet hasn't voted 1`] = `
                     role="rowgroup"
                   >
                     <tr
-                      class="sc-AxmLO kbgHZc group"
+                      class="sc-AxmLO iVatWU group"
                       data-testid="TableRow"
                     >
                       <td>
                         <div
-                          class="sc-Axmtr gaELvy"
+                          class="sc-Axmtr bMGOQy"
                         >
-                          <a
-                            class="sc-fznyAO fvIzri inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary hover:text-theme-primary-dark hover:underline active:text-theme-primary-500"
-                            data-testid="TransactionRow__ID"
-                            rel="noopener noreferrer"
-                            to="https://dexplorer.ark.io/transaction/8f913b6b719e7767d49861c0aec79ced212767645cb793d75d2f1b89abb49877"
-                          >
-                            <div
-                              class="sc-AxiKw dzBdqj"
-                              height="1em"
-                              width="1em"
+                          <span>
+                            <span
+                              class="flex items-center leading-none"
                             >
-                              <svg>
-                                id.svg
-                              </svg>
-                            </div>
-                          </a>
-                        </div>
-                      </td>
-                      <td>
-                        <div
-                          class="sc-Axmtr eisuEY text-theme-secondary-text"
-                        >
-                          <span
-                            class="whitespace-no-wrap"
-                            data-testid="TransactionRow__timestamp"
-                          >
-                            23 Jul 2020 08:03:20
+                              <span
+                                class="react-loading-skeleton css-1vmnjpn-skeletonStyles-Skeleton"
+                                style="width: 16px; height: 16px;"
+                              >
+                                ‌
+                              </span>
+                              ‌
+                            </span>
                           </span>
                         </div>
                       </td>
                       <td>
                         <div
-                          class="sc-Axmtr eisuEY space-x-4"
+                          class="sc-Axmtr ccwJsU"
                         >
-                          <div
-                            class="flex items-center -space-x-1"
-                            data-testid="TransactionRowMode"
-                          >
-                            <div
-                              class="sc-AxhUy iDenJW border-theme-success-200 text-theme-success-600 dark:border-theme-success-600"
-                            >
-                              <div
-                                class="sc-AxiKw dzBdqj"
-                                data-testid="TransactionRowMode__Received"
-                                height="1em"
-                                width="1em"
-                              >
-                                <svg>
-                                  received.svg
-                                </svg>
-                              </div>
-                            </div>
-                            <div
-                              class="Avatar__AvatarWrapper-sc-1vsy2s2-0 eHceTZ"
-                              data-testid="Avatar"
-                            >
-                              <div
-                                class="w-full h-full"
-                              >
-                                <img
-                                  alt="D5pVkhZbSb4UNXvfmF6j7zdau8yGxfKwSv"
-                                  src="data:image/svg+xml;utf8,<svg version=\\"1.1\\" xmlns=\\"http://www.w3.org/2000/svg\\" class=\\"picasso\\" width=\\"100\\" height=\\"100\\" viewBox=\\"0 0 100 100\\"><style>.picasso circle{mix-blend-mode:soft-light;}</style><rect fill=\\"rgb(33, 150, 243)\\" width=\\"100\\" height=\\"100\\"/><circle r=\\"40\\" cx=\\"80\\" cy=\\"30\\" fill=\\"rgb(255, 87, 34)\\"/><circle r=\\"60\\" cx=\\"70\\" cy=\\"50\\" fill=\\"rgb(156, 39, 176)\\"/><circle r=\\"55\\" cx=\\"100\\" cy=\\"70\\" fill=\\"rgb(0, 150, 136)\\"/></svg>"
-                                  title="D5pVkhZbSb4UNXvfmF6j7zdau8yGxfKwSv"
-                                />
-                              </div>
-                            </div>
-                          </div>
-                          <div
-                            class="inline-flex items-center"
-                          >
+                          <span>
                             <span
-                              class="sc-fzoLsD fqEnxe text-theme-text truncate font-semibold text-base"
-                              data-testid="address__wallet-address"
+                              class="flex items-center leading-none"
                             >
-                              D5pVkh … xfKwSv
+                              <span
+                                class="react-loading-skeleton css-1vmnjpn-skeletonStyles-Skeleton"
+                                style="width: 150px; height: 16px;"
+                              >
+                                ‌
+                              </span>
+                              ‌
                             </span>
-                          </div>
+                          </span>
                         </div>
                       </td>
                       <td>
                         <div
-                          class="sc-Axmtr eisuEY justify-center"
+                          class="sc-Axmtr ccwJsU"
                         >
                           <div
-                            class="inline-flex space-x-1 align-middle"
-                            data-testid="TransactionRowInfo"
+                            class="flex items-center mr-4 -space-x-1"
+                          >
+                            <div
+                              class="sc-AxhUy iDenJW border-transparent"
+                            >
+                              <span>
+                                <span
+                                  class="flex items-center leading-none"
+                                >
+                                  <span
+                                    class="react-loading-skeleton css-1vmnjpn-skeletonStyles-Skeleton"
+                                    style="width: 44px; height: 44px; border-radius: 50%;"
+                                  >
+                                    ‌
+                                  </span>
+                                  ‌
+                                </span>
+                              </span>
+                            </div>
+                            <div
+                              class="sc-AxhUy iDenJW border-transparent"
+                            >
+                              <span>
+                                <span
+                                  class="flex items-center leading-none"
+                                >
+                                  <span
+                                    class="react-loading-skeleton css-1vmnjpn-skeletonStyles-Skeleton"
+                                    style="width: 44px; height: 44px; border-radius: 50%;"
+                                  >
+                                    ‌
+                                  </span>
+                                  ‌
+                                </span>
+                              </span>
+                            </div>
+                          </div>
+                          <span>
+                            <span
+                              class="flex items-center leading-none"
+                            >
+                              <span
+                                class="react-loading-skeleton css-1vmnjpn-skeletonStyles-Skeleton"
+                                style="width: 143px; height: 16px;"
+                              >
+                                ‌
+                              </span>
+                              ‌
+                            </span>
+                          </span>
+                        </div>
+                      </td>
+                      <td>
+                        <div
+                          class="sc-Axmtr ccwJsU justify-center"
+                        >
+                          <span
+                            class="flex items-center space-x-2"
                           />
                         </div>
                       </td>
-                      <td
-                        class="w-16"
-                      >
-                        <div
-                          class="sc-Axmtr eisuEY justify-center"
-                        >
-                          <div
-                            class="inline-flex p-1 align-middle"
-                            data-testid="TransactionRowConfirmation"
-                          >
-                            <div
-                              class="sc-AxiKw fFXzuz text-theme-success"
-                              data-testid="TransactionRowConfirmation__confirmed"
-                              height="22"
-                              width="22"
-                            >
-                              <svg>
-                                status-ok.svg
-                              </svg>
-                            </div>
-                          </div>
-                        </div>
-                      </td>
                       <td>
                         <div
-                          class="sc-Axmtr eisuEY justify-end"
+                          class="sc-Axmtr ccwJsU justify-center"
                         >
-                          <div
-                            class="sc-fzozJi bXfNeq whitespace-no-wrap"
-                            color="success"
-                            data-testid="TransactionRowAmount"
-                          >
+                          <span>
                             <span
-                              data-testid="Amount"
+                              class="flex items-center leading-none"
                             >
-                              + 400,000 DARK
+                              <span
+                                class="react-loading-skeleton css-1vmnjpn-skeletonStyles-Skeleton"
+                                style="width: 22px; height: 22px; border-radius: 50%;"
+                              >
+                                ‌
+                              </span>
+                              ‌
                             </span>
-                          </div>
+                          </span>
                         </div>
                       </td>
                       <td>
                         <div
-                          class="sc-Axmtr exQntG justify-end"
+                          class="sc-Axmtr ccwJsU justify-end"
                         >
                           <span
-                            class="whitespace-no-wrap"
-                            data-testid="TransactionRow__currency"
+                            class="flex items-center px-2 space-x-1 border rounded h-7 border-theme-neutral-300 dark:border-theme-neutral-800"
                           >
-                            <span
-                              class="text-theme-secondary-text"
-                              data-testid="TransactionRowAmount"
-                            >
-                              0 BTC
+                            <span>
+                              <span
+                                class="flex items-center leading-none"
+                              >
+                                <span
+                                  class="react-loading-skeleton css-1vmnjpn-skeletonStyles-Skeleton"
+                                  style="width: 127px; height: 16px;"
+                                >
+                                  ‌
+                                </span>
+                                ‌
+                              </span>
+                            </span>
+                            <span>
+                              <span
+                                class="flex items-center leading-none"
+                              >
+                                <span
+                                  class="react-loading-skeleton css-1vmnjpn-skeletonStyles-Skeleton"
+                                  style="width: 35px; height: 16px;"
+                                >
+                                  ‌
+                                </span>
+                                ‌
+                              </span>
+                            </span>
+                          </span>
+                        </div>
+                      </td>
+                      <td>
+                        <div
+                          class="sc-Axmtr ijPrma justify-end"
+                        >
+                          <span
+                            class="flex items-center space-x-1"
+                          >
+                            <span>
+                              <span
+                                class="flex items-center leading-none"
+                              >
+                                <span
+                                  class="react-loading-skeleton css-1vmnjpn-skeletonStyles-Skeleton"
+                                  style="width: 95px; height: 16px;"
+                                >
+                                  ‌
+                                </span>
+                                ‌
+                              </span>
+                            </span>
+                            <span>
+                              <span
+                                class="flex items-center leading-none"
+                              >
+                                <span
+                                  class="react-loading-skeleton css-1vmnjpn-skeletonStyles-Skeleton"
+                                  style="width: 35px; height: 16px;"
+                                >
+                                  ‌
+                                </span>
+                                ‌
+                              </span>
                             </span>
                           </span>
                         </div>
@@ -8606,14 +8677,6 @@ exports[`WalletDetails should render when wallet hasn't voted 1`] = `
                 </table>
               </div>
             </div>
-            <button
-              class="sc-AxjAm fCKjFI w-full mt-10 mb-5"
-              color="primary"
-              data-testid="transactions__fetch-more-button"
-              type="button"
-            >
-              View More
-            </button>
           </div>
         </div>
       </div>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Adds the missing transition classes to the modal close button.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
