### PR TITLE
fix: restore profile on normal & demo mode

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -61,6 +61,9 @@ beforeAll(async () => {
 		} catch (error) {
 			throw new Error(`Restoring of profile [${profile.id}] failed. Reason: ${error}`);
 		}
+
+		// Mark profiles as restored, to prevent multiple restoration in profile synchronizer
+		process.env.TEST_PROFILES_RESTORE_STATUS = "restored";
 	}
 });
 

--- a/src/app/hooks/use-profile-synchronizer.ts
+++ b/src/app/hooks/use-profile-synchronizer.ts
@@ -131,6 +131,7 @@ export const useProfileSyncStatus = () => {
 };
 
 export const useProfileSynchronizer = () => {
+	const isDemo = process.env.REACT_APP_BUILD_MODE === "demo";
 	const { persist } = useEnvironmentContext();
 	const { setConfiguration, profileIsSyncing } = useConfiguration();
 	const profile = useProfileWatcher();
@@ -166,9 +167,12 @@ export const useProfileSynchronizer = () => {
 			if (shouldRestore(profile)) {
 				setStatus("restoring");
 
-				// Perform restore to make migrated wallets available in profile.wallets()
 				await profile.restore();
-				restoreProfileTestPassword(profile);
+
+				if (isDemo) {
+					restoreProfileTestPassword(profile);
+				}
+
 				await persist();
 
 				markAsRestored(profile.id());

--- a/src/app/hooks/use-profile-synchronizer.ts
+++ b/src/app/hooks/use-profile-synchronizer.ts
@@ -212,6 +212,7 @@ export const useProfileSynchronizer = () => {
 		markAsRestored,
 		status,
 		stop,
+		isDemo,
 	]);
 
 	return { profile, profileIsSyncing };

--- a/src/app/hooks/use-profile-synchronizer.ts
+++ b/src/app/hooks/use-profile-synchronizer.ts
@@ -86,7 +86,6 @@ type ProfileSyncState = {
 };
 
 export const useProfileSyncStatus = () => {
-	const isDemo = process.env.REACT_APP_BUILD_MODE === "demo";
 	const { current } = useRef<ProfileSyncState>({
 		status: "idle",
 		restored: [],
@@ -99,12 +98,14 @@ export const useProfileSyncStatus = () => {
 	const isCompleted = () => current.status === "completed";
 
 	const shouldRestore = (profile: Profile) => {
-		if (profile.wasCreated()) {
+		// For unit tests only. This flag prevents from running restore multiple times
+		// as the profiles are all restored before all (see jest.setup)
+		const isRestoredInTests = process.env.TEST_PROFILES_RESTORE_STATUS === "restored";
+		if (isRestoredInTests) {
 			return false;
 		}
 
-		// TODO: Should be removed. Needs checking e2e tests before removing this.
-		if (!isDemo) {
+		if (profile.wasCreated()) {
 			return false;
 		}
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
-   [x] Use the` process.env.TEST_PROFILES_RESTORE_STATUS` flag to prevent multiple profile restoring in unit tests.
-   [x] Ensure profiles are restored properly in all modes, except in unit tests (where `TEST_PROFILES_RESTORE_STATUS` is used to coordinate restoration status)
-   [x] Fix `isDemo` check to only perform fixtures migration and profile password reset in demo mode.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [x] My changes look good in both light AND dark mode
-   [x] The change is not hardcoded to a single network, but has multi-asset in mind
-   [x] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [x] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
