### PR TITLE
fix: use proper dropdown background in dark mode

### DIFF
--- a/src/app/components/Dropdown/Dropdown.styles.ts
+++ b/src/app/components/Dropdown/Dropdown.styles.ts
@@ -1,6 +1,6 @@
 import tw from "twin.macro";
 
-export const defaultClasses = "mt-3 py-3 absolute z-10 bg-theme-background rounded-lg shadow-xl";
+export const defaultClasses = "mt-3 py-3 absolute z-10 bg-white dark:bg-theme-secondary-800 rounded-lg shadow-xl";
 
 const getPosition = (position: string): any => {
 	switch (position) {

--- a/src/app/components/Notifications/__snapshots__/NotificationsDropdown.test.tsx.snap
+++ b/src/app/components/Notifications/__snapshots__/NotificationsDropdown.test.tsx.snap
@@ -37,7 +37,7 @@ exports[`Notifications should open and cancel wallet update notification modal 1
         </div>
       </span>
       <div
-        class="Dropdown__Wrapper-ocz1je-0 hArGtU mt-3 py-3 absolute z-10 bg-theme-background rounded-lg shadow-xl mt-8"
+        class="Dropdown__Wrapper-ocz1je-0 hArGtU mt-3 py-3 absolute z-10 bg-white dark:bg-theme-secondary-800 rounded-lg shadow-xl mt-8"
       >
         <div
           data-testid="dropdown__content"
@@ -436,7 +436,7 @@ exports[`Notifications should open and cancel wallet update notification modal 2
         </div>
       </span>
       <div
-        class="Dropdown__Wrapper-ocz1je-0 hArGtU mt-3 py-3 absolute z-10 bg-theme-background rounded-lg shadow-xl mt-8"
+        class="Dropdown__Wrapper-ocz1je-0 hArGtU mt-3 py-3 absolute z-10 bg-white dark:bg-theme-secondary-800 rounded-lg shadow-xl mt-8"
       >
         <div
           data-testid="dropdown__content"
@@ -748,7 +748,7 @@ exports[`Notifications should open and close transaction details modal 1`] = `
         </div>
       </span>
       <div
-        class="Dropdown__Wrapper-ocz1je-0 hArGtU mt-3 py-3 absolute z-10 bg-theme-background rounded-lg shadow-xl mt-8"
+        class="Dropdown__Wrapper-ocz1je-0 hArGtU mt-3 py-3 absolute z-10 bg-white dark:bg-theme-secondary-800 rounded-lg shadow-xl mt-8"
       >
         <div
           data-testid="dropdown__content"
@@ -1438,7 +1438,7 @@ exports[`Notifications should open and close transaction details modal 2`] = `
         </div>
       </span>
       <div
-        class="Dropdown__Wrapper-ocz1je-0 hArGtU mt-3 py-3 absolute z-10 bg-theme-background rounded-lg shadow-xl mt-8"
+        class="Dropdown__Wrapper-ocz1je-0 hArGtU mt-3 py-3 absolute z-10 bg-white dark:bg-theme-secondary-800 rounded-lg shadow-xl mt-8"
       >
         <div
           data-testid="dropdown__content"
@@ -1750,7 +1750,7 @@ exports[`Notifications should open and close wallet update notification modal 1`
         </div>
       </span>
       <div
-        class="Dropdown__Wrapper-ocz1je-0 hArGtU mt-3 py-3 absolute z-10 bg-theme-background rounded-lg shadow-xl mt-8"
+        class="Dropdown__Wrapper-ocz1je-0 hArGtU mt-3 py-3 absolute z-10 bg-white dark:bg-theme-secondary-800 rounded-lg shadow-xl mt-8"
       >
         <div
           data-testid="dropdown__content"
@@ -2149,7 +2149,7 @@ exports[`Notifications should open and close wallet update notification modal 2`
         </div>
       </span>
       <div
-        class="Dropdown__Wrapper-ocz1je-0 hArGtU mt-3 py-3 absolute z-10 bg-theme-background rounded-lg shadow-xl mt-8"
+        class="Dropdown__Wrapper-ocz1je-0 hArGtU mt-3 py-3 absolute z-10 bg-white dark:bg-theme-secondary-800 rounded-lg shadow-xl mt-8"
       >
         <div
           data-testid="dropdown__content"
@@ -2461,7 +2461,7 @@ exports[`Notifications should render with transactions and plugins 1`] = `
         </div>
       </span>
       <div
-        class="Dropdown__Wrapper-ocz1je-0 hArGtU mt-3 py-3 absolute z-10 bg-theme-background rounded-lg shadow-xl mt-8"
+        class="Dropdown__Wrapper-ocz1je-0 hArGtU mt-3 py-3 absolute z-10 bg-white dark:bg-theme-secondary-800 rounded-lg shadow-xl mt-8"
       >
         <div
           data-testid="dropdown__content"

--- a/src/app/components/SearchBar/SearchBarPluginFilters/__snapshots__/SearchBarPluginFilters.test.tsx.snap
+++ b/src/app/components/SearchBar/SearchBarPluginFilters/__snapshots__/SearchBarPluginFilters.test.tsx.snap
@@ -58,7 +58,7 @@ exports[`SearchBarPluginFilters should render categories 1`] = `
         </div>
       </span>
       <div
-        class="Dropdown__Wrapper-ocz1je-0 hArGtU mt-3 py-3 absolute z-10 bg-theme-background rounded-lg shadow-xl undefined"
+        class="Dropdown__Wrapper-ocz1je-0 hArGtU mt-3 py-3 absolute z-10 bg-white dark:bg-theme-secondary-800 rounded-lg shadow-xl undefined"
       >
         <div
           data-testid="dropdown__content"
@@ -626,7 +626,7 @@ exports[`SearchBarPluginFilters should render ratings 1`] = `
         </div>
       </span>
       <div
-        class="Dropdown__Wrapper-ocz1je-0 hArGtU mt-3 py-3 absolute z-10 bg-theme-background rounded-lg shadow-xl undefined"
+        class="Dropdown__Wrapper-ocz1je-0 hArGtU mt-3 py-3 absolute z-10 bg-white dark:bg-theme-secondary-800 rounded-lg shadow-xl undefined"
       >
         <div
           data-testid="dropdown__content"
@@ -1248,7 +1248,7 @@ exports[`SearchBarPluginFilters should render with null initialValues 1`] = `
         </div>
       </span>
       <div
-        class="Dropdown__Wrapper-ocz1je-0 hArGtU mt-3 py-3 absolute z-10 bg-theme-background rounded-lg shadow-xl undefined"
+        class="Dropdown__Wrapper-ocz1je-0 hArGtU mt-3 py-3 absolute z-10 bg-white dark:bg-theme-secondary-800 rounded-lg shadow-xl undefined"
       >
         <div
           data-testid="dropdown__content"
@@ -1746,7 +1746,7 @@ exports[`SearchBarPluginFilters should render with selected values 1`] = `
         </div>
       </span>
       <div
-        class="Dropdown__Wrapper-ocz1je-0 hArGtU mt-3 py-3 absolute z-10 bg-theme-background rounded-lg shadow-xl undefined"
+        class="Dropdown__Wrapper-ocz1je-0 hArGtU mt-3 py-3 absolute z-10 bg-white dark:bg-theme-secondary-800 rounded-lg shadow-xl undefined"
       >
         <div
           data-testid="dropdown__content"

--- a/src/domains/transaction/components/FilterTransactions/__snapshots__/FilterTransactions.test.tsx.snap
+++ b/src/domains/transaction/components/FilterTransactions/__snapshots__/FilterTransactions.test.tsx.snap
@@ -45,7 +45,7 @@ exports[`FilterTransactions should open dropdown list with all transaction types
         </button>
       </span>
       <div
-        class="Dropdown__Wrapper-ocz1je-0 hArGtU mt-3 py-3 absolute z-10 bg-theme-background rounded-lg shadow-xl w-80 max-h-128 overflow-y-auto"
+        class="Dropdown__Wrapper-ocz1je-0 hArGtU mt-3 py-3 absolute z-10 bg-white dark:bg-theme-secondary-800 rounded-lg shadow-xl w-80 max-h-128 overflow-y-auto"
       >
         <div
           data-testid="dropdown__content"

--- a/src/domains/vote/components/VotesFilter/__snapshots__/VotesFilter.test.tsx.snap
+++ b/src/domains/vote/components/VotesFilter/__snapshots__/VotesFilter.test.tsx.snap
@@ -56,7 +56,7 @@ exports[`VotesFilter should render default 1`] = `
         </div>
       </span>
       <div
-        class="Dropdown__Wrapper-ocz1je-0 hArGtU mt-3 py-3 absolute z-10 bg-theme-background rounded-lg shadow-xl undefined"
+        class="Dropdown__Wrapper-ocz1je-0 hArGtU mt-3 py-3 absolute z-10 bg-white dark:bg-theme-secondary-800 rounded-lg shadow-xl undefined"
       >
         <div
           data-testid="dropdown__content"
@@ -135,7 +135,7 @@ exports[`VotesFilter should render with current option selected 1`] = `
         </div>
       </span>
       <div
-        class="Dropdown__Wrapper-ocz1je-0 hArGtU mt-3 py-3 absolute z-10 bg-theme-background rounded-lg shadow-xl undefined"
+        class="Dropdown__Wrapper-ocz1je-0 hArGtU mt-3 py-3 absolute z-10 bg-white dark:bg-theme-secondary-800 rounded-lg shadow-xl undefined"
       >
         <div
           data-testid="dropdown__content"
@@ -214,7 +214,7 @@ exports[`VotesFilter should render with disabled current option 1`] = `
         </div>
       </span>
       <div
-        class="Dropdown__Wrapper-ocz1je-0 hArGtU mt-3 py-3 absolute z-10 bg-theme-background rounded-lg shadow-xl undefined"
+        class="Dropdown__Wrapper-ocz1je-0 hArGtU mt-3 py-3 absolute z-10 bg-white dark:bg-theme-secondary-800 rounded-lg shadow-xl undefined"
       >
         <div
           data-testid="dropdown__content"

--- a/src/domains/vote/pages/Votes/__snapshots__/Votes.test.tsx.snap
+++ b/src/domains/vote/pages/Votes/__snapshots__/Votes.test.tsx.snap
@@ -387,7 +387,7 @@ exports[`Votes should filter current delegates 1`] = `
                       </div>
                     </span>
                     <div
-                      class="Dropdown__Wrapper-ocz1je-0 hArGtU mt-3 py-3 absolute z-10 bg-theme-background rounded-lg shadow-xl undefined"
+                      class="Dropdown__Wrapper-ocz1je-0 hArGtU mt-3 py-3 absolute z-10 bg-white dark:bg-theme-secondary-800 rounded-lg shadow-xl undefined"
                     >
                       <div
                         data-testid="dropdown__content"
@@ -6127,7 +6127,7 @@ exports[`Votes should select favorites option in the wallets display type 1`] = 
                       </div>
                     </span>
                     <div
-                      class="Dropdown__Wrapper-ocz1je-0 hArGtU mt-3 py-3 absolute z-10 bg-theme-background rounded-lg shadow-xl undefined"
+                      class="Dropdown__Wrapper-ocz1je-0 hArGtU mt-3 py-3 absolute z-10 bg-white dark:bg-theme-secondary-800 rounded-lg shadow-xl undefined"
                     >
                       <div
                         data-testid="dropdown__content"
@@ -6652,7 +6652,7 @@ exports[`Votes should select ledger option in the wallets display type 1`] = `
                       </div>
                     </span>
                     <div
-                      class="Dropdown__Wrapper-ocz1je-0 hArGtU mt-3 py-3 absolute z-10 bg-theme-background rounded-lg shadow-xl undefined"
+                      class="Dropdown__Wrapper-ocz1je-0 hArGtU mt-3 py-3 absolute z-10 bg-white dark:bg-theme-secondary-800 rounded-lg shadow-xl undefined"
                     >
                       <div
                         data-testid="dropdown__content"
@@ -7177,7 +7177,7 @@ exports[`Votes should toggle network selection from network filters 1`] = `
                       </div>
                     </span>
                     <div
-                      class="Dropdown__Wrapper-ocz1je-0 hArGtU mt-3 py-3 absolute z-10 bg-theme-background rounded-lg shadow-xl undefined"
+                      class="Dropdown__Wrapper-ocz1je-0 hArGtU mt-3 py-3 absolute z-10 bg-white dark:bg-theme-secondary-800 rounded-lg shadow-xl undefined"
                     >
                       <div
                         data-testid="dropdown__content"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/crxe88
<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [x] My changes look good in both light AND dark mode
-   [x] The change is not hardcoded to a single network, but has multi-asset in mind
-   [x] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [x] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
