### PR TITLE
fix: pagination dark mode styling

### DIFF
--- a/src/app/components/Pagination/Pagination.tsx
+++ b/src/app/components/Pagination/Pagination.tsx
@@ -14,7 +14,7 @@ const Wrapper = styled.div`
 	}
 
 	button {
-		${tw`py-2 px-4 text-theme-primary-500`}
+		${tw`py-2 px-4`}
 	}
 `;
 
@@ -37,7 +37,7 @@ const PaginationButton = styled.div`
 	}
 
 	&.current-page {
-		${tw`bg-theme-primary-light dark:bg-theme-neutral-600 text-theme-primary-500 dark:text-theme-neutral-200`}
+		${tw`bg-theme-primary-200 dark:bg-theme-neutral-600 text-theme-primary-500 dark:text-theme-neutral-200`}
 	}
 `;
 
@@ -124,7 +124,7 @@ export const Pagination = ({
 				</Button>
 			)}
 
-			<div className="flex px-2 rounded bg-theme-primary-contrast dark:bg-theme-neutral-800">
+			<div className="flex px-2 rounded bg-theme-primary-100 dark:bg-theme-neutral-800">
 				{paginationButtons[0] !== 1 && (
 					<PaginationSearchButton>
 						<span>...</span>

--- a/src/app/components/Pagination/Pagination.tsx
+++ b/src/app/components/Pagination/Pagination.tsx
@@ -28,7 +28,7 @@ type PaginationProps = {
 };
 
 const PaginationButton = styled.div`
-	${tw`text-theme-primary-500 cursor-pointer px-2 text-base inline-flex items-center font-semibold text-center transition-all duration-100 ease-linear justify-center`}
+	${tw`text-theme-primary-500 dark:text-theme-neutral-200 cursor-pointer px-2 text-base inline-flex items-center font-semibold text-center transition-all duration-100 ease-linear justify-center`}
 
 	&:not(:disabled):hover {
 		${tw`bg-theme-primary text-white rounded`}
@@ -37,12 +37,12 @@ const PaginationButton = styled.div`
 	}
 
 	&.current-page {
-		${tw`bg-theme-primary-light`}
+		${tw`bg-theme-primary-light dark:bg-theme-neutral-600 text-theme-primary-500 dark:text-theme-neutral-200`}
 	}
 `;
 
 const PaginationSearchButton = styled.div`
-	${tw`relative text-theme-primary-500 p-3 cursor-pointer flex flex-nowrap items-center`}
+	${tw`relative text-theme-primary-500 p-3 cursor-pointer flex flex-nowrap items-center dark:text-theme-neutral-200`}
 
 	&:hover {
 		${tw`bg-theme-primary text-white rounded`}
@@ -124,7 +124,7 @@ export const Pagination = ({
 				</Button>
 			)}
 
-			<div className="flex px-2 rounded bg-theme-primary-contrast">
+			<div className="flex px-2 rounded bg-theme-primary-contrast dark:bg-theme-neutral-800">
 				{paginationButtons[0] !== 1 && (
 					<PaginationSearchButton>
 						<span>...</span>

--- a/src/app/components/Pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/src/app/components/Pagination/__snapshots__/Pagination.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Pagination should handle first page click properly 1`] = `
 <DocumentFragment>
   <div
-    class="Pagination__Wrapper-x7juhx-0 hyaceY"
+    class="Pagination__Wrapper-x7juhx-0 chOylR"
     data-testid="Pagination"
   >
     <button
@@ -38,42 +38,42 @@ exports[`Pagination should handle first page click properly 1`] = `
       Previous
     </button>
     <div
-      class="flex px-2 rounded bg-theme-primary-contrast"
+      class="flex px-2 rounded bg-theme-primary-100 dark:bg-theme-neutral-800"
     >
       <div
-        class="Pagination__PaginationSearchButton-x7juhx-2 fUIqyP"
+        class="Pagination__PaginationSearchButton-x7juhx-2 bUpgdG"
       >
         <span>
           ...
         </span>
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
       >
         99
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
       >
         100
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS current-page"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr current-page"
       >
         101
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
       >
         102
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
       >
         103
       </div>
       <div
-        class="Pagination__PaginationSearchButton-x7juhx-2 fUIqyP"
+        class="Pagination__PaginationSearchButton-x7juhx-2 bUpgdG"
       >
         <span>
           ...
@@ -118,49 +118,49 @@ exports[`Pagination should handle first page click properly 1`] = `
 exports[`Pagination should handle last page click properly 1`] = `
 <DocumentFragment>
   <div
-    class="Pagination__Wrapper-x7juhx-0 hyaceY"
+    class="Pagination__Wrapper-x7juhx-0 chOylR"
     data-testid="Pagination"
   >
     <div
-      class="flex px-2 rounded bg-theme-primary-contrast"
+      class="flex px-2 rounded bg-theme-primary-100 dark:bg-theme-neutral-800"
     >
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS current-page"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr current-page"
       >
         1
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
       >
         2
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
       >
         3
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
       >
         4
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
       >
         5
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
       >
         6
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
       >
         7
       </div>
       <div
-        class="Pagination__PaginationSearchButton-x7juhx-2 fUIqyP"
+        class="Pagination__PaginationSearchButton-x7juhx-2 bUpgdG"
       >
         <span>
           ...
@@ -205,7 +205,7 @@ exports[`Pagination should handle last page click properly 1`] = `
 exports[`Pagination should handle next page click properly 1`] = `
 <DocumentFragment>
   <div
-    class="Pagination__Wrapper-x7juhx-0 hyaceY"
+    class="Pagination__Wrapper-x7juhx-0 chOylR"
     data-testid="Pagination"
   >
     <button
@@ -225,20 +225,20 @@ exports[`Pagination should handle next page click properly 1`] = `
       Previous
     </button>
     <div
-      class="flex px-2 rounded bg-theme-primary-contrast"
+      class="flex px-2 rounded bg-theme-primary-100 dark:bg-theme-neutral-800"
     >
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
       >
         1
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS current-page"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr current-page"
       >
         2
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
       >
         3
       </div>
@@ -266,24 +266,24 @@ exports[`Pagination should handle next page click properly 1`] = `
 exports[`Pagination should handle page selection properly 1`] = `
 <DocumentFragment>
   <div
-    class="Pagination__Wrapper-x7juhx-0 hyaceY"
+    class="Pagination__Wrapper-x7juhx-0 chOylR"
     data-testid="Pagination"
   >
     <div
-      class="flex px-2 rounded bg-theme-primary-contrast"
+      class="flex px-2 rounded bg-theme-primary-100 dark:bg-theme-neutral-800"
     >
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS current-page"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr current-page"
       >
         1
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
       >
         2
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
       >
         3
       </div>
@@ -311,7 +311,7 @@ exports[`Pagination should handle page selection properly 1`] = `
 exports[`Pagination should handle previous page click properly 1`] = `
 <DocumentFragment>
   <div
-    class="Pagination__Wrapper-x7juhx-0 hyaceY"
+    class="Pagination__Wrapper-x7juhx-0 chOylR"
     data-testid="Pagination"
   >
     <button
@@ -346,47 +346,47 @@ exports[`Pagination should handle previous page click properly 1`] = `
       Previous
     </button>
     <div
-      class="flex px-2 rounded bg-theme-primary-contrast"
+      class="flex px-2 rounded bg-theme-primary-100 dark:bg-theme-neutral-800"
     >
       <div
-        class="Pagination__PaginationSearchButton-x7juhx-2 fUIqyP"
+        class="Pagination__PaginationSearchButton-x7juhx-2 bUpgdG"
       >
         <span>
           ...
         </span>
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
       >
         4
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
       >
         5
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
       >
         6
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
       >
         7
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
       >
         8
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS current-page"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr current-page"
       >
         9
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
       >
         10
       </div>
@@ -414,49 +414,49 @@ exports[`Pagination should handle previous page click properly 1`] = `
 exports[`Pagination should not render first button if pagination buttons include 1 (first page) 1`] = `
 <DocumentFragment>
   <div
-    class="Pagination__Wrapper-x7juhx-0 hyaceY"
+    class="Pagination__Wrapper-x7juhx-0 chOylR"
     data-testid="Pagination"
   >
     <div
-      class="flex px-2 rounded bg-theme-primary-contrast"
+      class="flex px-2 rounded bg-theme-primary-100 dark:bg-theme-neutral-800"
     >
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS current-page"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr current-page"
       >
         1
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
       >
         2
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
       >
         3
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
       >
         4
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
       >
         5
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
       >
         6
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
       >
         7
       </div>
       <div
-        class="Pagination__PaginationSearchButton-x7juhx-2 fUIqyP"
+        class="Pagination__PaginationSearchButton-x7juhx-2 bUpgdG"
       >
         <span>
           ...
@@ -501,7 +501,7 @@ exports[`Pagination should not render first button if pagination buttons include
 exports[`Pagination should not render first button if pagination buttons include 1 (second page) 1`] = `
 <DocumentFragment>
   <div
-    class="Pagination__Wrapper-x7juhx-0 hyaceY"
+    class="Pagination__Wrapper-x7juhx-0 chOylR"
     data-testid="Pagination"
   >
     <button
@@ -521,45 +521,45 @@ exports[`Pagination should not render first button if pagination buttons include
       Previous
     </button>
     <div
-      class="flex px-2 rounded bg-theme-primary-contrast"
+      class="flex px-2 rounded bg-theme-primary-100 dark:bg-theme-neutral-800"
     >
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
       >
         1
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS current-page"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr current-page"
       >
         2
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
       >
         3
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
       >
         4
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
       >
         5
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
       >
         6
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
       >
         7
       </div>
       <div
-        class="Pagination__PaginationSearchButton-x7juhx-2 fUIqyP"
+        class="Pagination__PaginationSearchButton-x7juhx-2 bUpgdG"
       >
         <span>
           ...
@@ -604,7 +604,7 @@ exports[`Pagination should not render first button if pagination buttons include
 exports[`Pagination should not render first button if pagination buttons include 1 (third page) 1`] = `
 <DocumentFragment>
   <div
-    class="Pagination__Wrapper-x7juhx-0 hyaceY"
+    class="Pagination__Wrapper-x7juhx-0 chOylR"
     data-testid="Pagination"
   >
     <button
@@ -624,45 +624,45 @@ exports[`Pagination should not render first button if pagination buttons include
       Previous
     </button>
     <div
-      class="flex px-2 rounded bg-theme-primary-contrast"
+      class="flex px-2 rounded bg-theme-primary-100 dark:bg-theme-neutral-800"
     >
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
       >
         1
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
       >
         2
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS current-page"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr current-page"
       >
         3
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
       >
         4
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
       >
         5
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
       >
         6
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
       >
         7
       </div>
       <div
-        class="Pagination__PaginationSearchButton-x7juhx-2 fUIqyP"
+        class="Pagination__PaginationSearchButton-x7juhx-2 bUpgdG"
       >
         <span>
           ...
@@ -707,7 +707,7 @@ exports[`Pagination should not render first button if pagination buttons include
 exports[`Pagination should not render first button if pagination buttons include the last page (last page) 1`] = `
 <DocumentFragment>
   <div
-    class="Pagination__Wrapper-x7juhx-0 hyaceY"
+    class="Pagination__Wrapper-x7juhx-0 chOylR"
     data-testid="Pagination"
   >
     <button
@@ -742,47 +742,47 @@ exports[`Pagination should not render first button if pagination buttons include
       Previous
     </button>
     <div
-      class="flex px-2 rounded bg-theme-primary-contrast"
+      class="flex px-2 rounded bg-theme-primary-100 dark:bg-theme-neutral-800"
     >
       <div
-        class="Pagination__PaginationSearchButton-x7juhx-2 fUIqyP"
+        class="Pagination__PaginationSearchButton-x7juhx-2 bUpgdG"
       >
         <span>
           ...
         </span>
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
       >
         4
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
       >
         5
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
       >
         6
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
       >
         7
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
       >
         8
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
       >
         9
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS current-page"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr current-page"
       >
         10
       </div>
@@ -794,7 +794,7 @@ exports[`Pagination should not render first button if pagination buttons include
 exports[`Pagination should not render first button if pagination buttons include the last page (second-to-last page) 1`] = `
 <DocumentFragment>
   <div
-    class="Pagination__Wrapper-x7juhx-0 hyaceY"
+    class="Pagination__Wrapper-x7juhx-0 chOylR"
     data-testid="Pagination"
   >
     <button
@@ -829,47 +829,47 @@ exports[`Pagination should not render first button if pagination buttons include
       Previous
     </button>
     <div
-      class="flex px-2 rounded bg-theme-primary-contrast"
+      class="flex px-2 rounded bg-theme-primary-100 dark:bg-theme-neutral-800"
     >
       <div
-        class="Pagination__PaginationSearchButton-x7juhx-2 fUIqyP"
+        class="Pagination__PaginationSearchButton-x7juhx-2 bUpgdG"
       >
         <span>
           ...
         </span>
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
       >
         4
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
       >
         5
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
       >
         6
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
       >
         7
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
       >
         8
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS current-page"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr current-page"
       >
         9
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
       >
         10
       </div>
@@ -897,7 +897,7 @@ exports[`Pagination should not render first button if pagination buttons include
 exports[`Pagination should not render first button if pagination buttons include the last page (third-to-last page) 1`] = `
 <DocumentFragment>
   <div
-    class="Pagination__Wrapper-x7juhx-0 hyaceY"
+    class="Pagination__Wrapper-x7juhx-0 chOylR"
     data-testid="Pagination"
   >
     <button
@@ -932,47 +932,47 @@ exports[`Pagination should not render first button if pagination buttons include
       Previous
     </button>
     <div
-      class="flex px-2 rounded bg-theme-primary-contrast"
+      class="flex px-2 rounded bg-theme-primary-100 dark:bg-theme-neutral-800"
     >
       <div
-        class="Pagination__PaginationSearchButton-x7juhx-2 fUIqyP"
+        class="Pagination__PaginationSearchButton-x7juhx-2 bUpgdG"
       >
         <span>
           ...
         </span>
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
       >
         4
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
       >
         5
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
       >
         6
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
       >
         7
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS current-page"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr current-page"
       >
         8
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
       >
         9
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
       >
         10
       </div>
@@ -1000,7 +1000,7 @@ exports[`Pagination should not render first button if pagination buttons include
 exports[`Pagination should not render next button on last page 1`] = `
 <DocumentFragment>
   <div
-    class="Pagination__Wrapper-x7juhx-0 hyaceY"
+    class="Pagination__Wrapper-x7juhx-0 chOylR"
     data-testid="Pagination"
   >
     <button
@@ -1035,47 +1035,47 @@ exports[`Pagination should not render next button on last page 1`] = `
       Previous
     </button>
     <div
-      class="flex px-2 rounded bg-theme-primary-contrast"
+      class="flex px-2 rounded bg-theme-primary-100 dark:bg-theme-neutral-800"
     >
       <div
-        class="Pagination__PaginationSearchButton-x7juhx-2 fUIqyP"
+        class="Pagination__PaginationSearchButton-x7juhx-2 bUpgdG"
       >
         <span>
           ...
         </span>
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
       >
         4
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
       >
         5
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
       >
         6
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
       >
         7
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
       >
         8
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
       >
         9
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS current-page"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr current-page"
       >
         10
       </div>
@@ -1087,49 +1087,49 @@ exports[`Pagination should not render next button on last page 1`] = `
 exports[`Pagination should not render previous buttons on first page 1`] = `
 <DocumentFragment>
   <div
-    class="Pagination__Wrapper-x7juhx-0 hyaceY"
+    class="Pagination__Wrapper-x7juhx-0 chOylR"
     data-testid="Pagination"
   >
     <div
-      class="flex px-2 rounded bg-theme-primary-contrast"
+      class="flex px-2 rounded bg-theme-primary-100 dark:bg-theme-neutral-800"
     >
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS current-page"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr current-page"
       >
         1
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
       >
         2
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
       >
         3
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
       >
         4
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
       >
         5
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
       >
         6
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
       >
         7
       </div>
       <div
-        class="Pagination__PaginationSearchButton-x7juhx-2 fUIqyP"
+        class="Pagination__PaginationSearchButton-x7juhx-2 bUpgdG"
       >
         <span>
           ...
@@ -1174,24 +1174,24 @@ exports[`Pagination should not render previous buttons on first page 1`] = `
 exports[`Pagination should render 1`] = `
 <DocumentFragment>
   <div
-    class="Pagination__Wrapper-x7juhx-0 hyaceY"
+    class="Pagination__Wrapper-x7juhx-0 chOylR"
     data-testid="Pagination"
   >
     <div
-      class="flex px-2 rounded bg-theme-primary-contrast"
+      class="flex px-2 rounded bg-theme-primary-100 dark:bg-theme-neutral-800"
     >
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS current-page"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr current-page"
       >
         1
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
       >
         2
       </div>
       <div
-        class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+        class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
       >
         3
       </div>

--- a/src/domains/news/pages/News/__snapshots__/News.test.tsx.snap
+++ b/src/domains/news/pages/News/__snapshots__/News.test.tsx.snap
@@ -491,14 +491,14 @@ exports[`News should filter results based on category query and asset 1`] = `
                 class="flex justify-center w-full"
               >
                 <div
-                  class="Pagination__Wrapper-x7juhx-0 hyaceY"
+                  class="Pagination__Wrapper-x7juhx-0 chOylR"
                   data-testid="Pagination"
                 >
                   <div
-                    class="flex px-2 rounded bg-theme-primary-contrast"
+                    class="flex px-2 rounded bg-theme-primary-100 dark:bg-theme-neutral-800"
                   >
                     <div
-                      class="Pagination__PaginationButton-x7juhx-1 gpUeNS current-page"
+                      class="Pagination__PaginationButton-x7juhx-1 dMKNhr current-page"
                     >
                       1
                     </div>
@@ -1288,49 +1288,49 @@ exports[`News should filter results based on category query and asset 2`] = `
                 class="flex justify-center w-full"
               >
                 <div
-                  class="Pagination__Wrapper-x7juhx-0 hyaceY"
+                  class="Pagination__Wrapper-x7juhx-0 chOylR"
                   data-testid="Pagination"
                 >
                   <div
-                    class="flex px-2 rounded bg-theme-primary-contrast"
+                    class="flex px-2 rounded bg-theme-primary-100 dark:bg-theme-neutral-800"
                   >
                     <div
-                      class="Pagination__PaginationButton-x7juhx-1 gpUeNS current-page"
+                      class="Pagination__PaginationButton-x7juhx-1 dMKNhr current-page"
                     >
                       1
                     </div>
                     <div
-                      class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+                      class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
                     >
                       2
                     </div>
                     <div
-                      class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+                      class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
                     >
                       3
                     </div>
                     <div
-                      class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+                      class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
                     >
                       4
                     </div>
                     <div
-                      class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+                      class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
                     >
                       5
                     </div>
                     <div
-                      class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+                      class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
                     >
                       6
                     </div>
                     <div
-                      class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+                      class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
                     >
                       7
                     </div>
                     <div
-                      class="Pagination__PaginationSearchButton-x7juhx-2 fUIqyP"
+                      class="Pagination__PaginationSearchButton-x7juhx-2 bUpgdG"
                     >
                       <span>
                         ...

--- a/src/domains/plugin/components/Comments/__snapshots__/Comments.test.tsx.snap
+++ b/src/domains/plugin/components/Comments/__snapshots__/Comments.test.tsx.snap
@@ -427,24 +427,24 @@ exports[`Comments should render properly 1`] = `
       class="mt-7"
     >
       <div
-        class="Pagination__Wrapper-x7juhx-0 hyaceY"
+        class="Pagination__Wrapper-x7juhx-0 chOylR"
         data-testid="Pagination"
       >
         <div
-          class="flex px-2 rounded bg-theme-primary-contrast"
+          class="flex px-2 rounded bg-theme-primary-100 dark:bg-theme-neutral-800"
         >
           <div
-            class="Pagination__PaginationButton-x7juhx-1 gpUeNS current-page"
+            class="Pagination__PaginationButton-x7juhx-1 dMKNhr current-page"
           >
             1
           </div>
           <div
-            class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+            class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
           >
             2
           </div>
           <div
-            class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+            class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
           >
             3
           </div>

--- a/src/domains/plugin/components/PluginGrid/__snapshots__/PluginGrid.test.tsx.snap
+++ b/src/domains/plugin/components/PluginGrid/__snapshots__/PluginGrid.test.tsx.snap
@@ -197,14 +197,14 @@ exports[`PluginGrid should render 1`] = `
       class="flex justify-center mt-4"
     >
       <div
-        class="Pagination__Wrapper-x7juhx-0 hyaceY mt-5"
+        class="Pagination__Wrapper-x7juhx-0 chOylR mt-5"
         data-testid="Pagination"
       >
         <div
-          class="flex px-2 rounded bg-theme-primary-contrast"
+          class="flex px-2 rounded bg-theme-primary-100 dark:bg-theme-neutral-800"
         >
           <div
-            class="Pagination__PaginationButton-x7juhx-1 gpUeNS current-page"
+            class="Pagination__PaginationButton-x7juhx-1 dMKNhr current-page"
           >
             1
           </div>
@@ -531,7 +531,7 @@ exports[`PluginGrid should split by page 1`] = `
       class="flex justify-center mt-4"
     >
       <div
-        class="Pagination__Wrapper-x7juhx-0 hyaceY mt-5"
+        class="Pagination__Wrapper-x7juhx-0 chOylR mt-5"
         data-testid="Pagination"
       >
         <button
@@ -551,15 +551,15 @@ exports[`PluginGrid should split by page 1`] = `
           Previous
         </button>
         <div
-          class="flex px-2 rounded bg-theme-primary-contrast"
+          class="flex px-2 rounded bg-theme-primary-100 dark:bg-theme-neutral-800"
         >
           <div
-            class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+            class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
           >
             1
           </div>
           <div
-            class="Pagination__PaginationButton-x7juhx-1 gpUeNS current-page"
+            class="Pagination__PaginationButton-x7juhx-1 dMKNhr current-page"
           >
             2
           </div>
@@ -767,14 +767,14 @@ exports[`PluginGrid should trigger delete 1`] = `
       class="flex justify-center mt-4"
     >
       <div
-        class="Pagination__Wrapper-x7juhx-0 hyaceY mt-5"
+        class="Pagination__Wrapper-x7juhx-0 chOylR mt-5"
         data-testid="Pagination"
       >
         <div
-          class="flex px-2 rounded bg-theme-primary-contrast"
+          class="flex px-2 rounded bg-theme-primary-100 dark:bg-theme-neutral-800"
         >
           <div
-            class="Pagination__PaginationButton-x7juhx-1 gpUeNS current-page"
+            class="Pagination__PaginationButton-x7juhx-1 dMKNhr current-page"
           >
             1
           </div>
@@ -982,14 +982,14 @@ exports[`PluginGrid should trigger select 1`] = `
       class="flex justify-center mt-4"
     >
       <div
-        class="Pagination__Wrapper-x7juhx-0 hyaceY mt-5"
+        class="Pagination__Wrapper-x7juhx-0 chOylR mt-5"
         data-testid="Pagination"
       >
         <div
-          class="flex px-2 rounded bg-theme-primary-contrast"
+          class="flex px-2 rounded bg-theme-primary-100 dark:bg-theme-neutral-800"
         >
           <div
-            class="Pagination__PaginationButton-x7juhx-1 gpUeNS current-page"
+            class="Pagination__PaginationButton-x7juhx-1 dMKNhr current-page"
           >
             1
           </div>

--- a/src/domains/plugin/components/PluginList/__snapshots__/PluginList.test.tsx.snap
+++ b/src/domains/plugin/components/PluginList/__snapshots__/PluginList.test.tsx.snap
@@ -563,14 +563,14 @@ exports[`PluginList should render 1`] = `
       class="flex justify-center"
     >
       <div
-        class="Pagination__Wrapper-x7juhx-0 hyaceY mt-5"
+        class="Pagination__Wrapper-x7juhx-0 chOylR mt-5"
         data-testid="Pagination"
       >
         <div
-          class="flex px-2 rounded bg-theme-primary-contrast"
+          class="flex px-2 rounded bg-theme-primary-100 dark:bg-theme-neutral-800"
         >
           <div
-            class="Pagination__PaginationButton-x7juhx-1 gpUeNS current-page"
+            class="Pagination__PaginationButton-x7juhx-1 dMKNhr current-page"
           >
             1
           </div>
@@ -1559,7 +1559,7 @@ exports[`PluginList should split by page 1`] = `
       class="flex justify-center"
     >
       <div
-        class="Pagination__Wrapper-x7juhx-0 hyaceY mt-5"
+        class="Pagination__Wrapper-x7juhx-0 chOylR mt-5"
         data-testid="Pagination"
       >
         <button
@@ -1579,15 +1579,15 @@ exports[`PluginList should split by page 1`] = `
           Previous
         </button>
         <div
-          class="flex px-2 rounded bg-theme-primary-contrast"
+          class="flex px-2 rounded bg-theme-primary-100 dark:bg-theme-neutral-800"
         >
           <div
-            class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+            class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
           >
             1
           </div>
           <div
-            class="Pagination__PaginationButton-x7juhx-1 gpUeNS current-page"
+            class="Pagination__PaginationButton-x7juhx-1 dMKNhr current-page"
           >
             2
           </div>
@@ -2161,14 +2161,14 @@ exports[`PluginList should trigger delete 1`] = `
       class="flex justify-center"
     >
       <div
-        class="Pagination__Wrapper-x7juhx-0 hyaceY mt-5"
+        class="Pagination__Wrapper-x7juhx-0 chOylR mt-5"
         data-testid="Pagination"
       >
         <div
-          class="flex px-2 rounded bg-theme-primary-contrast"
+          class="flex px-2 rounded bg-theme-primary-100 dark:bg-theme-neutral-800"
         >
           <div
-            class="Pagination__PaginationButton-x7juhx-1 gpUeNS current-page"
+            class="Pagination__PaginationButton-x7juhx-1 dMKNhr current-page"
           >
             1
           </div>
@@ -2742,14 +2742,14 @@ exports[`PluginList should trigger install 1`] = `
       class="flex justify-center"
     >
       <div
-        class="Pagination__Wrapper-x7juhx-0 hyaceY mt-5"
+        class="Pagination__Wrapper-x7juhx-0 chOylR mt-5"
         data-testid="Pagination"
       >
         <div
-          class="flex px-2 rounded bg-theme-primary-contrast"
+          class="flex px-2 rounded bg-theme-primary-100 dark:bg-theme-neutral-800"
         >
           <div
-            class="Pagination__PaginationButton-x7juhx-1 gpUeNS current-page"
+            class="Pagination__PaginationButton-x7juhx-1 dMKNhr current-page"
           >
             1
           </div>

--- a/src/domains/plugin/pages/PluginDetails/__snapshots__/PluginDetails.test.tsx.snap
+++ b/src/domains/plugin/pages/PluginDetails/__snapshots__/PluginDetails.test.tsx.snap
@@ -1141,24 +1141,24 @@ exports[`PluginDetails should render properly 1`] = `
                     class="mt-7"
                   >
                     <div
-                      class="Pagination__Wrapper-x7juhx-0 hyaceY"
+                      class="Pagination__Wrapper-x7juhx-0 chOylR"
                       data-testid="Pagination"
                     >
                       <div
-                        class="flex px-2 rounded bg-theme-primary-contrast"
+                        class="flex px-2 rounded bg-theme-primary-100 dark:bg-theme-neutral-800"
                       >
                         <div
-                          class="Pagination__PaginationButton-x7juhx-1 gpUeNS current-page"
+                          class="Pagination__PaginationButton-x7juhx-1 dMKNhr current-page"
                         >
                           1
                         </div>
                         <div
-                          class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+                          class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
                         >
                           2
                         </div>
                         <div
-                          class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+                          class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
                         >
                           3
                         </div>
@@ -2678,24 +2678,24 @@ exports[`PluginDetails should render properly as installed 1`] = `
                     class="mt-7"
                   >
                     <div
-                      class="Pagination__Wrapper-x7juhx-0 hyaceY"
+                      class="Pagination__Wrapper-x7juhx-0 chOylR"
                       data-testid="Pagination"
                     >
                       <div
-                        class="flex px-2 rounded bg-theme-primary-contrast"
+                        class="flex px-2 rounded bg-theme-primary-100 dark:bg-theme-neutral-800"
                       >
                         <div
-                          class="Pagination__PaginationButton-x7juhx-1 gpUeNS current-page"
+                          class="Pagination__PaginationButton-x7juhx-1 dMKNhr current-page"
                         >
                           1
                         </div>
                         <div
-                          class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+                          class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
                         >
                           2
                         </div>
                         <div
-                          class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+                          class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
                         >
                           3
                         </div>

--- a/src/domains/plugin/pages/PluginManager/__snapshots__/PluginManager.test.tsx.snap
+++ b/src/domains/plugin/pages/PluginManager/__snapshots__/PluginManager.test.tsx.snap
@@ -11065,14 +11065,14 @@ exports[`PluginManager should delete plugin on game 1`] = `
                 class="flex justify-center"
               >
                 <div
-                  class="Pagination__Wrapper-x7juhx-0 hyaceY mt-5"
+                  class="Pagination__Wrapper-x7juhx-0 chOylR mt-5"
                   data-testid="Pagination"
                 >
                   <div
-                    class="flex px-2 rounded bg-theme-primary-contrast"
+                    class="flex px-2 rounded bg-theme-primary-100 dark:bg-theme-neutral-800"
                   >
                     <div
-                      class="Pagination__PaginationButton-x7juhx-1 gpUeNS current-page"
+                      class="Pagination__PaginationButton-x7juhx-1 dMKNhr current-page"
                     >
                       1
                     </div>
@@ -15502,14 +15502,14 @@ exports[`PluginManager should download & install plugin on game 1`] = `
                 class="flex justify-center"
               >
                 <div
-                  class="Pagination__Wrapper-x7juhx-0 hyaceY mt-5"
+                  class="Pagination__Wrapper-x7juhx-0 chOylR mt-5"
                   data-testid="Pagination"
                 >
                   <div
-                    class="flex px-2 rounded bg-theme-primary-contrast"
+                    class="flex px-2 rounded bg-theme-primary-100 dark:bg-theme-neutral-800"
                   >
                     <div
-                      class="Pagination__PaginationButton-x7juhx-1 gpUeNS current-page"
+                      class="Pagination__PaginationButton-x7juhx-1 dMKNhr current-page"
                     >
                       1
                     </div>
@@ -29461,14 +29461,14 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
                   class="flex justify-center mt-4"
                 >
                   <div
-                    class="Pagination__Wrapper-x7juhx-0 hyaceY mt-5"
+                    class="Pagination__Wrapper-x7juhx-0 chOylR mt-5"
                     data-testid="Pagination"
                   >
                     <div
-                      class="flex px-2 rounded bg-theme-primary-contrast"
+                      class="flex px-2 rounded bg-theme-primary-100 dark:bg-theme-neutral-800"
                     >
                       <div
-                        class="Pagination__PaginationButton-x7juhx-1 gpUeNS current-page"
+                        class="Pagination__PaginationButton-x7juhx-1 dMKNhr current-page"
                       >
                         1
                       </div>

--- a/src/domains/plugin/pages/PluginsCategory/__snapshots__/PluginsCategory.test.tsx.snap
+++ b/src/domains/plugin/pages/PluginsCategory/__snapshots__/PluginsCategory.test.tsx.snap
@@ -1784,14 +1784,14 @@ exports[`PluginsCategory should cancel install plugin 1`] = `
                   class="flex justify-center"
                 >
                   <div
-                    class="Pagination__Wrapper-x7juhx-0 hyaceY mt-5"
+                    class="Pagination__Wrapper-x7juhx-0 chOylR mt-5"
                     data-testid="Pagination"
                   >
                     <div
-                      class="flex px-2 rounded bg-theme-primary-contrast"
+                      class="flex px-2 rounded bg-theme-primary-100 dark:bg-theme-neutral-800"
                     >
                       <div
-                        class="Pagination__PaginationButton-x7juhx-1 gpUeNS current-page"
+                        class="Pagination__PaginationButton-x7juhx-1 dMKNhr current-page"
                       >
                         1
                       </div>
@@ -3592,14 +3592,14 @@ exports[`PluginsCategory should close install plugin modal 1`] = `
                   class="flex justify-center"
                 >
                   <div
-                    class="Pagination__Wrapper-x7juhx-0 hyaceY mt-5"
+                    class="Pagination__Wrapper-x7juhx-0 chOylR mt-5"
                     data-testid="Pagination"
                   >
                     <div
-                      class="flex px-2 rounded bg-theme-primary-contrast"
+                      class="flex px-2 rounded bg-theme-primary-100 dark:bg-theme-neutral-800"
                     >
                       <div
-                        class="Pagination__PaginationButton-x7juhx-1 gpUeNS current-page"
+                        class="Pagination__PaginationButton-x7juhx-1 dMKNhr current-page"
                       >
                         1
                       </div>
@@ -6506,14 +6506,14 @@ exports[`PluginsCategory should download & install plugin 1`] = `
                   class="flex justify-center"
                 >
                   <div
-                    class="Pagination__Wrapper-x7juhx-0 hyaceY mt-5"
+                    class="Pagination__Wrapper-x7juhx-0 chOylR mt-5"
                     data-testid="Pagination"
                   >
                     <div
-                      class="flex px-2 rounded bg-theme-primary-contrast"
+                      class="flex px-2 rounded bg-theme-primary-100 dark:bg-theme-neutral-800"
                     >
                       <div
-                        class="Pagination__PaginationButton-x7juhx-1 gpUeNS current-page"
+                        class="Pagination__PaginationButton-x7juhx-1 dMKNhr current-page"
                       >
                         1
                       </div>
@@ -13093,14 +13093,14 @@ exports[`PluginsCategory should toggle between grid and list 1`] = `
                   class="flex justify-center"
                 >
                   <div
-                    class="Pagination__Wrapper-x7juhx-0 hyaceY mt-5"
+                    class="Pagination__Wrapper-x7juhx-0 chOylR mt-5"
                     data-testid="Pagination"
                   >
                     <div
-                      class="flex px-2 rounded bg-theme-primary-contrast"
+                      class="flex px-2 rounded bg-theme-primary-100 dark:bg-theme-neutral-800"
                     >
                       <div
-                        class="Pagination__PaginationButton-x7juhx-1 gpUeNS current-page"
+                        class="Pagination__PaginationButton-x7juhx-1 dMKNhr current-page"
                       >
                         1
                       </div>

--- a/src/domains/vote/components/DelegateTable/__snapshots__/DelegateTable.test.tsx.snap
+++ b/src/domains/vote/components/DelegateTable/__snapshots__/DelegateTable.test.tsx.snap
@@ -4223,24 +4223,24 @@ exports[`DelegateTable should render pagination 1`] = `
       class="flex justify-center mt-10 mb-24 w-full"
     >
       <div
-        class="Pagination__Wrapper-x7juhx-0 hyaceY"
+        class="Pagination__Wrapper-x7juhx-0 chOylR"
         data-testid="Pagination"
       >
         <div
-          class="flex px-2 rounded bg-theme-primary-contrast"
+          class="flex px-2 rounded bg-theme-primary-100 dark:bg-theme-neutral-800"
         >
           <div
-            class="Pagination__PaginationButton-x7juhx-1 gpUeNS current-page"
+            class="Pagination__PaginationButton-x7juhx-1 dMKNhr current-page"
           >
             1
           </div>
           <div
-            class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+            class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
           >
             2
           </div>
           <div
-            class="Pagination__PaginationButton-x7juhx-1 gpUeNS"
+            class="Pagination__PaginationButton-x7juhx-1 dMKNhr"
           >
             3
           </div>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/cgv4ag

TODO:

- [x] figure out why button styling overwrites dark styling
- [x] replace light / contrast with proper numerical color values
- [x] update snapshots

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [x] My changes look good in both light AND dark mode
-   [x] The change is not hardcoded to a single network, but has multi-asset in mind
-   [x] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
