### PR TITLE
fix: adjust border color in WalletsControls

### DIFF
--- a/src/domains/dashboard/components/Wallets/__snapshots__/Wallets.test.tsx.snap
+++ b/src/domains/dashboard/components/Wallets/__snapshots__/Wallets.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`Wallets should load more wallets 1`] = `
             data-testid="WalletControls"
           >
             <div
-              class="flex items-center pr-5 mr-5 border-r border-theme-primary-300 dark:border-theme-secondary-800"
+              class="flex items-center pr-5 mr-5 border-r border-theme-secondary-300 dark:border-theme-secondary-800"
             >
               <div
                 class="flex items-center space-x-1"
@@ -68,7 +68,7 @@ exports[`Wallets should load more wallets 1`] = `
               </div>
             </div>
             <div
-              class="flex relative items-center pr-5 mr-8 border-r text-theme-primary-400 border-theme-primary-300 dark:border-theme-secondary-800"
+              class="flex relative items-center pr-5 mr-8 border-r text-theme-primary-400 border-theme-secondary-300 dark:border-theme-secondary-800"
             >
               <div
                 class="relative"
@@ -603,7 +603,7 @@ exports[`Wallets should open and close ledger import modal 1`] = `
             data-testid="WalletControls"
           >
             <div
-              class="flex items-center pr-5 mr-5 border-r border-theme-primary-300 dark:border-theme-secondary-800"
+              class="flex items-center pr-5 mr-5 border-r border-theme-secondary-300 dark:border-theme-secondary-800"
             >
               <div
                 class="flex items-center space-x-1"
@@ -649,7 +649,7 @@ exports[`Wallets should open and close ledger import modal 1`] = `
               </div>
             </div>
             <div
-              class="flex relative items-center pr-5 mr-8 border-r text-theme-primary-400 border-theme-primary-300 dark:border-theme-secondary-800"
+              class="flex relative items-center pr-5 mr-8 border-r text-theme-primary-400 border-theme-secondary-300 dark:border-theme-secondary-800"
             >
               <div
                 class="relative"
@@ -1258,7 +1258,7 @@ exports[`Wallets should render empty profile wallets 1`] = `
             data-testid="WalletControls"
           >
             <div
-              class="flex items-center pr-5 mr-5 border-r border-theme-primary-300 dark:border-theme-secondary-800"
+              class="flex items-center pr-5 mr-5 border-r border-theme-secondary-300 dark:border-theme-secondary-800"
             >
               <div
                 class="flex items-center space-x-1"
@@ -1304,7 +1304,7 @@ exports[`Wallets should render empty profile wallets 1`] = `
               </div>
             </div>
             <div
-              class="flex relative items-center pr-5 mr-8 border-r text-theme-primary-400 border-theme-primary-300 dark:border-theme-secondary-800"
+              class="flex relative items-center pr-5 mr-8 border-r text-theme-primary-400 border-theme-secondary-300 dark:border-theme-secondary-800"
             >
               <div
                 class="relative"
@@ -1448,7 +1448,7 @@ exports[`Wallets should render grid 1`] = `
             data-testid="WalletControls"
           >
             <div
-              class="flex items-center pr-5 mr-5 border-r border-theme-primary-300 dark:border-theme-secondary-800"
+              class="flex items-center pr-5 mr-5 border-r border-theme-secondary-300 dark:border-theme-secondary-800"
             >
               <div
                 class="flex items-center space-x-1"
@@ -1494,7 +1494,7 @@ exports[`Wallets should render grid 1`] = `
               </div>
             </div>
             <div
-              class="flex relative items-center pr-5 mr-8 border-r text-theme-primary-400 border-theme-primary-300 dark:border-theme-secondary-800"
+              class="flex relative items-center pr-5 mr-8 border-r text-theme-primary-400 border-theme-secondary-300 dark:border-theme-secondary-800"
             >
               <div
                 class="relative"
@@ -1871,7 +1871,7 @@ exports[`Wallets should render list 1`] = `
             data-testid="WalletControls"
           >
             <div
-              class="flex items-center pr-5 mr-5 border-r border-theme-primary-300 dark:border-theme-secondary-800"
+              class="flex items-center pr-5 mr-5 border-r border-theme-secondary-300 dark:border-theme-secondary-800"
             >
               <div
                 class="flex items-center space-x-1"
@@ -1917,7 +1917,7 @@ exports[`Wallets should render list 1`] = `
               </div>
             </div>
             <div
-              class="flex relative items-center pr-5 mr-8 border-r text-theme-primary-400 border-theme-primary-300 dark:border-theme-secondary-800"
+              class="flex relative items-center pr-5 mr-8 border-r text-theme-primary-400 border-theme-secondary-300 dark:border-theme-secondary-800"
             >
               <div
                 class="relative"
@@ -2452,7 +2452,7 @@ exports[`Wallets should render without testnet wallets 1`] = `
             data-testid="WalletControls"
           >
             <div
-              class="flex items-center pr-5 mr-5 border-r border-theme-primary-300 dark:border-theme-secondary-800"
+              class="flex items-center pr-5 mr-5 border-r border-theme-secondary-300 dark:border-theme-secondary-800"
             >
               <div
                 class="flex items-center space-x-1"
@@ -2498,7 +2498,7 @@ exports[`Wallets should render without testnet wallets 1`] = `
               </div>
             </div>
             <div
-              class="flex relative items-center pr-5 mr-8 border-r text-theme-primary-400 border-theme-primary-300 dark:border-theme-secondary-800"
+              class="flex relative items-center pr-5 mr-8 border-r text-theme-primary-400 border-theme-secondary-300 dark:border-theme-secondary-800"
             >
               <div
                 class="relative"
@@ -2807,7 +2807,7 @@ exports[`Wallets should toggle between grid and list view 1`] = `
             data-testid="WalletControls"
           >
             <div
-              class="flex items-center pr-5 mr-5 border-r border-theme-primary-300 dark:border-theme-secondary-800"
+              class="flex items-center pr-5 mr-5 border-r border-theme-secondary-300 dark:border-theme-secondary-800"
             >
               <div
                 class="flex items-center space-x-1"
@@ -2853,7 +2853,7 @@ exports[`Wallets should toggle between grid and list view 1`] = `
               </div>
             </div>
             <div
-              class="flex relative items-center pr-5 mr-8 border-r text-theme-primary-400 border-theme-primary-300 dark:border-theme-secondary-800"
+              class="flex relative items-center pr-5 mr-8 border-r text-theme-primary-400 border-theme-secondary-300 dark:border-theme-secondary-800"
             >
               <div
                 class="relative"

--- a/src/domains/dashboard/components/WalletsControls/WalletsControls.tsx
+++ b/src/domains/dashboard/components/WalletsControls/WalletsControls.tsx
@@ -46,7 +46,7 @@ export const WalletsControls = memo(
 
 		return (
 			<div data-testid="WalletControls" className="flex justify-end">
-				<div className="flex items-center pr-5 mr-5 border-r border-theme-primary-300 dark:border-theme-secondary-800">
+				<div className="flex items-center pr-5 mr-5 border-r border-theme-secondary-300 dark:border-theme-secondary-800">
 					<LayoutControls
 						onSelectGridView={onClickGridView}
 						onSelectListView={onClickListview}
@@ -54,7 +54,7 @@ export const WalletsControls = memo(
 					/>
 				</div>
 
-				<div className="flex relative items-center pr-5 mr-8 border-r text-theme-primary-400 border-theme-primary-300 dark:border-theme-secondary-800">
+				<div className="flex relative items-center pr-5 mr-8 border-r text-theme-primary-400 border-theme-secondary-300 dark:border-theme-secondary-800">
 					<Dropdown
 						dropdownClass="transform -translate-y-4"
 						toggleContent={

--- a/src/domains/dashboard/components/WalletsControls/__snapshots__/WalletsControls.test.tsx.snap
+++ b/src/domains/dashboard/components/WalletsControls/__snapshots__/WalletsControls.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`WalletsControls should render 1`] = `
     data-testid="WalletControls"
   >
     <div
-      class="flex items-center pr-5 mr-5 border-r border-theme-primary-300 dark:border-theme-secondary-800"
+      class="flex items-center pr-5 mr-5 border-r border-theme-secondary-300 dark:border-theme-secondary-800"
     >
       <div
         class="flex items-center space-x-1"
@@ -53,7 +53,7 @@ exports[`WalletsControls should render 1`] = `
       </div>
     </div>
     <div
-      class="flex relative items-center pr-5 mr-8 border-r text-theme-primary-400 border-theme-primary-300 dark:border-theme-secondary-800"
+      class="flex relative items-center pr-5 mr-8 border-r text-theme-primary-400 border-theme-secondary-300 dark:border-theme-secondary-800"
     >
       <div
         class="relative"
@@ -162,7 +162,7 @@ exports[`WalletsControls should render with networks selection 1`] = `
     data-testid="WalletControls"
   >
     <div
-      class="flex items-center pr-5 mr-5 border-r border-theme-primary-300 dark:border-theme-secondary-800"
+      class="flex items-center pr-5 mr-5 border-r border-theme-secondary-300 dark:border-theme-secondary-800"
     >
       <div
         class="flex items-center space-x-1"
@@ -208,7 +208,7 @@ exports[`WalletsControls should render with networks selection 1`] = `
       </div>
     </div>
     <div
-      class="flex relative items-center pr-5 mr-8 border-r text-theme-primary-400 border-theme-primary-300 dark:border-theme-secondary-800"
+      class="flex relative items-center pr-5 mr-8 border-r text-theme-primary-400 border-theme-secondary-300 dark:border-theme-secondary-800"
     >
       <div
         class="relative"

--- a/src/domains/dashboard/pages/Dashboard/__snapshots__/Dashboard.test.tsx.snap
+++ b/src/domains/dashboard/pages/Dashboard/__snapshots__/Dashboard.test.tsx.snap
@@ -290,7 +290,7 @@ exports[`Dashboard should render 1`] = `
                 data-testid="WalletControls"
               >
                 <div
-                  class="flex items-center pr-5 mr-5 border-r border-theme-primary-300 dark:border-theme-secondary-800"
+                  class="flex items-center pr-5 mr-5 border-r border-theme-secondary-300 dark:border-theme-secondary-800"
                 >
                   <div
                     class="flex items-center space-x-1"
@@ -336,7 +336,7 @@ exports[`Dashboard should render 1`] = `
                   </div>
                 </div>
                 <div
-                  class="flex relative items-center pr-5 mr-8 border-r text-theme-primary-400 border-theme-primary-300 dark:border-theme-secondary-800"
+                  class="flex relative items-center pr-5 mr-8 border-r text-theme-primary-400 border-theme-secondary-300 dark:border-theme-secondary-800"
                 >
                   <div
                     class="relative"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Fixes the border color in the `WalletsControls` component.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [x] My changes look good in both light AND dark mode
-   [x] The change is not hardcoded to a single network, but has multi-asset in mind
-   [x] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
