### PR TITLE
fix: ensure transaction fees are synced and available

### DIFF
--- a/src/app/hooks/index.ts
+++ b/src/app/hooks/index.ts
@@ -7,6 +7,7 @@ export * from "./use-clipboard";
 export * from "./use-currency-display";
 export * from "./use-deeplink";
 export * from "./use-env-synchronizer";
+export * from "./use-fees";
 export * from "./use-previous";
 export * from "./use-profile-synchronizer";
 export * from "./use-query-params";

--- a/src/app/hooks/use-fees.test.tsx
+++ b/src/app/hooks/use-fees.test.tsx
@@ -1,0 +1,93 @@
+import { ARK } from "@arkecosystem/platform-sdk-ark";
+import { renderHook } from "@testing-library/react-hooks";
+import { EnvironmentProvider } from "app/contexts";
+import { httpClient } from "app/services";
+import React from "react";
+import { StubStorage } from "tests/mocks";
+import { env, getDefaultProfileId } from "utils/testing-library";
+
+import { useFees } from "./use-fees";
+
+describe("useFees", () => {
+	it("should not modify fees if they have proper values", () => {
+		const fees = {
+			min: "2",
+			max: "4",
+			avg: "3",
+			static: "2",
+		};
+
+		const wrapper = ({ children }: any) => <EnvironmentProvider env={env}>{children} </EnvironmentProvider>;
+		const {
+			result: { current },
+		} = renderHook(() => useFees(), { wrapper });
+
+		expect(current.formatWithDefaultStatic(fees)).toEqual({
+			min: "2",
+			max: "4",
+			avg: "3",
+			static: "2",
+		});
+	});
+
+	it("should fallback to static fee if min,max,avg are zero", () => {
+		const fees = {
+			min: "0",
+			max: "0",
+			avg: "0",
+			static: "5",
+		};
+
+		const wrapper = ({ children }: any) => <EnvironmentProvider env={env}>{children} </EnvironmentProvider>;
+		const {
+			result: { current },
+		} = renderHook(() => useFees(), { wrapper });
+
+		expect(current.formatWithDefaultStatic(fees)).toEqual({
+			min: "5",
+			max: "5",
+			avg: "5",
+			static: "5",
+		});
+	});
+
+	it("should find fees by type if already synced", async () => {
+		const profile = env.profiles().findById(getDefaultProfileId());
+
+		await env.wallets().syncByProfile(profile);
+		await env.fees().syncAll();
+		await env.delegates().syncAll();
+
+		const wrapper = ({ children }: any) => <EnvironmentProvider env={env}>{children} </EnvironmentProvider>;
+		const {
+			result: { current },
+		} = renderHook(() => useFees(), { wrapper });
+
+		expect(current.findByType("ARK", "ark.devnet", "ipfs")).resolves.toEqual({
+			static: "500000000",
+			max: "500000000",
+			min: "500000000",
+			avg: "500000000",
+		});
+	});
+
+	it("should ensure fees are synced before find", async () => {
+		env.reset({ coins: { ARK }, httpClient, storage: new StubStorage() });
+
+		const profile = env.profiles().create("John Doe");
+		await profile.wallets().generate("ARK", "ark.devnet");
+		await env.wallets().syncByProfile(profile);
+
+		const wrapper = ({ children }: any) => <EnvironmentProvider env={env}>{children} </EnvironmentProvider>;
+		const {
+			result: { current },
+		} = renderHook(() => useFees(), { wrapper });
+
+		expect(current.findByType("ARK", "ark.devnet", "ipfs")).resolves.toEqual({
+			static: "500000000",
+			max: "500000000",
+			min: "500000000",
+			avg: "500000000",
+		});
+	});
+});

--- a/src/app/hooks/use-fees.ts
+++ b/src/app/hooks/use-fees.ts
@@ -11,7 +11,7 @@ export const useFees = () => {
 	const formatWithDefaultStatic = useCallback((fees: TransactionFee) => {
 		const isZero = (fee: FeeInput) => BigNumber.make(fee).isZero() || BigNumber.make(fee).isNegative();
 		const setWithFallback = (fee: FeeInput, fallbackFee: FeeInput) =>
-			isZero(fee) ? String(fallbackFee) : String(fee);
+			!fee || isZero(fee) ? String(fallbackFee) : String(fee);
 
 		return {
 			avg: setWithFallback(fees.avg, fees.static),

--- a/src/app/hooks/use-fees.ts
+++ b/src/app/hooks/use-fees.ts
@@ -1,0 +1,44 @@
+import { TransactionFee } from "@arkecosystem/platform-sdk/dist/contracts";
+import { BigNumber } from "@arkecosystem/platform-sdk-support";
+import { useEnvironmentContext } from "app/contexts";
+import { useCallback } from "react";
+
+type FeeInput = string | number | BigNumber;
+
+export const useFees = () => {
+	const { env } = useEnvironmentContext();
+
+	const formatWithDefaultStatic = useCallback((fees: TransactionFee) => {
+		const isZero = (fee: FeeInput) => BigNumber.make(fee).isZero() || BigNumber.make(fee).isNegative();
+		const setWithFallback = (fee: FeeInput, fallbackFee: FeeInput) =>
+			isZero(fee) ? String(fallbackFee) : String(fee);
+
+		return {
+			avg: setWithFallback(fees.avg, fees.static),
+			min: setWithFallback(fees.min, fees.static),
+			max: setWithFallback(fees.max, fees.static),
+			static: fees.static,
+		};
+	}, []);
+
+	const findByType = useCallback(
+		async (coin: string, network: string, type: string) => {
+			let transactionFees: TransactionFee;
+
+			try {
+				transactionFees = env.fees().findByType(coin, network, type);
+			} catch (error) {
+				await env.fees().syncAll();
+				transactionFees = env.fees().findByType(coin, network, type);
+			}
+
+			return formatWithDefaultStatic(transactionFees);
+		},
+		[env, formatWithDefaultStatic],
+	);
+
+	return {
+		formatWithDefaultStatic,
+		findByType,
+	};
+};

--- a/src/app/hooks/use-validation.test.tsx
+++ b/src/app/hooks/use-validation.test.tsx
@@ -24,7 +24,7 @@ describe("useValidation hook", () => {
 				result: { current },
 			} = renderHook(() => useValidation(), { wrapper });
 			const balance = BigNumber.make(5);
-			const validation = current.common.fee(defaultFees, balance);
+			const validation = current.common.fee(() => defaultFees, balance);
 			const isValid = validation.validate.valid(2);
 
 			expect(isValid).toBe(true);
@@ -36,7 +36,7 @@ describe("useValidation hook", () => {
 				result: { current },
 			} = renderHook(() => useValidation(), { wrapper });
 			const balance = BigNumber.ZERO;
-			const validation = current.common.fee(defaultFees, balance, mockNetwork);
+			const validation = current.common.fee(() => defaultFees, balance, mockNetwork);
 			const isValid = validation.validate.valid(2);
 
 			expect(isValid).not.toBe(true);
@@ -48,7 +48,7 @@ describe("useValidation hook", () => {
 				result: { current },
 			} = renderHook(() => useValidation(), { wrapper });
 			const balance = BigNumber.make(-5);
-			const validation = current.common.fee(defaultFees, balance, mockNetwork);
+			const validation = current.common.fee(() => defaultFees, balance, mockNetwork);
 			const isValid = validation.validate.valid(2);
 
 			expect(isValid).not.toBe(true);
@@ -60,7 +60,7 @@ describe("useValidation hook", () => {
 				result: { current },
 			} = renderHook(() => useValidation(), { wrapper });
 			const balance = BigNumber.make(1);
-			const validation = current.common.fee(defaultFees, balance, mockNetwork);
+			const validation = current.common.fee(() => defaultFees, balance, mockNetwork);
 			const isValid = validation.validate.valid(2);
 
 			expect(isValid).not.toBe(true);
@@ -72,7 +72,7 @@ describe("useValidation hook", () => {
 				result: { current },
 			} = renderHook(() => useValidation(), { wrapper });
 			const balance = BigNumber.make(11);
-			const validation = current.common.fee(defaultFees, balance, mockNetwork);
+			const validation = current.common.fee(() => defaultFees, balance, mockNetwork);
 			const isValid = validation.validate.valid(0.9);
 
 			expect(isValid).not.toBe(true);
@@ -84,7 +84,7 @@ describe("useValidation hook", () => {
 				result: { current },
 			} = renderHook(() => useValidation(), { wrapper });
 			const balance = BigNumber.make(11);
-			const validation = current.common.fee(defaultFees, balance, mockNetwork);
+			const validation = current.common.fee(() => defaultFees, balance, mockNetwork);
 			const isValid = validation.validate.valid(6);
 
 			expect(isValid).not.toBe(true);

--- a/src/domains/transaction/components/DelegateRegistrationForm/FormStep.tsx
+++ b/src/domains/transaction/components/DelegateRegistrationForm/FormStep.tsx
@@ -26,7 +26,10 @@ export const FormStep = ({ fees, wallet, step = 0.001 }: any) => {
 	const fee = getValues("fee") || defaultFee;
 
 	useEffect(() => {
-		register("fee", common.fee(fees, wallet.balance(), wallet.network()));
+		register(
+			"fee",
+			common.fee(() => fees, wallet.balance(), wallet.network()),
+		);
 	}, [register, unregister, common, fees, wallet]);
 
 	useEffect(() => {

--- a/src/domains/transaction/components/MultiSignatureRegistrationForm/FormStep.tsx
+++ b/src/domains/transaction/components/MultiSignatureRegistrationForm/FormStep.tsx
@@ -29,7 +29,10 @@ export const FormStep = ({
 	const { common, multiSignatureRegistration } = useValidation();
 
 	useEffect(() => {
-		register("fee", common.fee(fees, wallet.balance(), wallet.network()));
+		register(
+			"fee",
+			common.fee(() => fees, wallet.balance(), wallet.network()),
+		);
 		register("participants", multiSignatureRegistration.participants());
 		register("minParticipants", multiSignatureRegistration.minParticipants(participants));
 	}, [register, participants, common, fees, multiSignatureRegistration, wallet]);

--- a/src/domains/transaction/components/SecondSignatureRegistrationForm/GenerationStep.tsx
+++ b/src/domains/transaction/components/SecondSignatureRegistrationForm/GenerationStep.tsx
@@ -31,7 +31,10 @@ export const GenerationStep = ({
 	const fee = getValues("fee") || defaultFee;
 
 	useEffect(() => {
-		register("fee", common.fee(fees, wallet.balance(), wallet.network()));
+		register(
+			"fee",
+			common.fee(() => fees, wallet.balance(), wallet.network()),
+		);
 		register("secondMnemonic");
 		register("wallet");
 	}, [register, common, fees, wallet]);

--- a/src/domains/transaction/pages/SendDelegateResignation/SendDelegateResignation.tsx
+++ b/src/domains/transaction/pages/SendDelegateResignation/SendDelegateResignation.tsx
@@ -7,7 +7,7 @@ import { Page, Section } from "app/components/Layout";
 import { StepIndicator } from "app/components/StepIndicator";
 import { TabPanel, Tabs } from "app/components/Tabs";
 import { useEnvironmentContext } from "app/contexts";
-import { useActiveProfile, useActiveWallet } from "app/hooks";
+import { useActiveProfile, useActiveWallet, useFees } from "app/hooks";
 import { AuthenticationStep } from "domains/transaction/components/AuthenticationStep";
 import { ErrorStep } from "domains/transaction/components/ErrorStep";
 import { isMnemonicError } from "domains/transaction/utils";
@@ -39,6 +39,7 @@ export const SendDelegateResignation = ({ formDefaultData }: SendResignationProp
 
 	const activeProfile = useActiveProfile();
 	const activeWallet = useActiveWallet();
+	const { findByType } = useFees();
 
 	const crumbs = [
 		{
@@ -63,14 +64,14 @@ export const SendDelegateResignation = ({ formDefaultData }: SendResignationProp
 
 	useEffect(() => {
 		const setTransactionFees = async (wallet: ReadWriteWallet) => {
-			await env.fees().syncAll();
-			const fees = env.fees().findByType(wallet.coinId(), wallet.networkId(), "delegateResignation");
+			const fees = await findByType(wallet.coinId(), wallet.networkId(), "delegateResignation");
+
 			setValue("fees", fees);
 			setValue("fee", fees?.avg);
 		};
 
 		setTransactionFees(activeWallet);
-	}, [env, setValue, activeWallet]);
+	}, [setValue, activeWallet, findByType]);
 
 	const handleBack = () => {
 		setActiveTab(activeTab - 1);

--- a/src/domains/transaction/pages/SendIpfs/SendIpfs.tsx
+++ b/src/domains/transaction/pages/SendIpfs/SendIpfs.tsx
@@ -48,7 +48,10 @@ export const SendIpfs = () => {
 		register("senderAddress", sendIpfs.senderAddress());
 		register("hash", sendIpfs.hash());
 		register("fees");
-		register("fee", common.fee(fees, activeWallet?.balance?.(), activeWallet?.network?.()));
+		register(
+			"fee",
+			common.fee(() => fees, activeWallet?.balance?.(), activeWallet?.network?.()),
+		);
 
 		setValue("senderAddress", activeWallet.address(), { shouldValidate: true, shouldDirty: true });
 

--- a/src/domains/transaction/pages/SendRegistration/SendRegistration.tsx
+++ b/src/domains/transaction/pages/SendRegistration/SendRegistration.tsx
@@ -7,7 +7,7 @@ import { Page, Section } from "app/components/Layout";
 import { StepIndicator } from "app/components/StepIndicator";
 import { TabPanel, Tabs } from "app/components/Tabs";
 import { useEnvironmentContext } from "app/contexts";
-import { useActiveProfile, useActiveWallet } from "app/hooks";
+import { useActiveProfile, useActiveWallet, useFees } from "app/hooks";
 import { AuthenticationStep } from "domains/transaction/components/AuthenticationStep";
 import { DelegateRegistrationForm } from "domains/transaction/components/DelegateRegistrationForm";
 import { ErrorStep } from "domains/transaction/components/ErrorStep";
@@ -34,6 +34,7 @@ export const SendRegistration = ({ formDefaultValues }: SendRegistrationProps) =
 	const [transaction, setTransaction] = useState((null as unknown) as Contracts.SignedTransactionData);
 	const [registrationForm, setRegistrationForm] = useState<SendRegistrationForm>();
 	const [crumbs, setCrumbs] = useState<Crumb[]>([]);
+	const { findByType } = useFees();
 
 	const { registrationType } = useParams();
 
@@ -46,21 +47,14 @@ export const SendRegistration = ({ formDefaultValues }: SendRegistrationProps) =
 
 	const stepCount = registrationForm ? registrationForm.tabSteps + 2 : 1;
 
-	const getFeesByRegistrationType = useCallback(
-		(type: string) => env.fees().findByType(activeWallet.coinId(), activeWallet.networkId(), type),
-		[env, activeWallet],
-	);
-
 	const setFeesByRegistrationType = useCallback(
 		async (type: string) => {
-			await env.fees().syncAll();
-			const fees = getFeesByRegistrationType(type);
+			const fees = await findByType(activeWallet.coinId(), activeWallet.networkId(), type);
 
 			setValue("fees", fees);
-			/* istanbul ignore next */
-			setValue("fee", fees?.avg || fees?.static);
+			setValue("fee", fees?.avg);
 		},
-		[getFeesByRegistrationType, setValue, env],
+		[setValue, activeWallet, findByType],
 	);
 
 	useEffect(() => {

--- a/src/domains/transaction/pages/SendTransfer/SendTransfer.tsx
+++ b/src/domains/transaction/pages/SendTransfer/SendTransfer.tsx
@@ -65,7 +65,10 @@ export const SendTransfer = () => {
 		register("network", sendTransfer.network());
 		register("recipients");
 		register("senderAddress", sendTransfer.senderAddress());
-		register("fee", common.fee(fees, remainingBalance, wallet?.network?.()));
+		register(
+			"fee",
+			common.fee(() => fees, remainingBalance, wallet?.network?.()),
+		);
 		register("smartbridge", sendTransfer.smartbridge());
 	}, [register, sendTransfer, common, fees, wallet, remainingBalance, amount, senderAddress]);
 

--- a/src/domains/transaction/pages/SendVote/FormStep.tsx
+++ b/src/domains/transaction/pages/SendVote/FormStep.tsx
@@ -3,6 +3,7 @@ import { Profile, ReadOnlyWallet, ReadWriteWallet } from "@arkecosystem/platform
 import { FormField, FormHelperText, FormLabel } from "app/components/Form";
 import { Header } from "app/components/Header";
 import { useEnvironmentContext } from "app/contexts";
+import { useFees } from "app/hooks";
 import { InputFee } from "domains/transaction/components/InputFee";
 import {
 	TransactionDetail,
@@ -15,7 +16,6 @@ import { useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 
 export const FormStep = ({
-	profile,
 	unvotes,
 	votes,
 	wallet,
@@ -28,6 +28,7 @@ export const FormStep = ({
 	const { env } = useEnvironmentContext();
 	const { t } = useTranslation();
 
+	const { findByType } = useFees();
 	const form = useFormContext();
 	const { getValues, setValue, watch, register } = form;
 
@@ -48,14 +49,14 @@ export const FormStep = ({
 
 	useEffect(() => {
 		const setVoteFees = async (senderWallet: ReadWriteWallet) => {
-			await env.fees().syncAll();
-			const voteFees = env.fees().findByType(senderWallet.coinId(), senderWallet.networkId(), "vote");
+			const voteFees = await findByType(senderWallet.coinId(), senderWallet.networkId(), "vote");
+
 			setFees(voteFees);
 			setValue("fees", voteFees);
 		};
 
 		setVoteFees(wallet);
-	}, [env, setFees, wallet, setValue]);
+	}, [env, setFees, wallet, setValue, findByType]);
 
 	useEffect(() => {
 		setValue("fee", fees.avg, { shouldValidate: true, shouldDirty: true });

--- a/src/domains/transaction/pages/SendVote/SendVote.tsx
+++ b/src/domains/transaction/pages/SendVote/SendVote.tsx
@@ -50,7 +50,10 @@ export const SendVote = () => {
 		register("network", sendVote.network());
 		register("senderAddress", sendVote.senderAddress());
 		register("fees");
-		register("fee", common.fee(getValues("fees"), activeWallet?.balance?.(), activeWallet?.network?.()));
+		register(
+			"fee",
+			common.fee(() => getValues("fees"), activeWallet?.balance?.(), activeWallet?.network?.()),
+		);
 
 		setValue("senderAddress", activeWallet.address(), { shouldValidate: true, shouldDirty: true });
 

--- a/src/domains/transaction/validations/Common.ts
+++ b/src/domains/transaction/validations/Common.ts
@@ -2,10 +2,11 @@ import { Coins, Contracts } from "@arkecosystem/platform-sdk";
 import { BigNumber } from "@arkecosystem/platform-sdk-support";
 
 export const common = (t: any) => ({
-	fee: (fees: Contracts.TransactionFee, balance: BigNumber = BigNumber.ZERO, network?: Coins.Network) => ({
+	fee: (getFees: () => Contracts.TransactionFee, balance: BigNumber = BigNumber.ZERO, network?: Coins.Network) => ({
 		validate: {
 			valid: (fee?: string | number) => {
 				const feeSatoshi = BigNumber.make(fee || 0);
+				const fees = getFees();
 
 				if (!network?.coin()) {
 					return true;


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
-   [x] Create new hook: `const { findByType} = useFees()`
-   [x] Sync fees on demand when calling `findByType` if fees are not already synced
-   [x] Use static fee when min/max/avg are zero or undefined
-   [x] Adjust fee validations

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [x] My changes look good in both light AND dark mode
-   [x] The change is not hardcoded to a single network, but has multi-asset in mind
-   [x] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [x] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
