### PR TITLE
refactor: use dotted underline in `Link`

### DIFF
--- a/src/app/components/Link/Link.tsx
+++ b/src/app/components/Link/Link.tsx
@@ -3,7 +3,7 @@ import { toasts } from "app/services";
 import React from "react";
 import { useTranslation } from "react-i18next";
 import { Link as RouterLink, LinkProps } from "react-router-dom";
-import tw, { css,styled } from "twin.macro";
+import tw, { css, styled } from "twin.macro";
 import { openExternal } from "utils/electron-utils";
 
 import { Icon } from "../Icon";

--- a/src/app/components/Link/Link.tsx
+++ b/src/app/components/Link/Link.tsx
@@ -12,11 +12,22 @@ const AnchorStyled = styled.a<{ isExternal: boolean }>`
 	${({ isExternal }) =>
 		isExternal &&
 		`
-		&:active {
-			text-decoration-style: dotted;
-		}
-		&:hover:not(:active) {
+		&:hover, &:active {
 			text-decoration: none;
+
+			.underline-dotted {
+				position: relative;
+
+				&:after {
+					content: "";
+					display: block;
+					position: absolute;
+					bottom:0;
+					width: 100%;
+					border-bottom: 1px dotted;
+				}
+			}
+
 		}
 	`}
 `;
@@ -42,7 +53,7 @@ const Anchor = React.forwardRef<HTMLAnchorElement, Props>(
 			}}
 			{...props}
 		>
-			{children}
+			<span className="underline-dotted">{children}</span>
 			{isExternal && showExternalIcon && (
 				<Icon
 					data-testid="Link__external"

--- a/src/app/components/Link/Link.tsx
+++ b/src/app/components/Link/Link.tsx
@@ -3,7 +3,7 @@ import { toasts } from "app/services";
 import React from "react";
 import { useTranslation } from "react-i18next";
 import { Link as RouterLink, LinkProps } from "react-router-dom";
-import { styled } from "twin.macro";
+import tw, { css,styled } from "twin.macro";
 import { openExternal } from "utils/electron-utils";
 
 import { Icon } from "../Icon";
@@ -11,25 +11,21 @@ import { Icon } from "../Icon";
 const AnchorStyled = styled.a<{ isExternal: boolean }>`
 	${({ isExternal }) =>
 		isExternal &&
-		`
-		&:hover, &:active {
-			text-decoration: none;
+		css`
+			&:hover,
+			&:active {
+				${tw`no-underline`}
 
-			.underline-dotted {
-				position: relative;
+				.underline-dotted {
+					${tw`relative`}
 
-				&:after {
-					content: "";
-					display: block;
-					position: absolute;
-					bottom:0;
-					width: 100%;
-					border-bottom: 1px dotted;
+					&:after {
+						content: "";
+						${tw`block w-full border-b absolute bottom-0 border-dotted`}
+					}
 				}
 			}
-
-		}
-	`}
+		`}
 `;
 
 type AnchorProps = {

--- a/src/app/components/Link/__snapshots__/Link.test.tsx.snap
+++ b/src/app/components/Link/__snapshots__/Link.test.tsx.snap
@@ -3,11 +3,14 @@
 exports[`Link should open an external link 1`] = `
 <DocumentFragment>
   <a
-    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
     data-testid="Link"
     rel="noopener noreferrer"
     to="https://ark.io/"
   >
+    <span
+      class="underline-dotted"
+    />
     <div
       class="sc-bdfBwQ fPrsah flex-shrink-0 "
       data-testid="Link__external"
@@ -29,7 +32,11 @@ exports[`Link should render 1`] = `
     data-testid="Link"
     href="/test"
   >
-    Test
+    <span
+      class="underline-dotted"
+    >
+      Test
+    </span>
   </a>
 </DocumentFragment>
 `;
@@ -37,11 +44,14 @@ exports[`Link should render 1`] = `
 exports[`Link should render external without children 1`] = `
 <DocumentFragment>
   <a
-    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
     data-testid="Link"
     rel="noopener noreferrer"
     to="https://ark.io"
   >
+    <span
+      class="underline-dotted"
+    />
     <div
       class="sc-bdfBwQ fPrsah flex-shrink-0 "
       data-testid="Link__external"
@@ -63,7 +73,11 @@ exports[`Link should render with tooltip 1`] = `
     data-testid="Link"
     href="/test"
   >
-    Test
+    <span
+      class="underline-dotted"
+    >
+      Test
+    </span>
   </a>
 </DocumentFragment>
 `;
@@ -71,11 +85,14 @@ exports[`Link should render with tooltip 1`] = `
 exports[`Link should show a toast when trying to open an invalid external link 1`] = `
 <DocumentFragment>
   <a
-    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
     data-testid="Link"
     rel="noopener noreferrer"
     to="invalid-url"
   >
+    <span
+      class="underline-dotted"
+    />
     <div
       class="sc-bdfBwQ fPrsah flex-shrink-0 "
       data-testid="Link__external"

--- a/src/app/components/Link/__snapshots__/Link.test.tsx.snap
+++ b/src/app/components/Link/__snapshots__/Link.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Link should open an external link 1`] = `
 <DocumentFragment>
   <a
-    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
     data-testid="Link"
     rel="noopener noreferrer"
     to="https://ark.io/"
@@ -44,7 +44,7 @@ exports[`Link should render 1`] = `
 exports[`Link should render external without children 1`] = `
 <DocumentFragment>
   <a
-    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
     data-testid="Link"
     rel="noopener noreferrer"
     to="https://ark.io"
@@ -85,7 +85,7 @@ exports[`Link should render with tooltip 1`] = `
 exports[`Link should show a toast when trying to open an invalid external link 1`] = `
 <DocumentFragment>
   <a
-    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
     data-testid="Link"
     rel="noopener noreferrer"
     to="invalid-url"

--- a/src/app/components/Notifications/__snapshots__/NotificationsDropdown.test.tsx.snap
+++ b/src/app/components/Notifications/__snapshots__/NotificationsDropdown.test.tsx.snap
@@ -1298,16 +1298,20 @@ exports[`Notifications should open and close transaction details modal 1`] = `
                     class="flex items-center space-x-3"
                   >
                     <a
-                      class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                      class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                       data-testid="Link"
                       rel="noopener noreferrer"
                       to="https://dexplorer.ark.io/transaction/ea63bf9a4b3eaf75a1dfff721967c45dce64eb7facf1aef29461868681b5c79b"
                     >
                       <span
-                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                        data-testid="TruncateMiddle"
+                        class="underline-dotted"
                       >
-                        ea63bf9a4b3ea … 1868681b5c79b
+                        <span
+                          class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                          data-testid="TruncateMiddle"
+                        >
+                          ea63bf9a4b3ea … 1868681b5c79b
+                        </span>
                       </span>
                     </a>
                     <span
@@ -1351,16 +1355,20 @@ exports[`Notifications should open and close transaction details modal 1`] = `
                     class="flex items-center space-x-3"
                   >
                     <a
-                      class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                      class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                       data-testid="Link"
                       rel="noopener noreferrer"
                       to="https://dexplorer.ark.io/block/4fbdbedc9d1474dc7b96e503a0aa848146d9f2b941014cd79decdd16290920a4"
                     >
                       <span
-                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                        data-testid="TruncateMiddle"
+                        class="underline-dotted"
                       >
-                        4fbdbedc9d147 … cdd16290920a4
+                        <span
+                          class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                          data-testid="TruncateMiddle"
+                        >
+                          4fbdbedc9d147 … cdd16290920a4
+                        </span>
                       </span>
                     </a>
                     <span

--- a/src/app/components/Notifications/__snapshots__/NotificationsDropdown.test.tsx.snap
+++ b/src/app/components/Notifications/__snapshots__/NotificationsDropdown.test.tsx.snap
@@ -1298,7 +1298,7 @@ exports[`Notifications should open and close transaction details modal 1`] = `
                     class="flex items-center space-x-3"
                   >
                     <a
-                      class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                      class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                       data-testid="Link"
                       rel="noopener noreferrer"
                       to="https://dexplorer.ark.io/transaction/ea63bf9a4b3eaf75a1dfff721967c45dce64eb7facf1aef29461868681b5c79b"
@@ -1355,7 +1355,7 @@ exports[`Notifications should open and close transaction details modal 1`] = `
                     class="flex items-center space-x-3"
                   >
                     <a
-                      class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                      class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                       data-testid="Link"
                       rel="noopener noreferrer"
                       to="https://dexplorer.ark.io/block/4fbdbedc9d1474dc7b96e503a0aa848146d9f2b941014cd79decdd16290920a4"

--- a/src/domains/dashboard/components/Transactions/__snapshots__/Transactions.test.tsx.snap
+++ b/src/domains/dashboard/components/Transactions/__snapshots__/Transactions.test.tsx.snap
@@ -250,7 +250,7 @@ exports[`Transactions should fetch more transactions 1`] = `
                     class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 gMOims"
                   >
                     <a
-                      class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                      class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                       data-testid="TransactionRow__ID"
                       rel="noopener noreferrer"
                       to="https://dexplorer.ark.io/transaction/8f913b6b719e7767d49861c0aec79ced212767645cb793d75d2f1b89abb49877"
@@ -409,7 +409,7 @@ exports[`Transactions should fetch more transactions 1`] = `
                     class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 gMOims"
                   >
                     <a
-                      class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                      class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                       data-testid="TransactionRow__ID"
                       rel="noopener noreferrer"
                       to="https://dexplorer.ark.io/transaction/0d8d12d7980bf0183ef015e5938e56c44c3db4d3695cefd16ccec4a7bfd8a2cf"
@@ -568,7 +568,7 @@ exports[`Transactions should fetch more transactions 1`] = `
                     class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 gMOims"
                   >
                     <a
-                      class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                      class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                       data-testid="TransactionRow__ID"
                       rel="noopener noreferrer"
                       to="https://dexplorer.ark.io/transaction/8f913b6b719e7767d49861c0aec79ced212767645cb793d75d2f1b89abb49877"
@@ -727,7 +727,7 @@ exports[`Transactions should fetch more transactions 1`] = `
                     class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 gMOims"
                   >
                     <a
-                      class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                      class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                       data-testid="TransactionRow__ID"
                       rel="noopener noreferrer"
                       to="https://dexplorer.ark.io/transaction/0d8d12d7980bf0183ef015e5938e56c44c3db4d3695cefd16ccec4a7bfd8a2cf"
@@ -886,7 +886,7 @@ exports[`Transactions should fetch more transactions 1`] = `
                     class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 gMOims"
                   >
                     <a
-                      class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                      class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                       data-testid="TransactionRow__ID"
                       rel="noopener noreferrer"
                       to="https://dexplorer.ark.io/transaction/8f913b6b719e7767d49861c0aec79ced212767645cb793d75d2f1b89abb49877"
@@ -1045,7 +1045,7 @@ exports[`Transactions should fetch more transactions 1`] = `
                     class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 gMOims"
                   >
                     <a
-                      class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                      class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                       data-testid="TransactionRow__ID"
                       rel="noopener noreferrer"
                       to="https://dexplorer.ark.io/transaction/0d8d12d7980bf0183ef015e5938e56c44c3db4d3695cefd16ccec4a7bfd8a2cf"
@@ -1204,7 +1204,7 @@ exports[`Transactions should fetch more transactions 1`] = `
                     class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 gMOims"
                   >
                     <a
-                      class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                      class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                       data-testid="TransactionRow__ID"
                       rel="noopener noreferrer"
                       to="https://dexplorer.ark.io/transaction/8f913b6b719e7767d49861c0aec79ced212767645cb793d75d2f1b89abb49877"
@@ -1363,7 +1363,7 @@ exports[`Transactions should fetch more transactions 1`] = `
                     class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 gMOims"
                   >
                     <a
-                      class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                      class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                       data-testid="TransactionRow__ID"
                       rel="noopener noreferrer"
                       to="https://dexplorer.ark.io/transaction/0d8d12d7980bf0183ef015e5938e56c44c3db4d3695cefd16ccec4a7bfd8a2cf"
@@ -1779,7 +1779,7 @@ exports[`Transactions should open detail modal on transaction row click 1`] = `
                     class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 gMOims"
                   >
                     <a
-                      class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                      class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                       data-testid="TransactionRow__ID"
                       rel="noopener noreferrer"
                       to="https://dexplorer.ark.io/transaction/8f913b6b719e7767d49861c0aec79ced212767645cb793d75d2f1b89abb49877"
@@ -1938,7 +1938,7 @@ exports[`Transactions should open detail modal on transaction row click 1`] = `
                     class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 gMOims"
                   >
                     <a
-                      class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                      class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                       data-testid="TransactionRow__ID"
                       rel="noopener noreferrer"
                       to="https://dexplorer.ark.io/transaction/0d8d12d7980bf0183ef015e5938e56c44c3db4d3695cefd16ccec4a7bfd8a2cf"
@@ -2097,7 +2097,7 @@ exports[`Transactions should open detail modal on transaction row click 1`] = `
                     class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 gMOims"
                   >
                     <a
-                      class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                      class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                       data-testid="TransactionRow__ID"
                       rel="noopener noreferrer"
                       to="https://dexplorer.ark.io/transaction/8f913b6b719e7767d49861c0aec79ced212767645cb793d75d2f1b89abb49877"
@@ -2256,7 +2256,7 @@ exports[`Transactions should open detail modal on transaction row click 1`] = `
                     class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 gMOims"
                   >
                     <a
-                      class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                      class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                       data-testid="TransactionRow__ID"
                       rel="noopener noreferrer"
                       to="https://dexplorer.ark.io/transaction/0d8d12d7980bf0183ef015e5938e56c44c3db4d3695cefd16ccec4a7bfd8a2cf"
@@ -2672,7 +2672,7 @@ exports[`Transactions should render 1`] = `
                     class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 gMOims"
                   >
                     <a
-                      class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                      class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                       data-testid="TransactionRow__ID"
                       rel="noopener noreferrer"
                       to="https://dexplorer.ark.io/transaction/8f913b6b719e7767d49861c0aec79ced212767645cb793d75d2f1b89abb49877"
@@ -2831,7 +2831,7 @@ exports[`Transactions should render 1`] = `
                     class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 gMOims"
                   >
                     <a
-                      class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                      class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                       data-testid="TransactionRow__ID"
                       rel="noopener noreferrer"
                       to="https://dexplorer.ark.io/transaction/0d8d12d7980bf0183ef015e5938e56c44c3db4d3695cefd16ccec4a7bfd8a2cf"
@@ -2990,7 +2990,7 @@ exports[`Transactions should render 1`] = `
                     class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 gMOims"
                   >
                     <a
-                      class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                      class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                       data-testid="TransactionRow__ID"
                       rel="noopener noreferrer"
                       to="https://dexplorer.ark.io/transaction/8f913b6b719e7767d49861c0aec79ced212767645cb793d75d2f1b89abb49877"
@@ -3149,7 +3149,7 @@ exports[`Transactions should render 1`] = `
                     class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 gMOims"
                   >
                     <a
-                      class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                      class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                       data-testid="TransactionRow__ID"
                       rel="noopener noreferrer"
                       to="https://dexplorer.ark.io/transaction/0d8d12d7980bf0183ef015e5938e56c44c3db4d3695cefd16ccec4a7bfd8a2cf"

--- a/src/domains/dashboard/components/Transactions/__snapshots__/Transactions.test.tsx.snap
+++ b/src/domains/dashboard/components/Transactions/__snapshots__/Transactions.test.tsx.snap
@@ -250,20 +250,24 @@ exports[`Transactions should fetch more transactions 1`] = `
                     class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 gMOims"
                   >
                     <a
-                      class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                      class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                       data-testid="TransactionRow__ID"
                       rel="noopener noreferrer"
                       to="https://dexplorer.ark.io/transaction/8f913b6b719e7767d49861c0aec79ced212767645cb793d75d2f1b89abb49877"
                     >
-                      <div
-                        class="sc-bdfBwQ fPrsah"
-                        height="1em"
-                        width="1em"
+                      <span
+                        class="underline-dotted"
                       >
-                        <svg>
-                          id.svg
-                        </svg>
-                      </div>
+                        <div
+                          class="sc-bdfBwQ fPrsah"
+                          height="1em"
+                          width="1em"
+                        >
+                          <svg>
+                            id.svg
+                          </svg>
+                        </div>
+                      </span>
                     </a>
                   </div>
                 </td>
@@ -405,20 +409,24 @@ exports[`Transactions should fetch more transactions 1`] = `
                     class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 gMOims"
                   >
                     <a
-                      class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                      class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                       data-testid="TransactionRow__ID"
                       rel="noopener noreferrer"
                       to="https://dexplorer.ark.io/transaction/0d8d12d7980bf0183ef015e5938e56c44c3db4d3695cefd16ccec4a7bfd8a2cf"
                     >
-                      <div
-                        class="sc-bdfBwQ fPrsah"
-                        height="1em"
-                        width="1em"
+                      <span
+                        class="underline-dotted"
                       >
-                        <svg>
-                          id.svg
-                        </svg>
-                      </div>
+                        <div
+                          class="sc-bdfBwQ fPrsah"
+                          height="1em"
+                          width="1em"
+                        >
+                          <svg>
+                            id.svg
+                          </svg>
+                        </div>
+                      </span>
                     </a>
                   </div>
                 </td>
@@ -560,20 +568,24 @@ exports[`Transactions should fetch more transactions 1`] = `
                     class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 gMOims"
                   >
                     <a
-                      class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                      class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                       data-testid="TransactionRow__ID"
                       rel="noopener noreferrer"
                       to="https://dexplorer.ark.io/transaction/8f913b6b719e7767d49861c0aec79ced212767645cb793d75d2f1b89abb49877"
                     >
-                      <div
-                        class="sc-bdfBwQ fPrsah"
-                        height="1em"
-                        width="1em"
+                      <span
+                        class="underline-dotted"
                       >
-                        <svg>
-                          id.svg
-                        </svg>
-                      </div>
+                        <div
+                          class="sc-bdfBwQ fPrsah"
+                          height="1em"
+                          width="1em"
+                        >
+                          <svg>
+                            id.svg
+                          </svg>
+                        </div>
+                      </span>
                     </a>
                   </div>
                 </td>
@@ -715,20 +727,24 @@ exports[`Transactions should fetch more transactions 1`] = `
                     class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 gMOims"
                   >
                     <a
-                      class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                      class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                       data-testid="TransactionRow__ID"
                       rel="noopener noreferrer"
                       to="https://dexplorer.ark.io/transaction/0d8d12d7980bf0183ef015e5938e56c44c3db4d3695cefd16ccec4a7bfd8a2cf"
                     >
-                      <div
-                        class="sc-bdfBwQ fPrsah"
-                        height="1em"
-                        width="1em"
+                      <span
+                        class="underline-dotted"
                       >
-                        <svg>
-                          id.svg
-                        </svg>
-                      </div>
+                        <div
+                          class="sc-bdfBwQ fPrsah"
+                          height="1em"
+                          width="1em"
+                        >
+                          <svg>
+                            id.svg
+                          </svg>
+                        </div>
+                      </span>
                     </a>
                   </div>
                 </td>
@@ -870,20 +886,24 @@ exports[`Transactions should fetch more transactions 1`] = `
                     class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 gMOims"
                   >
                     <a
-                      class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                      class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                       data-testid="TransactionRow__ID"
                       rel="noopener noreferrer"
                       to="https://dexplorer.ark.io/transaction/8f913b6b719e7767d49861c0aec79ced212767645cb793d75d2f1b89abb49877"
                     >
-                      <div
-                        class="sc-bdfBwQ fPrsah"
-                        height="1em"
-                        width="1em"
+                      <span
+                        class="underline-dotted"
                       >
-                        <svg>
-                          id.svg
-                        </svg>
-                      </div>
+                        <div
+                          class="sc-bdfBwQ fPrsah"
+                          height="1em"
+                          width="1em"
+                        >
+                          <svg>
+                            id.svg
+                          </svg>
+                        </div>
+                      </span>
                     </a>
                   </div>
                 </td>
@@ -1025,20 +1045,24 @@ exports[`Transactions should fetch more transactions 1`] = `
                     class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 gMOims"
                   >
                     <a
-                      class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                      class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                       data-testid="TransactionRow__ID"
                       rel="noopener noreferrer"
                       to="https://dexplorer.ark.io/transaction/0d8d12d7980bf0183ef015e5938e56c44c3db4d3695cefd16ccec4a7bfd8a2cf"
                     >
-                      <div
-                        class="sc-bdfBwQ fPrsah"
-                        height="1em"
-                        width="1em"
+                      <span
+                        class="underline-dotted"
                       >
-                        <svg>
-                          id.svg
-                        </svg>
-                      </div>
+                        <div
+                          class="sc-bdfBwQ fPrsah"
+                          height="1em"
+                          width="1em"
+                        >
+                          <svg>
+                            id.svg
+                          </svg>
+                        </div>
+                      </span>
                     </a>
                   </div>
                 </td>
@@ -1180,20 +1204,24 @@ exports[`Transactions should fetch more transactions 1`] = `
                     class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 gMOims"
                   >
                     <a
-                      class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                      class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                       data-testid="TransactionRow__ID"
                       rel="noopener noreferrer"
                       to="https://dexplorer.ark.io/transaction/8f913b6b719e7767d49861c0aec79ced212767645cb793d75d2f1b89abb49877"
                     >
-                      <div
-                        class="sc-bdfBwQ fPrsah"
-                        height="1em"
-                        width="1em"
+                      <span
+                        class="underline-dotted"
                       >
-                        <svg>
-                          id.svg
-                        </svg>
-                      </div>
+                        <div
+                          class="sc-bdfBwQ fPrsah"
+                          height="1em"
+                          width="1em"
+                        >
+                          <svg>
+                            id.svg
+                          </svg>
+                        </div>
+                      </span>
                     </a>
                   </div>
                 </td>
@@ -1335,20 +1363,24 @@ exports[`Transactions should fetch more transactions 1`] = `
                     class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 gMOims"
                   >
                     <a
-                      class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                      class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                       data-testid="TransactionRow__ID"
                       rel="noopener noreferrer"
                       to="https://dexplorer.ark.io/transaction/0d8d12d7980bf0183ef015e5938e56c44c3db4d3695cefd16ccec4a7bfd8a2cf"
                     >
-                      <div
-                        class="sc-bdfBwQ fPrsah"
-                        height="1em"
-                        width="1em"
+                      <span
+                        class="underline-dotted"
                       >
-                        <svg>
-                          id.svg
-                        </svg>
-                      </div>
+                        <div
+                          class="sc-bdfBwQ fPrsah"
+                          height="1em"
+                          width="1em"
+                        >
+                          <svg>
+                            id.svg
+                          </svg>
+                        </div>
+                      </span>
                     </a>
                   </div>
                 </td>
@@ -1747,20 +1779,24 @@ exports[`Transactions should open detail modal on transaction row click 1`] = `
                     class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 gMOims"
                   >
                     <a
-                      class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                      class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                       data-testid="TransactionRow__ID"
                       rel="noopener noreferrer"
                       to="https://dexplorer.ark.io/transaction/8f913b6b719e7767d49861c0aec79ced212767645cb793d75d2f1b89abb49877"
                     >
-                      <div
-                        class="sc-bdfBwQ fPrsah"
-                        height="1em"
-                        width="1em"
+                      <span
+                        class="underline-dotted"
                       >
-                        <svg>
-                          id.svg
-                        </svg>
-                      </div>
+                        <div
+                          class="sc-bdfBwQ fPrsah"
+                          height="1em"
+                          width="1em"
+                        >
+                          <svg>
+                            id.svg
+                          </svg>
+                        </div>
+                      </span>
                     </a>
                   </div>
                 </td>
@@ -1902,20 +1938,24 @@ exports[`Transactions should open detail modal on transaction row click 1`] = `
                     class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 gMOims"
                   >
                     <a
-                      class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                      class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                       data-testid="TransactionRow__ID"
                       rel="noopener noreferrer"
                       to="https://dexplorer.ark.io/transaction/0d8d12d7980bf0183ef015e5938e56c44c3db4d3695cefd16ccec4a7bfd8a2cf"
                     >
-                      <div
-                        class="sc-bdfBwQ fPrsah"
-                        height="1em"
-                        width="1em"
+                      <span
+                        class="underline-dotted"
                       >
-                        <svg>
-                          id.svg
-                        </svg>
-                      </div>
+                        <div
+                          class="sc-bdfBwQ fPrsah"
+                          height="1em"
+                          width="1em"
+                        >
+                          <svg>
+                            id.svg
+                          </svg>
+                        </div>
+                      </span>
                     </a>
                   </div>
                 </td>
@@ -2057,20 +2097,24 @@ exports[`Transactions should open detail modal on transaction row click 1`] = `
                     class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 gMOims"
                   >
                     <a
-                      class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                      class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                       data-testid="TransactionRow__ID"
                       rel="noopener noreferrer"
                       to="https://dexplorer.ark.io/transaction/8f913b6b719e7767d49861c0aec79ced212767645cb793d75d2f1b89abb49877"
                     >
-                      <div
-                        class="sc-bdfBwQ fPrsah"
-                        height="1em"
-                        width="1em"
+                      <span
+                        class="underline-dotted"
                       >
-                        <svg>
-                          id.svg
-                        </svg>
-                      </div>
+                        <div
+                          class="sc-bdfBwQ fPrsah"
+                          height="1em"
+                          width="1em"
+                        >
+                          <svg>
+                            id.svg
+                          </svg>
+                        </div>
+                      </span>
                     </a>
                   </div>
                 </td>
@@ -2212,20 +2256,24 @@ exports[`Transactions should open detail modal on transaction row click 1`] = `
                     class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 gMOims"
                   >
                     <a
-                      class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                      class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                       data-testid="TransactionRow__ID"
                       rel="noopener noreferrer"
                       to="https://dexplorer.ark.io/transaction/0d8d12d7980bf0183ef015e5938e56c44c3db4d3695cefd16ccec4a7bfd8a2cf"
                     >
-                      <div
-                        class="sc-bdfBwQ fPrsah"
-                        height="1em"
-                        width="1em"
+                      <span
+                        class="underline-dotted"
                       >
-                        <svg>
-                          id.svg
-                        </svg>
-                      </div>
+                        <div
+                          class="sc-bdfBwQ fPrsah"
+                          height="1em"
+                          width="1em"
+                        >
+                          <svg>
+                            id.svg
+                          </svg>
+                        </div>
+                      </span>
                     </a>
                   </div>
                 </td>
@@ -2624,20 +2672,24 @@ exports[`Transactions should render 1`] = `
                     class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 gMOims"
                   >
                     <a
-                      class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                      class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                       data-testid="TransactionRow__ID"
                       rel="noopener noreferrer"
                       to="https://dexplorer.ark.io/transaction/8f913b6b719e7767d49861c0aec79ced212767645cb793d75d2f1b89abb49877"
                     >
-                      <div
-                        class="sc-bdfBwQ fPrsah"
-                        height="1em"
-                        width="1em"
+                      <span
+                        class="underline-dotted"
                       >
-                        <svg>
-                          id.svg
-                        </svg>
-                      </div>
+                        <div
+                          class="sc-bdfBwQ fPrsah"
+                          height="1em"
+                          width="1em"
+                        >
+                          <svg>
+                            id.svg
+                          </svg>
+                        </div>
+                      </span>
                     </a>
                   </div>
                 </td>
@@ -2779,20 +2831,24 @@ exports[`Transactions should render 1`] = `
                     class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 gMOims"
                   >
                     <a
-                      class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                      class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                       data-testid="TransactionRow__ID"
                       rel="noopener noreferrer"
                       to="https://dexplorer.ark.io/transaction/0d8d12d7980bf0183ef015e5938e56c44c3db4d3695cefd16ccec4a7bfd8a2cf"
                     >
-                      <div
-                        class="sc-bdfBwQ fPrsah"
-                        height="1em"
-                        width="1em"
+                      <span
+                        class="underline-dotted"
                       >
-                        <svg>
-                          id.svg
-                        </svg>
-                      </div>
+                        <div
+                          class="sc-bdfBwQ fPrsah"
+                          height="1em"
+                          width="1em"
+                        >
+                          <svg>
+                            id.svg
+                          </svg>
+                        </div>
+                      </span>
                     </a>
                   </div>
                 </td>
@@ -2934,20 +2990,24 @@ exports[`Transactions should render 1`] = `
                     class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 gMOims"
                   >
                     <a
-                      class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                      class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                       data-testid="TransactionRow__ID"
                       rel="noopener noreferrer"
                       to="https://dexplorer.ark.io/transaction/8f913b6b719e7767d49861c0aec79ced212767645cb793d75d2f1b89abb49877"
                     >
-                      <div
-                        class="sc-bdfBwQ fPrsah"
-                        height="1em"
-                        width="1em"
+                      <span
+                        class="underline-dotted"
                       >
-                        <svg>
-                          id.svg
-                        </svg>
-                      </div>
+                        <div
+                          class="sc-bdfBwQ fPrsah"
+                          height="1em"
+                          width="1em"
+                        >
+                          <svg>
+                            id.svg
+                          </svg>
+                        </div>
+                      </span>
                     </a>
                   </div>
                 </td>
@@ -3089,20 +3149,24 @@ exports[`Transactions should render 1`] = `
                     class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 gMOims"
                   >
                     <a
-                      class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                      class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                       data-testid="TransactionRow__ID"
                       rel="noopener noreferrer"
                       to="https://dexplorer.ark.io/transaction/0d8d12d7980bf0183ef015e5938e56c44c3db4d3695cefd16ccec4a7bfd8a2cf"
                     >
-                      <div
-                        class="sc-bdfBwQ fPrsah"
-                        height="1em"
-                        width="1em"
+                      <span
+                        class="underline-dotted"
                       >
-                        <svg>
-                          id.svg
-                        </svg>
-                      </div>
+                        <div
+                          class="sc-bdfBwQ fPrsah"
+                          height="1em"
+                          width="1em"
+                        >
+                          <svg>
+                            id.svg
+                          </svg>
+                        </div>
+                      </span>
                     </a>
                   </div>
                 </td>

--- a/src/domains/dashboard/pages/Dashboard/__snapshots__/Dashboard.test.tsx.snap
+++ b/src/domains/dashboard/pages/Dashboard/__snapshots__/Dashboard.test.tsx.snap
@@ -936,20 +936,24 @@ exports[`Dashboard should render 1`] = `
                         class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 gMOims"
                       >
                         <a
-                          class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                          class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                           data-testid="TransactionRow__ID"
                           rel="noopener noreferrer"
                           to="https://dexplorer.ark.io/transaction/8f913b6b719e7767d49861c0aec79ced212767645cb793d75d2f1b89abb49877"
                         >
-                          <div
-                            class="sc-bdfBwQ fPrsah"
-                            height="1em"
-                            width="1em"
+                          <span
+                            class="underline-dotted"
                           >
-                            <svg>
-                              id.svg
-                            </svg>
-                          </div>
+                            <div
+                              class="sc-bdfBwQ fPrsah"
+                              height="1em"
+                              width="1em"
+                            >
+                              <svg>
+                                id.svg
+                              </svg>
+                            </div>
+                          </span>
                         </a>
                       </div>
                     </td>
@@ -1091,20 +1095,24 @@ exports[`Dashboard should render 1`] = `
                         class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 gMOims"
                       >
                         <a
-                          class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                          class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                           data-testid="TransactionRow__ID"
                           rel="noopener noreferrer"
                           to="https://dexplorer.ark.io/transaction/0d8d12d7980bf0183ef015e5938e56c44c3db4d3695cefd16ccec4a7bfd8a2cf"
                         >
-                          <div
-                            class="sc-bdfBwQ fPrsah"
-                            height="1em"
-                            width="1em"
+                          <span
+                            class="underline-dotted"
                           >
-                            <svg>
-                              id.svg
-                            </svg>
-                          </div>
+                            <div
+                              class="sc-bdfBwQ fPrsah"
+                              height="1em"
+                              width="1em"
+                            >
+                              <svg>
+                                id.svg
+                              </svg>
+                            </div>
+                          </span>
                         </a>
                       </div>
                     </td>
@@ -1246,20 +1254,24 @@ exports[`Dashboard should render 1`] = `
                         class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 gMOims"
                       >
                         <a
-                          class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                          class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                           data-testid="TransactionRow__ID"
                           rel="noopener noreferrer"
                           to="https://dexplorer.ark.io/transaction/8f913b6b719e7767d49861c0aec79ced212767645cb793d75d2f1b89abb49877"
                         >
-                          <div
-                            class="sc-bdfBwQ fPrsah"
-                            height="1em"
-                            width="1em"
+                          <span
+                            class="underline-dotted"
                           >
-                            <svg>
-                              id.svg
-                            </svg>
-                          </div>
+                            <div
+                              class="sc-bdfBwQ fPrsah"
+                              height="1em"
+                              width="1em"
+                            >
+                              <svg>
+                                id.svg
+                              </svg>
+                            </div>
+                          </span>
                         </a>
                       </div>
                     </td>
@@ -1401,20 +1413,24 @@ exports[`Dashboard should render 1`] = `
                         class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 gMOims"
                       >
                         <a
-                          class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                          class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                           data-testid="TransactionRow__ID"
                           rel="noopener noreferrer"
                           to="https://dexplorer.ark.io/transaction/0d8d12d7980bf0183ef015e5938e56c44c3db4d3695cefd16ccec4a7bfd8a2cf"
                         >
-                          <div
-                            class="sc-bdfBwQ fPrsah"
-                            height="1em"
-                            width="1em"
+                          <span
+                            class="underline-dotted"
                           >
-                            <svg>
-                              id.svg
-                            </svg>
-                          </div>
+                            <div
+                              class="sc-bdfBwQ fPrsah"
+                              height="1em"
+                              width="1em"
+                            >
+                              <svg>
+                                id.svg
+                              </svg>
+                            </div>
+                          </span>
                         </a>
                       </div>
                     </td>

--- a/src/domains/dashboard/pages/Dashboard/__snapshots__/Dashboard.test.tsx.snap
+++ b/src/domains/dashboard/pages/Dashboard/__snapshots__/Dashboard.test.tsx.snap
@@ -936,7 +936,7 @@ exports[`Dashboard should render 1`] = `
                         class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 gMOims"
                       >
                         <a
-                          class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                          class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                           data-testid="TransactionRow__ID"
                           rel="noopener noreferrer"
                           to="https://dexplorer.ark.io/transaction/8f913b6b719e7767d49861c0aec79ced212767645cb793d75d2f1b89abb49877"
@@ -1095,7 +1095,7 @@ exports[`Dashboard should render 1`] = `
                         class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 gMOims"
                       >
                         <a
-                          class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                          class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                           data-testid="TransactionRow__ID"
                           rel="noopener noreferrer"
                           to="https://dexplorer.ark.io/transaction/0d8d12d7980bf0183ef015e5938e56c44c3db4d3695cefd16ccec4a7bfd8a2cf"
@@ -1254,7 +1254,7 @@ exports[`Dashboard should render 1`] = `
                         class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 gMOims"
                       >
                         <a
-                          class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                          class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                           data-testid="TransactionRow__ID"
                           rel="noopener noreferrer"
                           to="https://dexplorer.ark.io/transaction/8f913b6b719e7767d49861c0aec79ced212767645cb793d75d2f1b89abb49877"
@@ -1413,7 +1413,7 @@ exports[`Dashboard should render 1`] = `
                         class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 gMOims"
                       >
                         <a
-                          class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                          class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                           data-testid="TransactionRow__ID"
                           rel="noopener noreferrer"
                           to="https://dexplorer.ark.io/transaction/0d8d12d7980bf0183ef015e5938e56c44c3db4d3695cefd16ccec4a7bfd8a2cf"

--- a/src/domains/news/components/BlockfolioAd/__snapshots__/BlockfolioAd.test.tsx.snap
+++ b/src/domains/news/components/BlockfolioAd/__snapshots__/BlockfolioAd.test.tsx.snap
@@ -26,18 +26,22 @@ exports[`BlockfolioAd should render 1`] = `
         class="flex flex-col space-y-5 text-white"
       >
         <a
-          class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+          class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
           data-testid="Link"
           rel="noopener noreferrer"
           to="https://blockfolio.com/"
         >
-          <svg
-            class="-mx-8 text-white"
-            height="47"
-            width="238"
+          <span
+            class="underline-dotted"
           >
-            blockfolio.svg
-          </svg>
+            <svg
+              class="-mx-8 text-white"
+              height="47"
+              width="238"
+            >
+              blockfolio.svg
+            </svg>
+          </span>
         </a>
         <p
           class="w-3/4 text-lg font-medium"
@@ -49,28 +53,36 @@ exports[`BlockfolioAd should render 1`] = `
         class="flex mt-12 space-x-2"
       >
         <a
-          class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+          class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
           data-testid="Link"
           rel="noopener noreferrer"
           to="https://itunes.apple.com/us/app/blockfolio-bitcoin-altcoin/id1095564685?mt=8"
         >
-          <svg
-            class="w-32 h-10 b-0"
+          <span
+            class="underline-dotted"
           >
-            download-app-store.svg
-          </svg>
+            <svg
+              class="w-32 h-10 b-0"
+            >
+              download-app-store.svg
+            </svg>
+          </span>
         </a>
         <a
-          class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+          class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
           data-testid="Link"
           rel="noopener noreferrer"
           to="https://play.google.com/store/apps/details?id=com.blockfolio.blockfolio&hl=en_US"
         >
-          <svg
-            class="w-32 h-10"
+          <span
+            class="underline-dotted"
           >
-            download-google-play.svg
-          </svg>
+            <svg
+              class="w-32 h-10"
+            >
+              download-google-play.svg
+            </svg>
+          </span>
         </a>
       </div>
     </div>

--- a/src/domains/news/components/BlockfolioAd/__snapshots__/BlockfolioAd.test.tsx.snap
+++ b/src/domains/news/components/BlockfolioAd/__snapshots__/BlockfolioAd.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`BlockfolioAd should render 1`] = `
         class="flex flex-col space-y-5 text-white"
       >
         <a
-          class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+          class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
           data-testid="Link"
           rel="noopener noreferrer"
           to="https://blockfolio.com/"
@@ -53,7 +53,7 @@ exports[`BlockfolioAd should render 1`] = `
         class="flex mt-12 space-x-2"
       >
         <a
-          class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+          class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
           data-testid="Link"
           rel="noopener noreferrer"
           to="https://itunes.apple.com/us/app/blockfolio-bitcoin-altcoin/id1095564685?mt=8"
@@ -69,7 +69,7 @@ exports[`BlockfolioAd should render 1`] = `
           </span>
         </a>
         <a
-          class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+          class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
           data-testid="Link"
           rel="noopener noreferrer"
           to="https://play.google.com/store/apps/details?id=com.blockfolio.blockfolio&hl=en_US"

--- a/src/domains/news/components/NewsCard/__snapshots__/NewsCard.test.tsx.snap
+++ b/src/domains/news/components/NewsCard/__snapshots__/NewsCard.test.tsx.snap
@@ -93,7 +93,7 @@ exports[`NewsCard should render 1`] = `
         >
           Recently we released our all-in-one toolkit the ARK Platform SDK, along with an overview and what blockchain projects it will initially support. Today we are going into more details on a technical level. 
           <a
-            class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+            class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
             data-testid="Link"
             rel="noopener noreferrer"
             to="https://blog.ark.io/ark-platform-sdk-modernization-of-blockchain-network-interactions-b5a7d70c2461"
@@ -207,7 +207,7 @@ exports[`NewsCard should render with cover image 1`] = `
         >
           June is over and it's time for the Monthly Update. This blog post will cover last month’s highlights, activities, development, partner activities, news and updates of our upcoming releases. 
           <a
-            class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+            class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
             data-testid="Link"
             rel="noopener noreferrer"
             to="https://blog.ark.io/ark-monthly-update-june-2020-edition-279a3dd47a36"

--- a/src/domains/news/components/NewsCard/__snapshots__/NewsCard.test.tsx.snap
+++ b/src/domains/news/components/NewsCard/__snapshots__/NewsCard.test.tsx.snap
@@ -93,12 +93,16 @@ exports[`NewsCard should render 1`] = `
         >
           Recently we released our all-in-one toolkit the ARK Platform SDK, along with an overview and what blockchain projects it will initially support. Today we are going into more details on a technical level. 
           <a
-            class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+            class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
             data-testid="Link"
             rel="noopener noreferrer"
             to="https://blog.ark.io/ark-platform-sdk-modernization-of-blockchain-network-interactions-b5a7d70c2461"
           >
-            https://blog.ark.io/ark-platform-sdk-modernization-of-blockchain-network-interactions-b5a7d70c2461
+            <span
+              class="underline-dotted"
+            >
+              https://blog.ark.io/ark-platform-sdk-modernization-of-blockchain-network-interactions-b5a7d70c2461
+            </span>
           </a>
         </p>
       </div>
@@ -203,12 +207,16 @@ exports[`NewsCard should render with cover image 1`] = `
         >
           June is over and it's time for the Monthly Update. This blog post will cover last month’s highlights, activities, development, partner activities, news and updates of our upcoming releases. 
           <a
-            class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+            class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
             data-testid="Link"
             rel="noopener noreferrer"
             to="https://blog.ark.io/ark-monthly-update-june-2020-edition-279a3dd47a36"
           >
-            https://blog.ark.io/ark-monthly-update-june-2020-edition-279a3dd47a36
+            <span
+              class="underline-dotted"
+            >
+              https://blog.ark.io/ark-monthly-update-june-2020-edition-279a3dd47a36
+            </span>
           </a>
         </p>
         <div

--- a/src/domains/news/pages/News/__snapshots__/News.test.tsx.snap
+++ b/src/domains/news/pages/News/__snapshots__/News.test.tsx.snap
@@ -395,7 +395,7 @@ exports[`News should filter results based on category query and asset 1`] = `
                         Major League Hacking is having another virtual workshop showcasing ARK technology on August 19th 2020. Anyone can join at 5PM EDT to Build a Blockchain Taco Shop with ARK!
 
                         <a
-                          class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                          class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                           data-testid="Link"
                           rel="noopener noreferrer"
                           to="https://organize.mlh.io/participants/events/3858-build-a-blockchain-taco-shop-with-ark-io"
@@ -441,7 +441,7 @@ exports[`News should filter results based on category query and asset 1`] = `
                       class="flex flex-col space-y-5 text-white"
                     >
                       <a
-                        class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                        class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                         data-testid="Link"
                         rel="noopener noreferrer"
                         to="https://blockfolio.com/"
@@ -468,7 +468,7 @@ exports[`News should filter results based on category query and asset 1`] = `
                       class="flex mt-12 space-x-2"
                     >
                       <a
-                        class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                        class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                         data-testid="Link"
                         rel="noopener noreferrer"
                         to="https://itunes.apple.com/us/app/blockfolio-bitcoin-altcoin/id1095564685?mt=8"
@@ -484,7 +484,7 @@ exports[`News should filter results based on category query and asset 1`] = `
                         </span>
                       </a>
                       <a
-                        class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                        class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                         data-testid="Link"
                         rel="noopener noreferrer"
                         to="https://play.google.com/store/apps/details?id=com.blockfolio.blockfolio&hl=en_US"
@@ -1208,7 +1208,7 @@ exports[`News should filter results based on category query and asset 2`] = `
                       >
                         Recently we released our all-in-one toolkit the ARK Platform SDK, along with an overview and what blockchain projects it will initially support. Today we are going into more details on a technical level. 
                         <a
-                          class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                          class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                           data-testid="Link"
                           rel="noopener noreferrer"
                           to="https://blog.ark.io/ark-platform-sdk-modernization-of-blockchain-network-interactions-b5a7d70c2461"
@@ -1254,7 +1254,7 @@ exports[`News should filter results based on category query and asset 2`] = `
                       class="flex flex-col space-y-5 text-white"
                     >
                       <a
-                        class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                        class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                         data-testid="Link"
                         rel="noopener noreferrer"
                         to="https://blockfolio.com/"
@@ -1281,7 +1281,7 @@ exports[`News should filter results based on category query and asset 2`] = `
                       class="flex mt-12 space-x-2"
                     >
                       <a
-                        class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                        class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                         data-testid="Link"
                         rel="noopener noreferrer"
                         to="https://itunes.apple.com/us/app/blockfolio-bitcoin-altcoin/id1095564685?mt=8"
@@ -1297,7 +1297,7 @@ exports[`News should filter results based on category query and asset 2`] = `
                         </span>
                       </a>
                       <a
-                        class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                        class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                         data-testid="Link"
                         rel="noopener noreferrer"
                         to="https://play.google.com/store/apps/details?id=com.blockfolio.blockfolio&hl=en_US"

--- a/src/domains/news/pages/News/__snapshots__/News.test.tsx.snap
+++ b/src/domains/news/pages/News/__snapshots__/News.test.tsx.snap
@@ -395,12 +395,16 @@ exports[`News should filter results based on category query and asset 1`] = `
                         Major League Hacking is having another virtual workshop showcasing ARK technology on August 19th 2020. Anyone can join at 5PM EDT to Build a Blockchain Taco Shop with ARK!
 
                         <a
-                          class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                          class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                           data-testid="Link"
                           rel="noopener noreferrer"
                           to="https://organize.mlh.io/participants/events/3858-build-a-blockchain-taco-shop-with-ark-io"
                         >
-                          https://organize.mlh.io/participants/events/3858-build-a-blockchain-taco-shop-with-ark-io
+                          <span
+                            class="underline-dotted"
+                          >
+                            https://organize.mlh.io/participants/events/3858-build-a-blockchain-taco-shop-with-ark-io
+                          </span>
                         </a>
                       </p>
                     </div>
@@ -437,18 +441,22 @@ exports[`News should filter results based on category query and asset 1`] = `
                       class="flex flex-col space-y-5 text-white"
                     >
                       <a
-                        class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                        class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                         data-testid="Link"
                         rel="noopener noreferrer"
                         to="https://blockfolio.com/"
                       >
-                        <svg
-                          class="-mx-8 text-white"
-                          height="47"
-                          width="238"
+                        <span
+                          class="underline-dotted"
                         >
-                          blockfolio.svg
-                        </svg>
+                          <svg
+                            class="-mx-8 text-white"
+                            height="47"
+                            width="238"
+                          >
+                            blockfolio.svg
+                          </svg>
+                        </span>
                       </a>
                       <p
                         class="w-3/4 text-lg font-medium"
@@ -460,28 +468,36 @@ exports[`News should filter results based on category query and asset 1`] = `
                       class="flex mt-12 space-x-2"
                     >
                       <a
-                        class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                        class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                         data-testid="Link"
                         rel="noopener noreferrer"
                         to="https://itunes.apple.com/us/app/blockfolio-bitcoin-altcoin/id1095564685?mt=8"
                       >
-                        <svg
-                          class="w-32 h-10 b-0"
+                        <span
+                          class="underline-dotted"
                         >
-                          download-app-store.svg
-                        </svg>
+                          <svg
+                            class="w-32 h-10 b-0"
+                          >
+                            download-app-store.svg
+                          </svg>
+                        </span>
                       </a>
                       <a
-                        class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                        class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                         data-testid="Link"
                         rel="noopener noreferrer"
                         to="https://play.google.com/store/apps/details?id=com.blockfolio.blockfolio&hl=en_US"
                       >
-                        <svg
-                          class="w-32 h-10"
+                        <span
+                          class="underline-dotted"
                         >
-                          download-google-play.svg
-                        </svg>
+                          <svg
+                            class="w-32 h-10"
+                          >
+                            download-google-play.svg
+                          </svg>
+                        </span>
                       </a>
                     </div>
                   </div>
@@ -1192,12 +1208,16 @@ exports[`News should filter results based on category query and asset 2`] = `
                       >
                         Recently we released our all-in-one toolkit the ARK Platform SDK, along with an overview and what blockchain projects it will initially support. Today we are going into more details on a technical level. 
                         <a
-                          class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                          class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                           data-testid="Link"
                           rel="noopener noreferrer"
                           to="https://blog.ark.io/ark-platform-sdk-modernization-of-blockchain-network-interactions-b5a7d70c2461"
                         >
-                          https://blog.ark.io/ark-platform-sdk-modernization-of-blockchain-network-interactions-b5a7d70c2461
+                          <span
+                            class="underline-dotted"
+                          >
+                            https://blog.ark.io/ark-platform-sdk-modernization-of-blockchain-network-interactions-b5a7d70c2461
+                          </span>
                         </a>
                       </p>
                     </div>
@@ -1234,18 +1254,22 @@ exports[`News should filter results based on category query and asset 2`] = `
                       class="flex flex-col space-y-5 text-white"
                     >
                       <a
-                        class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                        class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                         data-testid="Link"
                         rel="noopener noreferrer"
                         to="https://blockfolio.com/"
                       >
-                        <svg
-                          class="-mx-8 text-white"
-                          height="47"
-                          width="238"
+                        <span
+                          class="underline-dotted"
                         >
-                          blockfolio.svg
-                        </svg>
+                          <svg
+                            class="-mx-8 text-white"
+                            height="47"
+                            width="238"
+                          >
+                            blockfolio.svg
+                          </svg>
+                        </span>
                       </a>
                       <p
                         class="w-3/4 text-lg font-medium"
@@ -1257,28 +1281,36 @@ exports[`News should filter results based on category query and asset 2`] = `
                       class="flex mt-12 space-x-2"
                     >
                       <a
-                        class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                        class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                         data-testid="Link"
                         rel="noopener noreferrer"
                         to="https://itunes.apple.com/us/app/blockfolio-bitcoin-altcoin/id1095564685?mt=8"
                       >
-                        <svg
-                          class="w-32 h-10 b-0"
+                        <span
+                          class="underline-dotted"
                         >
-                          download-app-store.svg
-                        </svg>
+                          <svg
+                            class="w-32 h-10 b-0"
+                          >
+                            download-app-store.svg
+                          </svg>
+                        </span>
                       </a>
                       <a
-                        class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                        class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                         data-testid="Link"
                         rel="noopener noreferrer"
                         to="https://play.google.com/store/apps/details?id=com.blockfolio.blockfolio&hl=en_US"
                       >
-                        <svg
-                          class="w-32 h-10"
+                        <span
+                          class="underline-dotted"
                         >
-                          download-google-play.svg
-                        </svg>
+                          <svg
+                            class="w-32 h-10"
+                          >
+                            download-google-play.svg
+                          </svg>
+                        </span>
                       </a>
                     </div>
                   </div>

--- a/src/domains/transaction/components/DelegateRegistrationDetail/__snapshots__/DelegateRegistrationDetail.test.tsx.snap
+++ b/src/domains/transaction/components/DelegateRegistrationDetail/__snapshots__/DelegateRegistrationDetail.test.tsx.snap
@@ -224,7 +224,7 @@ exports[`DelegateRegistrationDetail should render a modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
@@ -281,7 +281,7 @@ exports[`DelegateRegistrationDetail should render a modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
@@ -550,7 +550,7 @@ exports[`DelegateRegistrationDetail should render as confirmed 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
@@ -607,7 +607,7 @@ exports[`DelegateRegistrationDetail should render as confirmed 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"

--- a/src/domains/transaction/components/DelegateRegistrationDetail/__snapshots__/DelegateRegistrationDetail.test.tsx.snap
+++ b/src/domains/transaction/components/DelegateRegistrationDetail/__snapshots__/DelegateRegistrationDetail.test.tsx.snap
@@ -224,16 +224,20 @@ exports[`DelegateRegistrationDetail should render a modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      ee4175091d9f4 … 9d09bcf3ecefe
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        ee4175091d9f4 … 9d09bcf3ecefe
+                      </span>
                     </span>
                   </a>
                   <span
@@ -277,16 +281,20 @@ exports[`DelegateRegistrationDetail should render a modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      71fd1a494ded5 … 972b8075d67e9
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        71fd1a494ded5 … 972b8075d67e9
+                      </span>
                     </span>
                   </a>
                   <span
@@ -542,16 +550,20 @@ exports[`DelegateRegistrationDetail should render as confirmed 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      ee4175091d9f4 … 9d09bcf3ecefe
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        ee4175091d9f4 … 9d09bcf3ecefe
+                      </span>
                     </span>
                   </a>
                   <span
@@ -595,16 +607,20 @@ exports[`DelegateRegistrationDetail should render as confirmed 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      71fd1a494ded5 … 972b8075d67e9
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        71fd1a494ded5 … 972b8075d67e9
+                      </span>
                     </span>
                   </a>
                   <span

--- a/src/domains/transaction/components/DelegateResignationDetail/__snapshots__/DelegateResignationDetail.test.tsx.snap
+++ b/src/domains/transaction/components/DelegateResignationDetail/__snapshots__/DelegateResignationDetail.test.tsx.snap
@@ -224,7 +224,7 @@ exports[`DelegateResignationDetail should render a modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
@@ -281,7 +281,7 @@ exports[`DelegateResignationDetail should render a modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
@@ -550,7 +550,7 @@ exports[`DelegateResignationDetail should render as confirmed 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
@@ -607,7 +607,7 @@ exports[`DelegateResignationDetail should render as confirmed 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"

--- a/src/domains/transaction/components/DelegateResignationDetail/__snapshots__/DelegateResignationDetail.test.tsx.snap
+++ b/src/domains/transaction/components/DelegateResignationDetail/__snapshots__/DelegateResignationDetail.test.tsx.snap
@@ -224,16 +224,20 @@ exports[`DelegateResignationDetail should render a modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      ee4175091d9f4 … 9d09bcf3ecefe
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        ee4175091d9f4 … 9d09bcf3ecefe
+                      </span>
                     </span>
                   </a>
                   <span
@@ -277,16 +281,20 @@ exports[`DelegateResignationDetail should render a modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      71fd1a494ded5 … 972b8075d67e9
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        71fd1a494ded5 … 972b8075d67e9
+                      </span>
                     </span>
                   </a>
                   <span
@@ -542,16 +550,20 @@ exports[`DelegateResignationDetail should render as confirmed 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      ee4175091d9f4 … 9d09bcf3ecefe
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        ee4175091d9f4 … 9d09bcf3ecefe
+                      </span>
                     </span>
                   </a>
                   <span
@@ -595,16 +607,20 @@ exports[`DelegateResignationDetail should render as confirmed 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      71fd1a494ded5 … 972b8075d67e9
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        71fd1a494ded5 … 972b8075d67e9
+                      </span>
                     </span>
                   </a>
                   <span

--- a/src/domains/transaction/components/EntityDetail/__snapshots__/EntityDetail.test.tsx.snap
+++ b/src/domains/transaction/components/EntityDetail/__snapshots__/EntityDetail.test.tsx.snap
@@ -205,7 +205,7 @@ exports[`EntityDetail should render a business entity resignation modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
@@ -262,7 +262,7 @@ exports[`EntityDetail should render a business entity resignation modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
@@ -510,7 +510,7 @@ exports[`EntityDetail should render a business entity update modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
@@ -567,7 +567,7 @@ exports[`EntityDetail should render a business entity update modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
@@ -815,7 +815,7 @@ exports[`EntityDetail should render a modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
@@ -872,7 +872,7 @@ exports[`EntityDetail should render a modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
@@ -1114,7 +1114,7 @@ exports[`EntityDetail should render a modal without a wallet alias 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
@@ -1171,7 +1171,7 @@ exports[`EntityDetail should render a modal without a wallet alias 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
@@ -1419,7 +1419,7 @@ exports[`EntityDetail should render a module entity registration modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
@@ -1476,7 +1476,7 @@ exports[`EntityDetail should render a module entity registration modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
@@ -1724,7 +1724,7 @@ exports[`EntityDetail should render a module entity resignation modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
@@ -1781,7 +1781,7 @@ exports[`EntityDetail should render a module entity resignation modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
@@ -2029,7 +2029,7 @@ exports[`EntityDetail should render a module entity update modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
@@ -2086,7 +2086,7 @@ exports[`EntityDetail should render a module entity update modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
@@ -2334,7 +2334,7 @@ exports[`EntityDetail should render a plugin entity registration modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
@@ -2391,7 +2391,7 @@ exports[`EntityDetail should render a plugin entity registration modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
@@ -2639,7 +2639,7 @@ exports[`EntityDetail should render a plugin entity resignation modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
@@ -2696,7 +2696,7 @@ exports[`EntityDetail should render a plugin entity resignation modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
@@ -2944,7 +2944,7 @@ exports[`EntityDetail should render a plugin entity update modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
@@ -3001,7 +3001,7 @@ exports[`EntityDetail should render a plugin entity update modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
@@ -3249,7 +3249,7 @@ exports[`EntityDetail should render a product entity registration modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
@@ -3306,7 +3306,7 @@ exports[`EntityDetail should render a product entity registration modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
@@ -3554,7 +3554,7 @@ exports[`EntityDetail should render a product entity resignation modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
@@ -3611,7 +3611,7 @@ exports[`EntityDetail should render a product entity resignation modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
@@ -3859,7 +3859,7 @@ exports[`EntityDetail should render a product entity update modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
@@ -3916,7 +3916,7 @@ exports[`EntityDetail should render a product entity update modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
@@ -4166,7 +4166,7 @@ exports[`EntityDetail should render as confirmed 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
@@ -4223,7 +4223,7 @@ exports[`EntityDetail should render as confirmed 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"

--- a/src/domains/transaction/components/EntityDetail/__snapshots__/EntityDetail.test.tsx.snap
+++ b/src/domains/transaction/components/EntityDetail/__snapshots__/EntityDetail.test.tsx.snap
@@ -205,16 +205,20 @@ exports[`EntityDetail should render a business entity resignation modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      ee4175091d9f4 … 9d09bcf3ecefe
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        ee4175091d9f4 … 9d09bcf3ecefe
+                      </span>
                     </span>
                   </a>
                   <span
@@ -258,16 +262,20 @@ exports[`EntityDetail should render a business entity resignation modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      71fd1a494ded5 … 972b8075d67e9
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        71fd1a494ded5 … 972b8075d67e9
+                      </span>
                     </span>
                   </a>
                   <span
@@ -502,16 +510,20 @@ exports[`EntityDetail should render a business entity update modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      ee4175091d9f4 … 9d09bcf3ecefe
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        ee4175091d9f4 … 9d09bcf3ecefe
+                      </span>
                     </span>
                   </a>
                   <span
@@ -555,16 +567,20 @@ exports[`EntityDetail should render a business entity update modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      71fd1a494ded5 … 972b8075d67e9
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        71fd1a494ded5 … 972b8075d67e9
+                      </span>
                     </span>
                   </a>
                   <span
@@ -799,16 +815,20 @@ exports[`EntityDetail should render a modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      ee4175091d9f4 … 9d09bcf3ecefe
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        ee4175091d9f4 … 9d09bcf3ecefe
+                      </span>
                     </span>
                   </a>
                   <span
@@ -852,16 +872,20 @@ exports[`EntityDetail should render a modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      71fd1a494ded5 … 972b8075d67e9
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        71fd1a494ded5 … 972b8075d67e9
+                      </span>
                     </span>
                   </a>
                   <span
@@ -1090,16 +1114,20 @@ exports[`EntityDetail should render a modal without a wallet alias 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      ee4175091d9f4 … 9d09bcf3ecefe
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        ee4175091d9f4 … 9d09bcf3ecefe
+                      </span>
                     </span>
                   </a>
                   <span
@@ -1143,16 +1171,20 @@ exports[`EntityDetail should render a modal without a wallet alias 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      71fd1a494ded5 … 972b8075d67e9
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        71fd1a494ded5 … 972b8075d67e9
+                      </span>
                     </span>
                   </a>
                   <span
@@ -1387,16 +1419,20 @@ exports[`EntityDetail should render a module entity registration modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      ee4175091d9f4 … 9d09bcf3ecefe
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        ee4175091d9f4 … 9d09bcf3ecefe
+                      </span>
                     </span>
                   </a>
                   <span
@@ -1440,16 +1476,20 @@ exports[`EntityDetail should render a module entity registration modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      71fd1a494ded5 … 972b8075d67e9
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        71fd1a494ded5 … 972b8075d67e9
+                      </span>
                     </span>
                   </a>
                   <span
@@ -1684,16 +1724,20 @@ exports[`EntityDetail should render a module entity resignation modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      ee4175091d9f4 … 9d09bcf3ecefe
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        ee4175091d9f4 … 9d09bcf3ecefe
+                      </span>
                     </span>
                   </a>
                   <span
@@ -1737,16 +1781,20 @@ exports[`EntityDetail should render a module entity resignation modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      71fd1a494ded5 … 972b8075d67e9
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        71fd1a494ded5 … 972b8075d67e9
+                      </span>
                     </span>
                   </a>
                   <span
@@ -1981,16 +2029,20 @@ exports[`EntityDetail should render a module entity update modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      ee4175091d9f4 … 9d09bcf3ecefe
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        ee4175091d9f4 … 9d09bcf3ecefe
+                      </span>
                     </span>
                   </a>
                   <span
@@ -2034,16 +2086,20 @@ exports[`EntityDetail should render a module entity update modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      71fd1a494ded5 … 972b8075d67e9
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        71fd1a494ded5 … 972b8075d67e9
+                      </span>
                     </span>
                   </a>
                   <span
@@ -2278,16 +2334,20 @@ exports[`EntityDetail should render a plugin entity registration modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      ee4175091d9f4 … 9d09bcf3ecefe
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        ee4175091d9f4 … 9d09bcf3ecefe
+                      </span>
                     </span>
                   </a>
                   <span
@@ -2331,16 +2391,20 @@ exports[`EntityDetail should render a plugin entity registration modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      71fd1a494ded5 … 972b8075d67e9
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        71fd1a494ded5 … 972b8075d67e9
+                      </span>
                     </span>
                   </a>
                   <span
@@ -2575,16 +2639,20 @@ exports[`EntityDetail should render a plugin entity resignation modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      ee4175091d9f4 … 9d09bcf3ecefe
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        ee4175091d9f4 … 9d09bcf3ecefe
+                      </span>
                     </span>
                   </a>
                   <span
@@ -2628,16 +2696,20 @@ exports[`EntityDetail should render a plugin entity resignation modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      71fd1a494ded5 … 972b8075d67e9
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        71fd1a494ded5 … 972b8075d67e9
+                      </span>
                     </span>
                   </a>
                   <span
@@ -2872,16 +2944,20 @@ exports[`EntityDetail should render a plugin entity update modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      ee4175091d9f4 … 9d09bcf3ecefe
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        ee4175091d9f4 … 9d09bcf3ecefe
+                      </span>
                     </span>
                   </a>
                   <span
@@ -2925,16 +3001,20 @@ exports[`EntityDetail should render a plugin entity update modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      71fd1a494ded5 … 972b8075d67e9
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        71fd1a494ded5 … 972b8075d67e9
+                      </span>
                     </span>
                   </a>
                   <span
@@ -3169,16 +3249,20 @@ exports[`EntityDetail should render a product entity registration modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      ee4175091d9f4 … 9d09bcf3ecefe
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        ee4175091d9f4 … 9d09bcf3ecefe
+                      </span>
                     </span>
                   </a>
                   <span
@@ -3222,16 +3306,20 @@ exports[`EntityDetail should render a product entity registration modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      71fd1a494ded5 … 972b8075d67e9
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        71fd1a494ded5 … 972b8075d67e9
+                      </span>
                     </span>
                   </a>
                   <span
@@ -3466,16 +3554,20 @@ exports[`EntityDetail should render a product entity resignation modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      ee4175091d9f4 … 9d09bcf3ecefe
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        ee4175091d9f4 … 9d09bcf3ecefe
+                      </span>
                     </span>
                   </a>
                   <span
@@ -3519,16 +3611,20 @@ exports[`EntityDetail should render a product entity resignation modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      71fd1a494ded5 … 972b8075d67e9
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        71fd1a494ded5 … 972b8075d67e9
+                      </span>
                     </span>
                   </a>
                   <span
@@ -3763,16 +3859,20 @@ exports[`EntityDetail should render a product entity update modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      ee4175091d9f4 … 9d09bcf3ecefe
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        ee4175091d9f4 … 9d09bcf3ecefe
+                      </span>
                     </span>
                   </a>
                   <span
@@ -3816,16 +3916,20 @@ exports[`EntityDetail should render a product entity update modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      71fd1a494ded5 … 972b8075d67e9
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        71fd1a494ded5 … 972b8075d67e9
+                      </span>
                     </span>
                   </a>
                   <span
@@ -4062,16 +4166,20 @@ exports[`EntityDetail should render as confirmed 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      ee4175091d9f4 … 9d09bcf3ecefe
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        ee4175091d9f4 … 9d09bcf3ecefe
+                      </span>
                     </span>
                   </a>
                   <span
@@ -4115,16 +4223,20 @@ exports[`EntityDetail should render as confirmed 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      71fd1a494ded5 … 972b8075d67e9
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        71fd1a494ded5 … 972b8075d67e9
+                      </span>
                     </span>
                   </a>
                   <span

--- a/src/domains/transaction/components/IpfsDetail/__snapshots__/IpfsDetail.test.tsx.snap
+++ b/src/domains/transaction/components/IpfsDetail/__snapshots__/IpfsDetail.test.tsx.snap
@@ -237,7 +237,7 @@ exports[`IpfsDetail should render a modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
@@ -294,7 +294,7 @@ exports[`IpfsDetail should render a modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
@@ -568,7 +568,7 @@ exports[`IpfsDetail should render a modal without a wallet alias 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
@@ -625,7 +625,7 @@ exports[`IpfsDetail should render a modal without a wallet alias 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
@@ -907,7 +907,7 @@ exports[`IpfsDetail should render as confirmed 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
@@ -964,7 +964,7 @@ exports[`IpfsDetail should render as confirmed 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"

--- a/src/domains/transaction/components/IpfsDetail/__snapshots__/IpfsDetail.test.tsx.snap
+++ b/src/domains/transaction/components/IpfsDetail/__snapshots__/IpfsDetail.test.tsx.snap
@@ -237,16 +237,20 @@ exports[`IpfsDetail should render a modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      ee4175091d9f4 … 9d09bcf3ecefe
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        ee4175091d9f4 … 9d09bcf3ecefe
+                      </span>
                     </span>
                   </a>
                   <span
@@ -290,16 +294,20 @@ exports[`IpfsDetail should render a modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      71fd1a494ded5 … 972b8075d67e9
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        71fd1a494ded5 … 972b8075d67e9
+                      </span>
                     </span>
                   </a>
                   <span
@@ -560,16 +568,20 @@ exports[`IpfsDetail should render a modal without a wallet alias 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      ee4175091d9f4 … 9d09bcf3ecefe
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        ee4175091d9f4 … 9d09bcf3ecefe
+                      </span>
                     </span>
                   </a>
                   <span
@@ -613,16 +625,20 @@ exports[`IpfsDetail should render a modal without a wallet alias 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      71fd1a494ded5 … 972b8075d67e9
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        71fd1a494ded5 … 972b8075d67e9
+                      </span>
                     </span>
                   </a>
                   <span
@@ -891,16 +907,20 @@ exports[`IpfsDetail should render as confirmed 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      ee4175091d9f4 … 9d09bcf3ecefe
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        ee4175091d9f4 … 9d09bcf3ecefe
+                      </span>
                     </span>
                   </a>
                   <span
@@ -944,16 +964,20 @@ exports[`IpfsDetail should render as confirmed 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      71fd1a494ded5 … 972b8075d67e9
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        71fd1a494ded5 … 972b8075d67e9
+                      </span>
                     </span>
                   </a>
                   <span

--- a/src/domains/transaction/components/LegacyMagistrateDetail/__snapshots__/LegacyMagistrateDetail.test.tsx.snap
+++ b/src/domains/transaction/components/LegacyMagistrateDetail/__snapshots__/LegacyMagistrateDetail.test.tsx.snap
@@ -203,7 +203,7 @@ exports[`LegacyMagistrateDetail Legacy Bridgechain Transactions should render a 
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
@@ -260,7 +260,7 @@ exports[`LegacyMagistrateDetail Legacy Bridgechain Transactions should render a 
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
@@ -508,7 +508,7 @@ exports[`LegacyMagistrateDetail Legacy Bridgechain Transactions should render a 
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
@@ -565,7 +565,7 @@ exports[`LegacyMagistrateDetail Legacy Bridgechain Transactions should render a 
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
@@ -813,7 +813,7 @@ exports[`LegacyMagistrateDetail Legacy Bridgechain Transactions should render a 
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
@@ -870,7 +870,7 @@ exports[`LegacyMagistrateDetail Legacy Bridgechain Transactions should render a 
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
@@ -1118,7 +1118,7 @@ exports[`LegacyMagistrateDetail Legacy Business Transactions should render a leg
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
@@ -1175,7 +1175,7 @@ exports[`LegacyMagistrateDetail Legacy Business Transactions should render a leg
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
@@ -1423,7 +1423,7 @@ exports[`LegacyMagistrateDetail Legacy Business Transactions should render a leg
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
@@ -1480,7 +1480,7 @@ exports[`LegacyMagistrateDetail Legacy Business Transactions should render a leg
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
@@ -1728,7 +1728,7 @@ exports[`LegacyMagistrateDetail Legacy Business Transactions should render a leg
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
@@ -1785,7 +1785,7 @@ exports[`LegacyMagistrateDetail Legacy Business Transactions should render a leg
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"

--- a/src/domains/transaction/components/LegacyMagistrateDetail/__snapshots__/LegacyMagistrateDetail.test.tsx.snap
+++ b/src/domains/transaction/components/LegacyMagistrateDetail/__snapshots__/LegacyMagistrateDetail.test.tsx.snap
@@ -203,16 +203,20 @@ exports[`LegacyMagistrateDetail Legacy Bridgechain Transactions should render a 
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      ee4175091d9f4 … 9d09bcf3ecefe
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        ee4175091d9f4 … 9d09bcf3ecefe
+                      </span>
                     </span>
                   </a>
                   <span
@@ -256,16 +260,20 @@ exports[`LegacyMagistrateDetail Legacy Bridgechain Transactions should render a 
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      71fd1a494ded5 … 972b8075d67e9
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        71fd1a494ded5 … 972b8075d67e9
+                      </span>
                     </span>
                   </a>
                   <span
@@ -500,16 +508,20 @@ exports[`LegacyMagistrateDetail Legacy Bridgechain Transactions should render a 
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      ee4175091d9f4 … 9d09bcf3ecefe
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        ee4175091d9f4 … 9d09bcf3ecefe
+                      </span>
                     </span>
                   </a>
                   <span
@@ -553,16 +565,20 @@ exports[`LegacyMagistrateDetail Legacy Bridgechain Transactions should render a 
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      71fd1a494ded5 … 972b8075d67e9
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        71fd1a494ded5 … 972b8075d67e9
+                      </span>
                     </span>
                   </a>
                   <span
@@ -797,16 +813,20 @@ exports[`LegacyMagistrateDetail Legacy Bridgechain Transactions should render a 
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      ee4175091d9f4 … 9d09bcf3ecefe
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        ee4175091d9f4 … 9d09bcf3ecefe
+                      </span>
                     </span>
                   </a>
                   <span
@@ -850,16 +870,20 @@ exports[`LegacyMagistrateDetail Legacy Bridgechain Transactions should render a 
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      71fd1a494ded5 … 972b8075d67e9
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        71fd1a494ded5 … 972b8075d67e9
+                      </span>
                     </span>
                   </a>
                   <span
@@ -1094,16 +1118,20 @@ exports[`LegacyMagistrateDetail Legacy Business Transactions should render a leg
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      ee4175091d9f4 … 9d09bcf3ecefe
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        ee4175091d9f4 … 9d09bcf3ecefe
+                      </span>
                     </span>
                   </a>
                   <span
@@ -1147,16 +1175,20 @@ exports[`LegacyMagistrateDetail Legacy Business Transactions should render a leg
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      71fd1a494ded5 … 972b8075d67e9
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        71fd1a494ded5 … 972b8075d67e9
+                      </span>
                     </span>
                   </a>
                   <span
@@ -1391,16 +1423,20 @@ exports[`LegacyMagistrateDetail Legacy Business Transactions should render a leg
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      ee4175091d9f4 … 9d09bcf3ecefe
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        ee4175091d9f4 … 9d09bcf3ecefe
+                      </span>
                     </span>
                   </a>
                   <span
@@ -1444,16 +1480,20 @@ exports[`LegacyMagistrateDetail Legacy Business Transactions should render a leg
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      71fd1a494ded5 … 972b8075d67e9
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        71fd1a494ded5 … 972b8075d67e9
+                      </span>
                     </span>
                   </a>
                   <span
@@ -1688,16 +1728,20 @@ exports[`LegacyMagistrateDetail Legacy Business Transactions should render a leg
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      ee4175091d9f4 … 9d09bcf3ecefe
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        ee4175091d9f4 … 9d09bcf3ecefe
+                      </span>
                     </span>
                   </a>
                   <span
@@ -1741,16 +1785,20 @@ exports[`LegacyMagistrateDetail Legacy Business Transactions should render a leg
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      71fd1a494ded5 … 972b8075d67e9
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        71fd1a494ded5 … 972b8075d67e9
+                      </span>
                     </span>
                   </a>
                   <span

--- a/src/domains/transaction/components/MultiPaymentDetail/__snapshots__/MultiPaymentDetail.test.tsx.snap
+++ b/src/domains/transaction/components/MultiPaymentDetail/__snapshots__/MultiPaymentDetail.test.tsx.snap
@@ -288,7 +288,7 @@ exports[`MultiPaymentDetail should render a modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
@@ -345,7 +345,7 @@ exports[`MultiPaymentDetail should render a modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
@@ -932,7 +932,7 @@ exports[`MultiPaymentDetail should render with recipients 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
@@ -989,7 +989,7 @@ exports[`MultiPaymentDetail should render with recipients 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"

--- a/src/domains/transaction/components/MultiPaymentDetail/__snapshots__/MultiPaymentDetail.test.tsx.snap
+++ b/src/domains/transaction/components/MultiPaymentDetail/__snapshots__/MultiPaymentDetail.test.tsx.snap
@@ -288,16 +288,20 @@ exports[`MultiPaymentDetail should render a modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      ee4175091d9f4 … 9d09bcf3ecefe
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        ee4175091d9f4 … 9d09bcf3ecefe
+                      </span>
                     </span>
                   </a>
                   <span
@@ -341,16 +345,20 @@ exports[`MultiPaymentDetail should render a modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      adsad12312xsd1w312e1s13203e12
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        adsad12312xsd1w312e1s13203e12
+                      </span>
                     </span>
                   </a>
                   <span
@@ -924,16 +932,20 @@ exports[`MultiPaymentDetail should render with recipients 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      ee4175091d9f4 … 9d09bcf3ecefe
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        ee4175091d9f4 … 9d09bcf3ecefe
+                      </span>
                     </span>
                   </a>
                   <span
@@ -977,16 +989,20 @@ exports[`MultiPaymentDetail should render with recipients 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      adsad12312xsd1w312e1s13203e12
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        adsad12312xsd1w312e1s13203e12
+                      </span>
                     </span>
                   </a>
                   <span

--- a/src/domains/transaction/components/MultiSignatureDetail/__snapshots__/MultiSignatureRegistrationDetail.test.tsx.snap
+++ b/src/domains/transaction/components/MultiSignatureDetail/__snapshots__/MultiSignatureRegistrationDetail.test.tsx.snap
@@ -272,7 +272,7 @@ exports[`MultiSignatureRegistrationDetail should render 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
@@ -329,7 +329,7 @@ exports[`MultiSignatureRegistrationDetail should render 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"

--- a/src/domains/transaction/components/MultiSignatureDetail/__snapshots__/MultiSignatureRegistrationDetail.test.tsx.snap
+++ b/src/domains/transaction/components/MultiSignatureDetail/__snapshots__/MultiSignatureRegistrationDetail.test.tsx.snap
@@ -272,16 +272,20 @@ exports[`MultiSignatureRegistrationDetail should render 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      ee4175091d9f4 … 9d09bcf3ecefe
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        ee4175091d9f4 … 9d09bcf3ecefe
+                      </span>
                     </span>
                   </a>
                   <span
@@ -325,16 +329,20 @@ exports[`MultiSignatureRegistrationDetail should render 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      71fd1a494ded5 … 972b8075d67e9
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        71fd1a494ded5 … 972b8075d67e9
+                      </span>
                     </span>
                   </a>
                   <span

--- a/src/domains/transaction/components/SecondSignatureDetail/__snapshots__/SecondSignatureDetail.test.tsx.snap
+++ b/src/domains/transaction/components/SecondSignatureDetail/__snapshots__/SecondSignatureDetail.test.tsx.snap
@@ -205,7 +205,7 @@ exports[`SecondSignatureDetail should render a modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
@@ -262,7 +262,7 @@ exports[`SecondSignatureDetail should render a modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
@@ -504,7 +504,7 @@ exports[`SecondSignatureDetail should render a modal without a wallet alias 1`] 
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
@@ -561,7 +561,7 @@ exports[`SecondSignatureDetail should render a modal without a wallet alias 1`] 
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
@@ -811,7 +811,7 @@ exports[`SecondSignatureDetail should render as confirmed 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
@@ -868,7 +868,7 @@ exports[`SecondSignatureDetail should render as confirmed 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"

--- a/src/domains/transaction/components/SecondSignatureDetail/__snapshots__/SecondSignatureDetail.test.tsx.snap
+++ b/src/domains/transaction/components/SecondSignatureDetail/__snapshots__/SecondSignatureDetail.test.tsx.snap
@@ -205,16 +205,20 @@ exports[`SecondSignatureDetail should render a modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      ee4175091d9f4 … 9d09bcf3ecefe
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        ee4175091d9f4 … 9d09bcf3ecefe
+                      </span>
                     </span>
                   </a>
                   <span
@@ -258,16 +262,20 @@ exports[`SecondSignatureDetail should render a modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      71fd1a494ded5 … 972b8075d67e9
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        71fd1a494ded5 … 972b8075d67e9
+                      </span>
                     </span>
                   </a>
                   <span
@@ -496,16 +504,20 @@ exports[`SecondSignatureDetail should render a modal without a wallet alias 1`] 
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      ee4175091d9f4 … 9d09bcf3ecefe
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        ee4175091d9f4 … 9d09bcf3ecefe
+                      </span>
                     </span>
                   </a>
                   <span
@@ -549,16 +561,20 @@ exports[`SecondSignatureDetail should render a modal without a wallet alias 1`] 
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      71fd1a494ded5 … 972b8075d67e9
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        71fd1a494ded5 … 972b8075d67e9
+                      </span>
                     </span>
                   </a>
                   <span
@@ -795,16 +811,20 @@ exports[`SecondSignatureDetail should render as confirmed 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      ee4175091d9f4 … 9d09bcf3ecefe
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        ee4175091d9f4 … 9d09bcf3ecefe
+                      </span>
                     </span>
                   </a>
                   <span
@@ -848,16 +868,20 @@ exports[`SecondSignatureDetail should render as confirmed 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      71fd1a494ded5 … 972b8075d67e9
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        71fd1a494ded5 … 972b8075d67e9
+                      </span>
                     </span>
                   </a>
                   <span

--- a/src/domains/transaction/components/TransactionDetail/TransactionExplorerLink/__snapshots__/TransactionExplorerLink.test.tsx.snap
+++ b/src/domains/transaction/components/TransactionDetail/TransactionExplorerLink/__snapshots__/TransactionExplorerLink.test.tsx.snap
@@ -21,16 +21,20 @@ exports[`TransactionExplorerLink should render a 'block' link 1`] = `
           class="flex items-center space-x-3"
         >
           <a
-            class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+            class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
             data-testid="Link"
             rel="noopener noreferrer"
             to="block-link}"
           >
             <span
-              class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-              data-testid="TruncateMiddle"
+              class="underline-dotted"
             >
-              test-id
+              <span
+                class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                data-testid="TruncateMiddle"
+              >
+                test-id
+              </span>
             </span>
           </a>
           <span
@@ -79,16 +83,20 @@ exports[`TransactionExplorerLink should render a 'transaction' link 1`] = `
           class="flex items-center space-x-3"
         >
           <a
-            class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+            class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
             data-testid="Link"
             rel="noopener noreferrer"
             to="transaction-link}"
           >
             <span
-              class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-              data-testid="TruncateMiddle"
+              class="underline-dotted"
             >
-              test-id
+              <span
+                class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                data-testid="TruncateMiddle"
+              >
+                test-id
+              </span>
             </span>
           </a>
           <span

--- a/src/domains/transaction/components/TransactionDetail/TransactionExplorerLink/__snapshots__/TransactionExplorerLink.test.tsx.snap
+++ b/src/domains/transaction/components/TransactionDetail/TransactionExplorerLink/__snapshots__/TransactionExplorerLink.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`TransactionExplorerLink should render a 'block' link 1`] = `
           class="flex items-center space-x-3"
         >
           <a
-            class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+            class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
             data-testid="Link"
             rel="noopener noreferrer"
             to="block-link}"
@@ -83,7 +83,7 @@ exports[`TransactionExplorerLink should render a 'transaction' link 1`] = `
           class="flex items-center space-x-3"
         >
           <a
-            class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+            class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
             data-testid="Link"
             rel="noopener noreferrer"
             to="transaction-link}"

--- a/src/domains/transaction/components/TransactionDetailModal/__snapshots__/TransactionDetailModal.test.tsx.snap
+++ b/src/domains/transaction/components/TransactionDetailModal/__snapshots__/TransactionDetailModal.test.tsx.snap
@@ -224,16 +224,20 @@ exports[`TransactionDetailModal should render a delegate registration modal 1`] 
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      ee4175091d9f4 … 9d09bcf3ecefe
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        ee4175091d9f4 … 9d09bcf3ecefe
+                      </span>
                     </span>
                   </a>
                   <span
@@ -277,16 +281,20 @@ exports[`TransactionDetailModal should render a delegate registration modal 1`] 
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      as32d1as65d1a … as3d2as165das
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        as32d1as65d1a … as3d2as165das
+                      </span>
                     </span>
                   </a>
                   <span
@@ -541,16 +549,20 @@ exports[`TransactionDetailModal should render a delegate resignation modal 1`] =
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      ee4175091d9f4 … 9d09bcf3ecefe
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        ee4175091d9f4 … 9d09bcf3ecefe
+                      </span>
                     </span>
                   </a>
                   <span
@@ -594,16 +606,20 @@ exports[`TransactionDetailModal should render a delegate resignation modal 1`] =
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      as32d1as65d1a … as3d2as165das
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        as32d1as65d1a … as3d2as165das
+                      </span>
                     </span>
                   </a>
                   <span
@@ -839,16 +855,20 @@ exports[`TransactionDetailModal should render a entity modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      ee4175091d9f4 … 9d09bcf3ecefe
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        ee4175091d9f4 … 9d09bcf3ecefe
+                      </span>
                     </span>
                   </a>
                   <span
@@ -892,16 +912,20 @@ exports[`TransactionDetailModal should render a entity modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      as32d1as65d1a … as3d2as165das
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        as32d1as65d1a … as3d2as165das
+                      </span>
                     </span>
                   </a>
                   <span
@@ -1169,16 +1193,20 @@ exports[`TransactionDetailModal should render a ipfs modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      ee4175091d9f4 … 9d09bcf3ecefe
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        ee4175091d9f4 … 9d09bcf3ecefe
+                      </span>
                     </span>
                   </a>
                   <span
@@ -1222,16 +1250,20 @@ exports[`TransactionDetailModal should render a ipfs modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      71fd1a494ded5 … 972b8075d67e9
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        71fd1a494ded5 … 972b8075d67e9
+                      </span>
                     </span>
                   </a>
                   <span
@@ -1467,16 +1499,20 @@ exports[`TransactionDetailModal should render a legacy magistrate modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      ee4175091d9f4 … 9d09bcf3ecefe
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        ee4175091d9f4 … 9d09bcf3ecefe
+                      </span>
                     </span>
                   </a>
                   <span
@@ -1520,16 +1556,20 @@ exports[`TransactionDetailModal should render a legacy magistrate modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      as32d1as65d1a … as3d2as165das
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        as32d1as65d1a … as3d2as165das
+                      </span>
                     </span>
                   </a>
                   <span
@@ -1848,16 +1888,20 @@ exports[`TransactionDetailModal should render a multi payment modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      ee4175091d9f4 … 9d09bcf3ecefe
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        ee4175091d9f4 … 9d09bcf3ecefe
+                      </span>
                     </span>
                   </a>
                   <span
@@ -1901,16 +1945,20 @@ exports[`TransactionDetailModal should render a multi payment modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      as32d1as65d1a … as3d2as165das
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        as32d1as65d1a … as3d2as165das
+                      </span>
                     </span>
                   </a>
                   <span
@@ -2213,16 +2261,20 @@ exports[`TransactionDetailModal should render a multi signature modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      ee4175091d9f4 … 9d09bcf3ecefe
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        ee4175091d9f4 … 9d09bcf3ecefe
+                      </span>
                     </span>
                   </a>
                   <span
@@ -2266,16 +2318,20 @@ exports[`TransactionDetailModal should render a multi signature modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      as32d1as65d1a … as3d2as165das
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        as32d1as65d1a … as3d2as165das
+                      </span>
                     </span>
                   </a>
                   <span
@@ -2511,16 +2567,20 @@ exports[`TransactionDetailModal should render a second signature modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      ee4175091d9f4 … 9d09bcf3ecefe
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        ee4175091d9f4 … 9d09bcf3ecefe
+                      </span>
                     </span>
                   </a>
                   <span
@@ -2564,16 +2624,20 @@ exports[`TransactionDetailModal should render a second signature modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      as32d1as65d1a … as3d2as165das
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        as32d1as65d1a … as3d2as165das
+                      </span>
                     </span>
                   </a>
                   <span
@@ -2934,16 +2998,20 @@ exports[`TransactionDetailModal should render a transfer modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      ee4175091d9f4 … 9d09bcf3ecefe
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        ee4175091d9f4 … 9d09bcf3ecefe
+                      </span>
                     </span>
                   </a>
                   <span
@@ -2987,16 +3055,20 @@ exports[`TransactionDetailModal should render a transfer modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      as32d1as65d1a … as3d2as165das
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        as32d1as65d1a … as3d2as165das
+                      </span>
                     </span>
                   </a>
                   <span
@@ -3384,16 +3456,20 @@ exports[`TransactionDetailModal should render a unvote modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      ee4175091d9f4 … 9d09bcf3ecefe
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        ee4175091d9f4 … 9d09bcf3ecefe
+                      </span>
                     </span>
                   </a>
                   <span
@@ -3437,16 +3513,20 @@ exports[`TransactionDetailModal should render a unvote modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      as32d1as65d1a … as3d2as165das
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        as32d1as65d1a … as3d2as165das
+                      </span>
                     </span>
                   </a>
                   <span
@@ -3834,16 +3914,20 @@ exports[`TransactionDetailModal should render a vote modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      ee4175091d9f4 … 9d09bcf3ecefe
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        ee4175091d9f4 … 9d09bcf3ecefe
+                      </span>
                     </span>
                   </a>
                   <span
@@ -3887,16 +3971,20 @@ exports[`TransactionDetailModal should render a vote modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      as32d1as65d1a … as3d2as165das
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        as32d1as65d1a … as3d2as165das
+                      </span>
                     </span>
                   </a>
                   <span

--- a/src/domains/transaction/components/TransactionDetailModal/__snapshots__/TransactionDetailModal.test.tsx.snap
+++ b/src/domains/transaction/components/TransactionDetailModal/__snapshots__/TransactionDetailModal.test.tsx.snap
@@ -224,7 +224,7 @@ exports[`TransactionDetailModal should render a delegate registration modal 1`] 
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
@@ -281,7 +281,7 @@ exports[`TransactionDetailModal should render a delegate registration modal 1`] 
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
@@ -549,7 +549,7 @@ exports[`TransactionDetailModal should render a delegate resignation modal 1`] =
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
@@ -606,7 +606,7 @@ exports[`TransactionDetailModal should render a delegate resignation modal 1`] =
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
@@ -855,7 +855,7 @@ exports[`TransactionDetailModal should render a entity modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
@@ -912,7 +912,7 @@ exports[`TransactionDetailModal should render a entity modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
@@ -1193,7 +1193,7 @@ exports[`TransactionDetailModal should render a ipfs modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
@@ -1250,7 +1250,7 @@ exports[`TransactionDetailModal should render a ipfs modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
@@ -1499,7 +1499,7 @@ exports[`TransactionDetailModal should render a legacy magistrate modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
@@ -1556,7 +1556,7 @@ exports[`TransactionDetailModal should render a legacy magistrate modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
@@ -1888,7 +1888,7 @@ exports[`TransactionDetailModal should render a multi payment modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
@@ -1945,7 +1945,7 @@ exports[`TransactionDetailModal should render a multi payment modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
@@ -2261,7 +2261,7 @@ exports[`TransactionDetailModal should render a multi signature modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
@@ -2318,7 +2318,7 @@ exports[`TransactionDetailModal should render a multi signature modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
@@ -2567,7 +2567,7 @@ exports[`TransactionDetailModal should render a second signature modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
@@ -2624,7 +2624,7 @@ exports[`TransactionDetailModal should render a second signature modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
@@ -2998,7 +2998,7 @@ exports[`TransactionDetailModal should render a transfer modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
@@ -3055,7 +3055,7 @@ exports[`TransactionDetailModal should render a transfer modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
@@ -3456,7 +3456,7 @@ exports[`TransactionDetailModal should render a unvote modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
@@ -3513,7 +3513,7 @@ exports[`TransactionDetailModal should render a unvote modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
@@ -3914,7 +3914,7 @@ exports[`TransactionDetailModal should render a vote modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
@@ -3971,7 +3971,7 @@ exports[`TransactionDetailModal should render a vote modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"

--- a/src/domains/transaction/components/TransactionTable/__snapshots__/TransactionTable.test.tsx.snap
+++ b/src/domains/transaction/components/TransactionTable/__snapshots__/TransactionTable.test.tsx.snap
@@ -3563,7 +3563,7 @@ exports[`TransactionTable should render 1`] = `
                 class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 gMOims"
               >
                 <a
-                  class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                  class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                   data-testid="TransactionRow__ID"
                   rel="noopener noreferrer"
                   to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
@@ -3725,7 +3725,7 @@ exports[`TransactionTable should render 1`] = `
                 class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 gMOims"
               >
                 <a
-                  class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                  class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                   data-testid="TransactionRow__ID"
                   rel="noopener noreferrer"
                   to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
@@ -4279,7 +4279,7 @@ exports[`TransactionTable should render with sign 1`] = `
                 class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 gMOims"
               >
                 <a
-                  class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                  class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                   data-testid="TransactionRow__ID"
                   rel="noopener noreferrer"
                   to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
@@ -4460,7 +4460,7 @@ exports[`TransactionTable should render with sign 1`] = `
                 class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 gMOims"
               >
                 <a
-                  class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                  class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                   data-testid="TransactionRow__ID"
                   rel="noopener noreferrer"
                   to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"

--- a/src/domains/transaction/components/TransactionTable/__snapshots__/TransactionTable.test.tsx.snap
+++ b/src/domains/transaction/components/TransactionTable/__snapshots__/TransactionTable.test.tsx.snap
@@ -3563,20 +3563,24 @@ exports[`TransactionTable should render 1`] = `
                 class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 gMOims"
               >
                 <a
-                  class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                  class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                   data-testid="TransactionRow__ID"
                   rel="noopener noreferrer"
                   to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
                 >
-                  <div
-                    class="sc-bdfBwQ fPrsah"
-                    height="1em"
-                    width="1em"
+                  <span
+                    class="underline-dotted"
                   >
-                    <svg>
-                      id.svg
-                    </svg>
-                  </div>
+                    <div
+                      class="sc-bdfBwQ fPrsah"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        id.svg
+                      </svg>
+                    </div>
+                  </span>
                 </a>
               </div>
             </td>
@@ -3721,20 +3725,24 @@ exports[`TransactionTable should render 1`] = `
                 class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 gMOims"
               >
                 <a
-                  class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                  class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                   data-testid="TransactionRow__ID"
                   rel="noopener noreferrer"
                   to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
                 >
-                  <div
-                    class="sc-bdfBwQ fPrsah"
-                    height="1em"
-                    width="1em"
+                  <span
+                    class="underline-dotted"
                   >
-                    <svg>
-                      id.svg
-                    </svg>
-                  </div>
+                    <div
+                      class="sc-bdfBwQ fPrsah"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        id.svg
+                      </svg>
+                    </div>
+                  </span>
                 </a>
               </div>
             </td>
@@ -4271,20 +4279,24 @@ exports[`TransactionTable should render with sign 1`] = `
                 class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 gMOims"
               >
                 <a
-                  class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                  class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                   data-testid="TransactionRow__ID"
                   rel="noopener noreferrer"
                   to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
                 >
-                  <div
-                    class="sc-bdfBwQ fPrsah"
-                    height="1em"
-                    width="1em"
+                  <span
+                    class="underline-dotted"
                   >
-                    <svg>
-                      id.svg
-                    </svg>
-                  </div>
+                    <div
+                      class="sc-bdfBwQ fPrsah"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        id.svg
+                      </svg>
+                    </div>
+                  </span>
                 </a>
               </div>
             </td>
@@ -4448,20 +4460,24 @@ exports[`TransactionTable should render with sign 1`] = `
                 class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 gMOims"
               >
                 <a
-                  class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                  class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                   data-testid="TransactionRow__ID"
                   rel="noopener noreferrer"
                   to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
                 >
-                  <div
-                    class="sc-bdfBwQ fPrsah"
-                    height="1em"
-                    width="1em"
+                  <span
+                    class="underline-dotted"
                   >
-                    <svg>
-                      id.svg
-                    </svg>
-                  </div>
+                    <div
+                      class="sc-bdfBwQ fPrsah"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        id.svg
+                      </svg>
+                    </div>
+                  </span>
                 </a>
               </div>
             </td>

--- a/src/domains/transaction/components/TransferDetail/__snapshots__/TransferDetail.test.tsx.snap
+++ b/src/domains/transaction/components/TransferDetail/__snapshots__/TransferDetail.test.tsx.snap
@@ -330,7 +330,7 @@ exports[`TransferDetail should render a modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
@@ -387,7 +387,7 @@ exports[`TransferDetail should render a modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
@@ -762,7 +762,7 @@ exports[`TransferDetail should render as confirmed 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
@@ -819,7 +819,7 @@ exports[`TransferDetail should render as confirmed 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
@@ -1192,7 +1192,7 @@ exports[`TransferDetail should render as not is sent 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
@@ -1249,7 +1249,7 @@ exports[`TransferDetail should render as not is sent 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
@@ -1622,7 +1622,7 @@ exports[`TransferDetail should render with wallet alias 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
@@ -1679,7 +1679,7 @@ exports[`TransferDetail should render with wallet alias 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"

--- a/src/domains/transaction/components/TransferDetail/__snapshots__/TransferDetail.test.tsx.snap
+++ b/src/domains/transaction/components/TransferDetail/__snapshots__/TransferDetail.test.tsx.snap
@@ -330,16 +330,20 @@ exports[`TransferDetail should render a modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      ee4175091d9f4 … 9d09bcf3ecefe
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        ee4175091d9f4 … 9d09bcf3ecefe
+                      </span>
                     </span>
                   </a>
                   <span
@@ -383,16 +387,20 @@ exports[`TransferDetail should render a modal 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      adsad12312xsd1w312e1s13203e12
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        adsad12312xsd1w312e1s13203e12
+                      </span>
                     </span>
                   </a>
                   <span
@@ -754,16 +762,20 @@ exports[`TransferDetail should render as confirmed 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      ee4175091d9f4 … 9d09bcf3ecefe
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        ee4175091d9f4 … 9d09bcf3ecefe
+                      </span>
                     </span>
                   </a>
                   <span
@@ -807,16 +819,20 @@ exports[`TransferDetail should render as confirmed 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      adsad12312xsd1w312e1s13203e12
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        adsad12312xsd1w312e1s13203e12
+                      </span>
                     </span>
                   </a>
                   <span
@@ -1176,16 +1192,20 @@ exports[`TransferDetail should render as not is sent 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      ee4175091d9f4 … 9d09bcf3ecefe
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        ee4175091d9f4 … 9d09bcf3ecefe
+                      </span>
                     </span>
                   </a>
                   <span
@@ -1229,16 +1249,20 @@ exports[`TransferDetail should render as not is sent 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      adsad12312xsd1w312e1s13203e12
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        adsad12312xsd1w312e1s13203e12
+                      </span>
                     </span>
                   </a>
                   <span
@@ -1598,16 +1622,20 @@ exports[`TransferDetail should render with wallet alias 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      ee4175091d9f4 … 9d09bcf3ecefe
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        ee4175091d9f4 … 9d09bcf3ecefe
+                      </span>
                     </span>
                   </a>
                   <span
@@ -1651,16 +1679,20 @@ exports[`TransferDetail should render with wallet alias 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      adsad12312xsd1w312e1s13203e12
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        adsad12312xsd1w312e1s13203e12
+                      </span>
                     </span>
                   </a>
                   <span

--- a/src/domains/transaction/components/VoteDetail/__snapshots__/VoteDetail.test.tsx.snap
+++ b/src/domains/transaction/components/VoteDetail/__snapshots__/VoteDetail.test.tsx.snap
@@ -297,16 +297,20 @@ exports[`VoteDetail should render a modal with unvotes 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      ee4175091d9f4 … 9d09bcf3ecefe
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        ee4175091d9f4 … 9d09bcf3ecefe
+                      </span>
                     </span>
                   </a>
                   <span
@@ -350,16 +354,20 @@ exports[`VoteDetail should render a modal with unvotes 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      71fd1a494ded5 … 972b8075d67e9
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        71fd1a494ded5 … 972b8075d67e9
+                      </span>
                     </span>
                   </a>
                   <span
@@ -686,16 +694,20 @@ exports[`VoteDetail should render a modal with votes 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      ee4175091d9f4 … 9d09bcf3ecefe
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        ee4175091d9f4 … 9d09bcf3ecefe
+                      </span>
                     </span>
                   </a>
                   <span
@@ -739,16 +751,20 @@ exports[`VoteDetail should render a modal with votes 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      71fd1a494ded5 … 972b8075d67e9
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        71fd1a494ded5 … 972b8075d67e9
+                      </span>
                     </span>
                   </a>
                   <span
@@ -1135,16 +1151,20 @@ exports[`VoteDetail should render a modal with votes and unvotes 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      ee4175091d9f4 … 9d09bcf3ecefe
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        ee4175091d9f4 … 9d09bcf3ecefe
+                      </span>
                     </span>
                   </a>
                   <span
@@ -1188,16 +1208,20 @@ exports[`VoteDetail should render a modal with votes and unvotes 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
                   >
                     <span
-                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                      data-testid="TruncateMiddle"
+                      class="underline-dotted"
                     >
-                      71fd1a494ded5 … 972b8075d67e9
+                      <span
+                        class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                        data-testid="TruncateMiddle"
+                      >
+                        71fd1a494ded5 … 972b8075d67e9
+                      </span>
                     </span>
                   </a>
                   <span

--- a/src/domains/transaction/components/VoteDetail/__snapshots__/VoteDetail.test.tsx.snap
+++ b/src/domains/transaction/components/VoteDetail/__snapshots__/VoteDetail.test.tsx.snap
@@ -297,7 +297,7 @@ exports[`VoteDetail should render a modal with unvotes 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
@@ -354,7 +354,7 @@ exports[`VoteDetail should render a modal with unvotes 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
@@ -694,7 +694,7 @@ exports[`VoteDetail should render a modal with votes 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
@@ -751,7 +751,7 @@ exports[`VoteDetail should render a modal with votes 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"
@@ -1151,7 +1151,7 @@ exports[`VoteDetail should render a modal with votes and unvotes 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/transaction/ee4175091d9f4dacf5fed213711c3e0e4cc371e37afa7bce0429d09bcf3ecefe"
@@ -1208,7 +1208,7 @@ exports[`VoteDetail should render a modal with votes and unvotes 1`] = `
                   class="flex items-center space-x-3"
                 >
                   <a
-                    class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                    class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                     data-testid="Link"
                     rel="noopener noreferrer"
                     to="https://explorer.ark.io/blocks/71fd1a494ded5430586f4dd1c79c3ac77bf38120e868c8f8980972b8075d67e9"

--- a/src/domains/transaction/pages/SendDelegateResignation/__snapshots__/SendDelegateResignation.test.tsx.snap
+++ b/src/domains/transaction/pages/SendDelegateResignation/__snapshots__/SendDelegateResignation.test.tsx.snap
@@ -3998,16 +3998,20 @@ exports[`SendDelegateResignation Delegate Resignation should successfully sign a
                                 class="flex items-center space-x-3"
                               >
                                 <a
-                                  class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                                  class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                                   data-testid="Link"
                                   rel="noopener noreferrer"
                                   to="https://dexplorer.ark.io/transaction/8f913b6b719e7767d49861c0aec79ced212767645cb793d75d2f1b89abb49877"
                                 >
                                   <span
-                                    class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                                    data-testid="TruncateMiddle"
+                                    class="underline-dotted"
                                   >
-                                    8f913b6b719e7 … f1b89abb49877
+                                    <span
+                                      class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                                      data-testid="TruncateMiddle"
+                                    >
+                                      8f913b6b719e7 … f1b89abb49877
+                                    </span>
                                   </span>
                                 </a>
                                 <span

--- a/src/domains/transaction/pages/SendDelegateResignation/__snapshots__/SendDelegateResignation.test.tsx.snap
+++ b/src/domains/transaction/pages/SendDelegateResignation/__snapshots__/SendDelegateResignation.test.tsx.snap
@@ -3998,7 +3998,7 @@ exports[`SendDelegateResignation Delegate Resignation should successfully sign a
                                 class="flex items-center space-x-3"
                               >
                                 <a
-                                  class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                                  class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                                   data-testid="Link"
                                   rel="noopener noreferrer"
                                   to="https://dexplorer.ark.io/transaction/8f913b6b719e7767d49861c0aec79ced212767645cb793d75d2f1b89abb49877"

--- a/src/domains/transaction/pages/SendIpfs/__snapshots__/SendIpfs.test.tsx.snap
+++ b/src/domains/transaction/pages/SendIpfs/__snapshots__/SendIpfs.test.tsx.snap
@@ -1441,16 +1441,20 @@ exports[`SendIpfs should send an IPFS transaction and go back to wallet page 1`]
                               class="flex items-center space-x-3"
                             >
                               <a
-                                class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                                class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                                 data-testid="Link"
                                 rel="noopener noreferrer"
                                 to="https://dexplorer.ark.io/transaction/1e9b975eff66a731095876c3b6cbff14fd4dec3bb37a4127c46db3d69131067e"
                               >
                                 <span
-                                  class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                                  data-testid="TruncateMiddle"
+                                  class="underline-dotted"
                                 >
-                                  1e9b975eff66a … db3d69131067e
+                                  <span
+                                    class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                                    data-testid="TruncateMiddle"
+                                  >
+                                    1e9b975eff66a … db3d69131067e
+                                  </span>
                                 </span>
                               </a>
                               <span

--- a/src/domains/transaction/pages/SendIpfs/__snapshots__/SendIpfs.test.tsx.snap
+++ b/src/domains/transaction/pages/SendIpfs/__snapshots__/SendIpfs.test.tsx.snap
@@ -1441,7 +1441,7 @@ exports[`SendIpfs should send an IPFS transaction and go back to wallet page 1`]
                               class="flex items-center space-x-3"
                             >
                               <a
-                                class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                                class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                                 data-testid="Link"
                                 rel="noopener noreferrer"
                                 to="https://dexplorer.ark.io/transaction/1e9b975eff66a731095876c3b6cbff14fd4dec3bb37a4127c46db3d69131067e"

--- a/src/domains/transaction/pages/SendTransfer/__snapshots__/SendTransfer.test.tsx.snap
+++ b/src/domains/transaction/pages/SendTransfer/__snapshots__/SendTransfer.test.tsx.snap
@@ -2935,7 +2935,7 @@ exports[`SendTransfer should render 4th step (summary) 1`] = `
               class="flex items-center space-x-3"
             >
               <a
-                class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                 data-testid="Link"
                 rel="noopener noreferrer"
                 to="https://dexplorer.ark.io/transaction/8f913b6b719e7767d49861c0aec79ced212767645cb793d75d2f1b89abb49877"
@@ -6907,7 +6907,7 @@ exports[`SendTransfer should send a single transfer 1`] = `
                               class="flex items-center space-x-3"
                             >
                               <a
-                                class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                                class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                                 data-testid="Link"
                                 rel="noopener noreferrer"
                                 to="https://dexplorer.ark.io/transaction/8f913b6b719e7767d49861c0aec79ced212767645cb793d75d2f1b89abb49877"

--- a/src/domains/transaction/pages/SendTransfer/__snapshots__/SendTransfer.test.tsx.snap
+++ b/src/domains/transaction/pages/SendTransfer/__snapshots__/SendTransfer.test.tsx.snap
@@ -2935,16 +2935,20 @@ exports[`SendTransfer should render 4th step (summary) 1`] = `
               class="flex items-center space-x-3"
             >
               <a
-                class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                 data-testid="Link"
                 rel="noopener noreferrer"
                 to="https://dexplorer.ark.io/transaction/8f913b6b719e7767d49861c0aec79ced212767645cb793d75d2f1b89abb49877"
               >
                 <span
-                  class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                  data-testid="TruncateMiddle"
+                  class="underline-dotted"
                 >
-                  8f913b6b719e7 … f1b89abb49877
+                  <span
+                    class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                    data-testid="TruncateMiddle"
+                  >
+                    8f913b6b719e7 … f1b89abb49877
+                  </span>
                 </span>
               </a>
               <span
@@ -6903,16 +6907,20 @@ exports[`SendTransfer should send a single transfer 1`] = `
                               class="flex items-center space-x-3"
                             >
                               <a
-                                class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                                class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                                 data-testid="Link"
                                 rel="noopener noreferrer"
                                 to="https://dexplorer.ark.io/transaction/8f913b6b719e7767d49861c0aec79ced212767645cb793d75d2f1b89abb49877"
                               >
                                 <span
-                                  class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                                  data-testid="TruncateMiddle"
+                                  class="underline-dotted"
                                 >
-                                  8f913b6b719e7 … f1b89abb49877
+                                  <span
+                                    class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                                    data-testid="TruncateMiddle"
+                                  >
+                                    8f913b6b719e7 … f1b89abb49877
+                                  </span>
                                 </span>
                               </a>
                               <span

--- a/src/domains/transaction/pages/SendVote/__snapshots__/SendVote.test.tsx.snap
+++ b/src/domains/transaction/pages/SendVote/__snapshots__/SendVote.test.tsx.snap
@@ -406,16 +406,20 @@ exports[`SendVote should send a unvote & vote transaction 1`] = `
                               class="flex items-center space-x-3"
                             >
                               <a
-                                class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                                class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                                 data-testid="Link"
                                 rel="noopener noreferrer"
                                 to="https://dexplorer.ark.io/transaction/d819c5199e323a62a4349948ff075edde91e509028329f66ec76b8518ad1e493"
                               >
                                 <span
-                                  class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                                  data-testid="TruncateMiddle"
+                                  class="underline-dotted"
                                 >
-                                  d819c5199e323 … 6b8518ad1e493
+                                  <span
+                                    class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                                    data-testid="TruncateMiddle"
+                                  >
+                                    d819c5199e323 … 6b8518ad1e493
+                                  </span>
                                 </span>
                               </a>
                               <span
@@ -1139,16 +1143,20 @@ exports[`SendVote should send a unvote transaction 1`] = `
                               class="flex items-center space-x-3"
                             >
                               <a
-                                class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                                class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                                 data-testid="Link"
                                 rel="noopener noreferrer"
                                 to="https://dexplorer.ark.io/transaction/32e5278cb72f24f2c04c4797dbfbffa7072f6a30e016093fdd3f7660a2ee2faf"
                               >
                                 <span
-                                  class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                                  data-testid="TruncateMiddle"
+                                  class="underline-dotted"
                                 >
-                                  32e5278cb72f2 … f7660a2ee2faf
+                                  <span
+                                    class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                                    data-testid="TruncateMiddle"
+                                  >
+                                    32e5278cb72f2 … f7660a2ee2faf
+                                  </span>
                                 </span>
                               </a>
                               <span
@@ -1812,16 +1820,20 @@ exports[`SendVote should send a vote transaction 1`] = `
                               class="flex items-center space-x-3"
                             >
                               <a
-                                class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                                class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                                 data-testid="Link"
                                 rel="noopener noreferrer"
                                 to="https://dexplorer.ark.io/transaction/d819c5199e323a62a4349948ff075edde91e509028329f66ec76b8518ad1e493"
                               >
                                 <span
-                                  class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                                  data-testid="TruncateMiddle"
+                                  class="underline-dotted"
                                 >
-                                  d819c5199e323 … 6b8518ad1e493
+                                  <span
+                                    class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                                    data-testid="TruncateMiddle"
+                                  >
+                                    d819c5199e323 … 6b8518ad1e493
+                                  </span>
                                 </span>
                               </a>
                               <span
@@ -2485,16 +2497,20 @@ exports[`SendVote should send a vote transaction 2`] = `
                               class="flex items-center space-x-3"
                             >
                               <a
-                                class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                                class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                                 data-testid="Link"
                                 rel="noopener noreferrer"
                                 to="https://dexplorer.ark.io/transaction/d819c5199e323a62a4349948ff075edde91e509028329f66ec76b8518ad1e493"
                               >
                                 <span
-                                  class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
-                                  data-testid="TruncateMiddle"
+                                  class="underline-dotted"
                                 >
-                                  d819c5199e323 … 6b8518ad1e493
+                                  <span
+                                    class="TruncateMiddle__Wrapper-sc-3j3e79-0 text-theme-primary-700"
+                                    data-testid="TruncateMiddle"
+                                  >
+                                    d819c5199e323 … 6b8518ad1e493
+                                  </span>
                                 </span>
                               </a>
                               <span

--- a/src/domains/transaction/pages/SendVote/__snapshots__/SendVote.test.tsx.snap
+++ b/src/domains/transaction/pages/SendVote/__snapshots__/SendVote.test.tsx.snap
@@ -406,7 +406,7 @@ exports[`SendVote should send a unvote & vote transaction 1`] = `
                               class="flex items-center space-x-3"
                             >
                               <a
-                                class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                                class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                                 data-testid="Link"
                                 rel="noopener noreferrer"
                                 to="https://dexplorer.ark.io/transaction/d819c5199e323a62a4349948ff075edde91e509028329f66ec76b8518ad1e493"
@@ -1143,7 +1143,7 @@ exports[`SendVote should send a unvote transaction 1`] = `
                               class="flex items-center space-x-3"
                             >
                               <a
-                                class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                                class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                                 data-testid="Link"
                                 rel="noopener noreferrer"
                                 to="https://dexplorer.ark.io/transaction/32e5278cb72f24f2c04c4797dbfbffa7072f6a30e016093fdd3f7660a2ee2faf"
@@ -1820,7 +1820,7 @@ exports[`SendVote should send a vote transaction 1`] = `
                               class="flex items-center space-x-3"
                             >
                               <a
-                                class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                                class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                                 data-testid="Link"
                                 rel="noopener noreferrer"
                                 to="https://dexplorer.ark.io/transaction/d819c5199e323a62a4349948ff075edde91e509028329f66ec76b8518ad1e493"
@@ -2497,7 +2497,7 @@ exports[`SendVote should send a vote transaction 2`] = `
                               class="flex items-center space-x-3"
                             >
                               <a
-                                class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                                class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                                 data-testid="Link"
                                 rel="noopener noreferrer"
                                 to="https://dexplorer.ark.io/transaction/d819c5199e323a62a4349948ff075edde91e509028329f66ec76b8518ad1e493"

--- a/src/domains/wallet/pages/WalletDetails/__snapshots__/WalletDetails.test.tsx.snap
+++ b/src/domains/wallet/pages/WalletDetails/__snapshots__/WalletDetails.test.tsx.snap
@@ -564,12 +564,16 @@ exports[`WalletDetails should not fail if the votes have not yet been synchroniz
                         class="mt-1 mr-auto"
                       >
                         <a
-                          class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                          class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                           data-testid="Link"
                           rel="noopener noreferrer"
                           to="https:////"
                         >
-                          Learn more
+                          <span
+                            class="underline-dotted"
+                          >
+                            Learn more
+                          </span>
                           <div
                             class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
                             data-testid="Link__external"
@@ -648,12 +652,16 @@ exports[`WalletDetails should not fail if the votes have not yet been synchroniz
                         class="mt-1 mr-auto"
                       >
                         <a
-                          class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                          class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                           data-testid="Link"
                           rel="noopener noreferrer"
                           to="@TODO"
                         >
-                          Learn more
+                          <span
+                            class="underline-dotted"
+                          >
+                            Learn more
+                          </span>
                           <div
                             class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
                             data-testid="Link__external"
@@ -923,20 +931,24 @@ exports[`WalletDetails should not fail if the votes have not yet been synchroniz
                           class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 gMOims"
                         >
                           <a
-                            class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                            class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                             data-testid="TransactionRow__ID"
                             rel="noopener noreferrer"
                             to="https://dexplorer.ark.io/transaction/8f913b6b719e7767d49861c0aec79ced212767645cb793d75d2f1b89abb49877"
                           >
-                            <div
-                              class="sc-bdfBwQ fPrsah"
-                              height="1em"
-                              width="1em"
+                            <span
+                              class="underline-dotted"
                             >
-                              <svg>
-                                id.svg
-                              </svg>
-                            </div>
+                              <div
+                                class="sc-bdfBwQ fPrsah"
+                                height="1em"
+                                width="1em"
+                              >
+                                <svg>
+                                  id.svg
+                                </svg>
+                              </div>
+                            </span>
                           </a>
                         </div>
                       </td>
@@ -1740,12 +1752,16 @@ exports[`WalletDetails should open detail modal on transaction row click 1`] = `
                         class="mt-1 mr-auto"
                       >
                         <a
-                          class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                          class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                           data-testid="Link"
                           rel="noopener noreferrer"
                           to="@TODO"
                         >
-                          Learn more
+                          <span
+                            class="underline-dotted"
+                          >
+                            Learn more
+                          </span>
                           <div
                             class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
                             data-testid="Link__external"
@@ -2015,20 +2031,24 @@ exports[`WalletDetails should open detail modal on transaction row click 1`] = `
                           class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 gMOims"
                         >
                           <a
-                            class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                            class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                             data-testid="TransactionRow__ID"
                             rel="noopener noreferrer"
                             to="https://dexplorer.ark.io/transaction/8f913b6b719e7767d49861c0aec79ced212767645cb793d75d2f1b89abb49877"
                           >
-                            <div
-                              class="sc-bdfBwQ fPrsah"
-                              height="1em"
-                              width="1em"
+                            <span
+                              class="underline-dotted"
                             >
-                              <svg>
-                                id.svg
-                              </svg>
-                            </div>
+                              <div
+                                class="sc-bdfBwQ fPrsah"
+                                height="1em"
+                                width="1em"
+                              >
+                                <svg>
+                                  id.svg
+                                </svg>
+                              </div>
+                            </span>
                           </a>
                         </div>
                       </td>
@@ -2832,12 +2852,16 @@ exports[`WalletDetails should remove wallet name 1`] = `
                         class="mt-1 mr-auto"
                       >
                         <a
-                          class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                          class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                           data-testid="Link"
                           rel="noopener noreferrer"
                           to="@TODO"
                         >
-                          Learn more
+                          <span
+                            class="underline-dotted"
+                          >
+                            Learn more
+                          </span>
                           <div
                             class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
                             data-testid="Link__external"
@@ -3107,20 +3131,24 @@ exports[`WalletDetails should remove wallet name 1`] = `
                           class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 gMOims"
                         >
                           <a
-                            class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                            class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                             data-testid="TransactionRow__ID"
                             rel="noopener noreferrer"
                             to="https://dexplorer.ark.io/transaction/8f913b6b719e7767d49861c0aec79ced212767645cb793d75d2f1b89abb49877"
                           >
-                            <div
-                              class="sc-bdfBwQ fPrsah"
-                              height="1em"
-                              width="1em"
+                            <span
+                              class="underline-dotted"
                             >
-                              <svg>
-                                id.svg
-                              </svg>
-                            </div>
+                              <div
+                                class="sc-bdfBwQ fPrsah"
+                                height="1em"
+                                width="1em"
+                              >
+                                <svg>
+                                  id.svg
+                                </svg>
+                              </div>
+                            </span>
                           </a>
                         </div>
                       </td>
@@ -3836,12 +3864,16 @@ exports[`WalletDetails should render when wallet not found for votes 1`] = `
                         class="mt-1 mr-auto"
                       >
                         <a
-                          class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                          class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                           data-testid="Link"
                           rel="noopener noreferrer"
                           to="https:////"
                         >
-                          Learn more
+                          <span
+                            class="underline-dotted"
+                          >
+                            Learn more
+                          </span>
                           <div
                             class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
                             data-testid="Link__external"
@@ -3920,12 +3952,16 @@ exports[`WalletDetails should render when wallet not found for votes 1`] = `
                         class="mt-1 mr-auto"
                       >
                         <a
-                          class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                          class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                           data-testid="Link"
                           rel="noopener noreferrer"
                           to="@TODO"
                         >
-                          Learn more
+                          <span
+                            class="underline-dotted"
+                          >
+                            Learn more
+                          </span>
                           <div
                             class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
                             data-testid="Link__external"
@@ -4195,20 +4231,24 @@ exports[`WalletDetails should render when wallet not found for votes 1`] = `
                           class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 gMOims"
                         >
                           <a
-                            class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                            class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                             data-testid="TransactionRow__ID"
                             rel="noopener noreferrer"
                             to="https://dexplorer.ark.io/transaction/8f913b6b719e7767d49861c0aec79ced212767645cb793d75d2f1b89abb49877"
                           >
-                            <div
-                              class="sc-bdfBwQ fPrsah"
-                              height="1em"
-                              width="1em"
+                            <span
+                              class="underline-dotted"
                             >
-                              <svg>
-                                id.svg
-                              </svg>
-                            </div>
+                              <div
+                                class="sc-bdfBwQ fPrsah"
+                                height="1em"
+                                width="1em"
+                              >
+                                <svg>
+                                  id.svg
+                                </svg>
+                              </div>
+                            </span>
                           </a>
                         </div>
                       </td>
@@ -5012,12 +5052,16 @@ exports[`WalletDetails should star and unstar a wallet 1`] = `
                         class="mt-1 mr-auto"
                       >
                         <a
-                          class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                          class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                           data-testid="Link"
                           rel="noopener noreferrer"
                           to="@TODO"
                         >
-                          Learn more
+                          <span
+                            class="underline-dotted"
+                          >
+                            Learn more
+                          </span>
                           <div
                             class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
                             data-testid="Link__external"
@@ -5287,20 +5331,24 @@ exports[`WalletDetails should star and unstar a wallet 1`] = `
                           class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 gMOims"
                         >
                           <a
-                            class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                            class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                             data-testid="TransactionRow__ID"
                             rel="noopener noreferrer"
                             to="https://dexplorer.ark.io/transaction/8f913b6b719e7767d49861c0aec79ced212767645cb793d75d2f1b89abb49877"
                           >
-                            <div
-                              class="sc-bdfBwQ fPrsah"
-                              height="1em"
-                              width="1em"
+                            <span
+                              class="underline-dotted"
                             >
-                              <svg>
-                                id.svg
-                              </svg>
-                            </div>
+                              <div
+                                class="sc-bdfBwQ fPrsah"
+                                height="1em"
+                                width="1em"
+                              >
+                                <svg>
+                                  id.svg
+                                </svg>
+                              </div>
+                            </span>
                           </a>
                         </div>
                       </td>
@@ -6110,12 +6158,16 @@ exports[`WalletDetails should update wallet name 1`] = `
                         class="mt-1 mr-auto"
                       >
                         <a
-                          class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                          class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                           data-testid="Link"
                           rel="noopener noreferrer"
                           to="@TODO"
                         >
-                          Learn more
+                          <span
+                            class="underline-dotted"
+                          >
+                            Learn more
+                          </span>
                           <div
                             class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
                             data-testid="Link__external"
@@ -6385,20 +6437,24 @@ exports[`WalletDetails should update wallet name 1`] = `
                           class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 gMOims"
                         >
                           <a
-                            class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                            class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                             data-testid="TransactionRow__ID"
                             rel="noopener noreferrer"
                             to="https://dexplorer.ark.io/transaction/8f913b6b719e7767d49861c0aec79ced212767645cb793d75d2f1b89abb49877"
                           >
-                            <div
-                              class="sc-bdfBwQ fPrsah"
-                              height="1em"
-                              width="1em"
+                            <span
+                              class="underline-dotted"
                             >
-                              <svg>
-                                id.svg
-                              </svg>
-                            </div>
+                              <div
+                                class="sc-bdfBwQ fPrsah"
+                                height="1em"
+                                width="1em"
+                              >
+                                <svg>
+                                  id.svg
+                                </svg>
+                              </div>
+                            </span>
                           </a>
                         </div>
                       </td>

--- a/src/domains/wallet/pages/WalletDetails/__snapshots__/WalletDetails.test.tsx.snap
+++ b/src/domains/wallet/pages/WalletDetails/__snapshots__/WalletDetails.test.tsx.snap
@@ -564,7 +564,7 @@ exports[`WalletDetails should not fail if the votes have not yet been synchroniz
                         class="mt-1 mr-auto"
                       >
                         <a
-                          class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                          class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                           data-testid="Link"
                           rel="noopener noreferrer"
                           to="https:////"
@@ -652,7 +652,7 @@ exports[`WalletDetails should not fail if the votes have not yet been synchroniz
                         class="mt-1 mr-auto"
                       >
                         <a
-                          class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                          class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                           data-testid="Link"
                           rel="noopener noreferrer"
                           to="@TODO"
@@ -931,7 +931,7 @@ exports[`WalletDetails should not fail if the votes have not yet been synchroniz
                           class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 gMOims"
                         >
                           <a
-                            class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                            class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                             data-testid="TransactionRow__ID"
                             rel="noopener noreferrer"
                             to="https://dexplorer.ark.io/transaction/8f913b6b719e7767d49861c0aec79ced212767645cb793d75d2f1b89abb49877"
@@ -1752,7 +1752,7 @@ exports[`WalletDetails should open detail modal on transaction row click 1`] = `
                         class="mt-1 mr-auto"
                       >
                         <a
-                          class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                          class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                           data-testid="Link"
                           rel="noopener noreferrer"
                           to="@TODO"
@@ -2031,7 +2031,7 @@ exports[`WalletDetails should open detail modal on transaction row click 1`] = `
                           class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 gMOims"
                         >
                           <a
-                            class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                            class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                             data-testid="TransactionRow__ID"
                             rel="noopener noreferrer"
                             to="https://dexplorer.ark.io/transaction/8f913b6b719e7767d49861c0aec79ced212767645cb793d75d2f1b89abb49877"
@@ -2852,7 +2852,7 @@ exports[`WalletDetails should remove wallet name 1`] = `
                         class="mt-1 mr-auto"
                       >
                         <a
-                          class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                          class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                           data-testid="Link"
                           rel="noopener noreferrer"
                           to="@TODO"
@@ -3131,7 +3131,7 @@ exports[`WalletDetails should remove wallet name 1`] = `
                           class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 gMOims"
                         >
                           <a
-                            class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                            class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                             data-testid="TransactionRow__ID"
                             rel="noopener noreferrer"
                             to="https://dexplorer.ark.io/transaction/8f913b6b719e7767d49861c0aec79ced212767645cb793d75d2f1b89abb49877"
@@ -3864,7 +3864,7 @@ exports[`WalletDetails should render when wallet not found for votes 1`] = `
                         class="mt-1 mr-auto"
                       >
                         <a
-                          class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                          class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                           data-testid="Link"
                           rel="noopener noreferrer"
                           to="https:////"
@@ -3952,7 +3952,7 @@ exports[`WalletDetails should render when wallet not found for votes 1`] = `
                         class="mt-1 mr-auto"
                       >
                         <a
-                          class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                          class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                           data-testid="Link"
                           rel="noopener noreferrer"
                           to="@TODO"
@@ -4231,7 +4231,7 @@ exports[`WalletDetails should render when wallet not found for votes 1`] = `
                           class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 gMOims"
                         >
                           <a
-                            class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                            class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                             data-testid="TransactionRow__ID"
                             rel="noopener noreferrer"
                             to="https://dexplorer.ark.io/transaction/8f913b6b719e7767d49861c0aec79ced212767645cb793d75d2f1b89abb49877"
@@ -5052,7 +5052,7 @@ exports[`WalletDetails should star and unstar a wallet 1`] = `
                         class="mt-1 mr-auto"
                       >
                         <a
-                          class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                          class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                           data-testid="Link"
                           rel="noopener noreferrer"
                           to="@TODO"
@@ -5331,7 +5331,7 @@ exports[`WalletDetails should star and unstar a wallet 1`] = `
                           class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 gMOims"
                         >
                           <a
-                            class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                            class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                             data-testid="TransactionRow__ID"
                             rel="noopener noreferrer"
                             to="https://dexplorer.ark.io/transaction/8f913b6b719e7767d49861c0aec79ced212767645cb793d75d2f1b89abb49877"
@@ -6158,7 +6158,7 @@ exports[`WalletDetails should update wallet name 1`] = `
                         class="mt-1 mr-auto"
                       >
                         <a
-                          class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                          class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                           data-testid="Link"
                           rel="noopener noreferrer"
                           to="@TODO"
@@ -6437,7 +6437,7 @@ exports[`WalletDetails should update wallet name 1`] = `
                           class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 gMOims"
                         >
                           <a
-                            class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+                            class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
                             data-testid="TransactionRow__ID"
                             rel="noopener noreferrer"
                             to="https://dexplorer.ark.io/transaction/8f913b6b719e7767d49861c0aec79ced212767645cb793d75d2f1b89abb49877"

--- a/src/domains/wallet/pages/WalletDetails/components/WalletRegistrations/__snapshots__/WalletRegistrations.test.tsx.snap
+++ b/src/domains/wallet/pages/WalletDetails/components/WalletRegistrations/__snapshots__/WalletRegistrations.test.tsx.snap
@@ -53,7 +53,7 @@ exports[`WalletRegistrations should render empty state 1`] = `
             class="mt-1 mr-auto"
           >
             <a
-              class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+              class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
               data-testid="Link"
               rel="noopener noreferrer"
               to="@TODO"

--- a/src/domains/wallet/pages/WalletDetails/components/WalletRegistrations/__snapshots__/WalletRegistrations.test.tsx.snap
+++ b/src/domains/wallet/pages/WalletDetails/components/WalletRegistrations/__snapshots__/WalletRegistrations.test.tsx.snap
@@ -53,12 +53,16 @@ exports[`WalletRegistrations should render empty state 1`] = `
             class="mt-1 mr-auto"
           >
             <a
-              class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+              class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
               data-testid="Link"
               rel="noopener noreferrer"
               to="@TODO"
             >
-              Learn more
+              <span
+                class="underline-dotted"
+              >
+                Learn more
+              </span>
               <div
                 class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
                 data-testid="Link__external"

--- a/src/domains/wallet/pages/WalletDetails/components/WalletVote/__snapshots__/WalletVote.test.tsx.snap
+++ b/src/domains/wallet/pages/WalletDetails/components/WalletVote/__snapshots__/WalletVote.test.tsx.snap
@@ -678,7 +678,7 @@ exports[`WalletVote should render the maximum votes 1`] = `
             class="mt-1 mr-auto"
           >
             <a
-              class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+              class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
               data-testid="Link"
               rel="noopener noreferrer"
               to="https:////"
@@ -780,7 +780,7 @@ exports[`WalletVote should render without votes 1`] = `
             class="mt-1 mr-auto"
           >
             <a
-              class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+              class="Link__AnchorStyled-sc-1q7sbxr-0 cIuuRE inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
               data-testid="Link"
               rel="noopener noreferrer"
               to="https:////"

--- a/src/domains/wallet/pages/WalletDetails/components/WalletVote/__snapshots__/WalletVote.test.tsx.snap
+++ b/src/domains/wallet/pages/WalletDetails/components/WalletVote/__snapshots__/WalletVote.test.tsx.snap
@@ -678,12 +678,16 @@ exports[`WalletVote should render the maximum votes 1`] = `
             class="mt-1 mr-auto"
           >
             <a
-              class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+              class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
               data-testid="Link"
               rel="noopener noreferrer"
               to="https:////"
             >
-              Learn more
+              <span
+                class="underline-dotted"
+              >
+                Learn more
+              </span>
               <div
                 class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
                 data-testid="Link__external"
@@ -776,12 +780,16 @@ exports[`WalletVote should render without votes 1`] = `
             class="mt-1 mr-auto"
           >
             <a
-              class="Link__AnchorStyled-sc-1q7sbxr-0 gwkapx inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
+              class="Link__AnchorStyled-sc-1q7sbxr-0 jmOrQw inline-flex items-center font-semibold transition-colors duration-200 cursor-pointer text-theme-primary-600 hover:text-theme-primary-700 hover:underline active:text-theme-primary-500"
               data-testid="Link"
               rel="noopener noreferrer"
               to="https:////"
             >
-              Learn more
+              <span
+                class="underline-dotted"
+              >
+                Learn more
+              </span>
               <div
                 class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
                 data-testid="Link__external"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Use dotted underline on hover state in `Link` component

Examples:
![2021-01-20-120132_340x79_scrot](https://user-images.githubusercontent.com/22020168/105159249-88a7b600-5b17-11eb-9ed9-849b80c41309.png)
![2021-01-20-120028_363x96_scrot](https://user-images.githubusercontent.com/22020168/105159314-9eb57680-5b17-11eb-95e9-e4236283f179.png)



<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [x] My changes look good in both light AND dark mode
-   [x] The change is not hardcoded to a single network, but has multi-asset in mind
-   [x] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [x] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
