### PR TITLE
refactor: use icon in external links

### DIFF
--- a/src/app/components/Notifications/__snapshots__/NotificationsDropdown.test.tsx.snap
+++ b/src/app/components/Notifications/__snapshots__/NotificationsDropdown.test.tsx.snap
@@ -1313,6 +1313,16 @@ exports[`Notifications should open and close transaction details modal 1`] = `
                           ea63bf9a4b3ea … 1868681b5c79b
                         </span>
                       </span>
+                      <div
+                        class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                        data-testid="Link__external"
+                        height="1em"
+                        width="1em"
+                      >
+                        <svg>
+                          redirect.svg
+                        </svg>
+                      </div>
                     </a>
                     <span
                       class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -1370,6 +1380,16 @@ exports[`Notifications should open and close transaction details modal 1`] = `
                           4fbdbedc9d147 … cdd16290920a4
                         </span>
                       </span>
+                      <div
+                        class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                        data-testid="Link__external"
+                        height="1em"
+                        width="1em"
+                      >
+                        <svg>
+                          redirect.svg
+                        </svg>
+                      </div>
                     </a>
                     <span
                       class="flex text-theme-primary-300 dark:text-theme-secondary-600"

--- a/src/domains/dashboard/components/Transactions/__snapshots__/Transactions.test.tsx.snap
+++ b/src/domains/dashboard/components/Transactions/__snapshots__/Transactions.test.tsx.snap
@@ -268,6 +268,16 @@ exports[`Transactions should fetch more transactions 1`] = `
                           </svg>
                         </div>
                       </span>
+                      <div
+                        class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                        data-testid="Link__external"
+                        height="1em"
+                        width="1em"
+                      >
+                        <svg>
+                          redirect.svg
+                        </svg>
+                      </div>
                     </a>
                   </div>
                 </td>
@@ -427,6 +437,16 @@ exports[`Transactions should fetch more transactions 1`] = `
                           </svg>
                         </div>
                       </span>
+                      <div
+                        class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                        data-testid="Link__external"
+                        height="1em"
+                        width="1em"
+                      >
+                        <svg>
+                          redirect.svg
+                        </svg>
+                      </div>
                     </a>
                   </div>
                 </td>
@@ -586,6 +606,16 @@ exports[`Transactions should fetch more transactions 1`] = `
                           </svg>
                         </div>
                       </span>
+                      <div
+                        class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                        data-testid="Link__external"
+                        height="1em"
+                        width="1em"
+                      >
+                        <svg>
+                          redirect.svg
+                        </svg>
+                      </div>
                     </a>
                   </div>
                 </td>
@@ -745,6 +775,16 @@ exports[`Transactions should fetch more transactions 1`] = `
                           </svg>
                         </div>
                       </span>
+                      <div
+                        class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                        data-testid="Link__external"
+                        height="1em"
+                        width="1em"
+                      >
+                        <svg>
+                          redirect.svg
+                        </svg>
+                      </div>
                     </a>
                   </div>
                 </td>
@@ -904,6 +944,16 @@ exports[`Transactions should fetch more transactions 1`] = `
                           </svg>
                         </div>
                       </span>
+                      <div
+                        class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                        data-testid="Link__external"
+                        height="1em"
+                        width="1em"
+                      >
+                        <svg>
+                          redirect.svg
+                        </svg>
+                      </div>
                     </a>
                   </div>
                 </td>
@@ -1063,6 +1113,16 @@ exports[`Transactions should fetch more transactions 1`] = `
                           </svg>
                         </div>
                       </span>
+                      <div
+                        class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                        data-testid="Link__external"
+                        height="1em"
+                        width="1em"
+                      >
+                        <svg>
+                          redirect.svg
+                        </svg>
+                      </div>
                     </a>
                   </div>
                 </td>
@@ -1222,6 +1282,16 @@ exports[`Transactions should fetch more transactions 1`] = `
                           </svg>
                         </div>
                       </span>
+                      <div
+                        class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                        data-testid="Link__external"
+                        height="1em"
+                        width="1em"
+                      >
+                        <svg>
+                          redirect.svg
+                        </svg>
+                      </div>
                     </a>
                   </div>
                 </td>
@@ -1381,6 +1451,16 @@ exports[`Transactions should fetch more transactions 1`] = `
                           </svg>
                         </div>
                       </span>
+                      <div
+                        class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                        data-testid="Link__external"
+                        height="1em"
+                        width="1em"
+                      >
+                        <svg>
+                          redirect.svg
+                        </svg>
+                      </div>
                     </a>
                   </div>
                 </td>
@@ -1797,6 +1877,16 @@ exports[`Transactions should open detail modal on transaction row click 1`] = `
                           </svg>
                         </div>
                       </span>
+                      <div
+                        class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                        data-testid="Link__external"
+                        height="1em"
+                        width="1em"
+                      >
+                        <svg>
+                          redirect.svg
+                        </svg>
+                      </div>
                     </a>
                   </div>
                 </td>
@@ -1956,6 +2046,16 @@ exports[`Transactions should open detail modal on transaction row click 1`] = `
                           </svg>
                         </div>
                       </span>
+                      <div
+                        class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                        data-testid="Link__external"
+                        height="1em"
+                        width="1em"
+                      >
+                        <svg>
+                          redirect.svg
+                        </svg>
+                      </div>
                     </a>
                   </div>
                 </td>
@@ -2115,6 +2215,16 @@ exports[`Transactions should open detail modal on transaction row click 1`] = `
                           </svg>
                         </div>
                       </span>
+                      <div
+                        class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                        data-testid="Link__external"
+                        height="1em"
+                        width="1em"
+                      >
+                        <svg>
+                          redirect.svg
+                        </svg>
+                      </div>
                     </a>
                   </div>
                 </td>
@@ -2274,6 +2384,16 @@ exports[`Transactions should open detail modal on transaction row click 1`] = `
                           </svg>
                         </div>
                       </span>
+                      <div
+                        class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                        data-testid="Link__external"
+                        height="1em"
+                        width="1em"
+                      >
+                        <svg>
+                          redirect.svg
+                        </svg>
+                      </div>
                     </a>
                   </div>
                 </td>
@@ -2690,6 +2810,16 @@ exports[`Transactions should render 1`] = `
                           </svg>
                         </div>
                       </span>
+                      <div
+                        class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                        data-testid="Link__external"
+                        height="1em"
+                        width="1em"
+                      >
+                        <svg>
+                          redirect.svg
+                        </svg>
+                      </div>
                     </a>
                   </div>
                 </td>
@@ -2849,6 +2979,16 @@ exports[`Transactions should render 1`] = `
                           </svg>
                         </div>
                       </span>
+                      <div
+                        class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                        data-testid="Link__external"
+                        height="1em"
+                        width="1em"
+                      >
+                        <svg>
+                          redirect.svg
+                        </svg>
+                      </div>
                     </a>
                   </div>
                 </td>
@@ -3008,6 +3148,16 @@ exports[`Transactions should render 1`] = `
                           </svg>
                         </div>
                       </span>
+                      <div
+                        class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                        data-testid="Link__external"
+                        height="1em"
+                        width="1em"
+                      >
+                        <svg>
+                          redirect.svg
+                        </svg>
+                      </div>
                     </a>
                   </div>
                 </td>
@@ -3167,6 +3317,16 @@ exports[`Transactions should render 1`] = `
                           </svg>
                         </div>
                       </span>
+                      <div
+                        class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                        data-testid="Link__external"
+                        height="1em"
+                        width="1em"
+                      >
+                        <svg>
+                          redirect.svg
+                        </svg>
+                      </div>
                     </a>
                   </div>
                 </td>

--- a/src/domains/dashboard/pages/Dashboard/__snapshots__/Dashboard.test.tsx.snap
+++ b/src/domains/dashboard/pages/Dashboard/__snapshots__/Dashboard.test.tsx.snap
@@ -954,6 +954,16 @@ exports[`Dashboard should render 1`] = `
                               </svg>
                             </div>
                           </span>
+                          <div
+                            class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                            data-testid="Link__external"
+                            height="1em"
+                            width="1em"
+                          >
+                            <svg>
+                              redirect.svg
+                            </svg>
+                          </div>
                         </a>
                       </div>
                     </td>
@@ -1113,6 +1123,16 @@ exports[`Dashboard should render 1`] = `
                               </svg>
                             </div>
                           </span>
+                          <div
+                            class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                            data-testid="Link__external"
+                            height="1em"
+                            width="1em"
+                          >
+                            <svg>
+                              redirect.svg
+                            </svg>
+                          </div>
                         </a>
                       </div>
                     </td>
@@ -1272,6 +1292,16 @@ exports[`Dashboard should render 1`] = `
                               </svg>
                             </div>
                           </span>
+                          <div
+                            class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                            data-testid="Link__external"
+                            height="1em"
+                            width="1em"
+                          >
+                            <svg>
+                              redirect.svg
+                            </svg>
+                          </div>
                         </a>
                       </div>
                     </td>
@@ -1431,6 +1461,16 @@ exports[`Dashboard should render 1`] = `
                               </svg>
                             </div>
                           </span>
+                          <div
+                            class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                            data-testid="Link__external"
+                            height="1em"
+                            width="1em"
+                          >
+                            <svg>
+                              redirect.svg
+                            </svg>
+                          </div>
                         </a>
                       </div>
                     </td>

--- a/src/domains/news/components/NewsCard/NewsCard.tsx
+++ b/src/domains/news/components/NewsCard/NewsCard.tsx
@@ -63,7 +63,7 @@ export const NewsCard = ({ text, category, author, created_at: createdAt, coverI
 
 					<Divider />
 
-					<p className="whitespace-pre-line text-theme-secondary-text" data-testid="NewsCard__content">
+					<div className="whitespace-pre-line text-theme-secondary-text" data-testid="NewsCard__content">
 						<Linkify
 							componentDecorator={(pathname: string, text: string, key: number) => (
 								<Link to={pathname} key={key} isExternal>
@@ -73,7 +73,7 @@ export const NewsCard = ({ text, category, author, created_at: createdAt, coverI
 						>
 							{text}
 						</Linkify>
-					</p>
+					</div>
 
 					{coverImage && (
 						<div className="flex justify-center p-1 -mx-10 border-t-2 border-theme-primary-100 dark:border-theme-secondary-800">

--- a/src/domains/news/components/NewsCard/NewsCard.tsx
+++ b/src/domains/news/components/NewsCard/NewsCard.tsx
@@ -66,7 +66,7 @@ export const NewsCard = ({ text, category, author, created_at: createdAt, coverI
 					<p className="whitespace-pre-line text-theme-secondary-text" data-testid="NewsCard__content">
 						<Linkify
 							componentDecorator={(pathname: string, text: string, key: number) => (
-								<Link to={pathname} key={key} isExternal showExternalIcon={false}>
+								<Link to={pathname} key={key} isExternal>
 									{text}
 								</Link>
 							)}

--- a/src/domains/news/components/NewsCard/__snapshots__/NewsCard.test.tsx.snap
+++ b/src/domains/news/components/NewsCard/__snapshots__/NewsCard.test.tsx.snap
@@ -87,7 +87,7 @@ exports[`NewsCard should render 1`] = `
           class="Divider-sc-19q4mlo-0 daSmjL border-theme-secondary-300 dark:border-theme-secondary-800"
           type="horizontal"
         />
-        <p
+        <div
           class="whitespace-pre-line text-theme-secondary-text"
           data-testid="NewsCard__content"
         >
@@ -103,8 +103,18 @@ exports[`NewsCard should render 1`] = `
             >
               https://blog.ark.io/ark-platform-sdk-modernization-of-blockchain-network-interactions-b5a7d70c2461
             </span>
+            <div
+              class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+              data-testid="Link__external"
+              height="1em"
+              width="1em"
+            >
+              <svg>
+                redirect.svg
+              </svg>
+            </div>
           </a>
-        </p>
+        </div>
       </div>
       <div
         class="flex absolute -top-1 -right-1 items-center m-4 space-x-1"
@@ -201,7 +211,7 @@ exports[`NewsCard should render with cover image 1`] = `
           class="Divider-sc-19q4mlo-0 daSmjL border-theme-secondary-300 dark:border-theme-secondary-800"
           type="horizontal"
         />
-        <p
+        <div
           class="whitespace-pre-line text-theme-secondary-text"
           data-testid="NewsCard__content"
         >
@@ -217,8 +227,18 @@ exports[`NewsCard should render with cover image 1`] = `
             >
               https://blog.ark.io/ark-monthly-update-june-2020-edition-279a3dd47a36
             </span>
+            <div
+              class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+              data-testid="Link__external"
+              height="1em"
+              width="1em"
+            >
+              <svg>
+                redirect.svg
+              </svg>
+            </div>
           </a>
-        </p>
+        </div>
         <div
           class="flex justify-center p-1 -mx-10 border-t-2 border-theme-primary-100 dark:border-theme-secondary-800"
         >

--- a/src/domains/news/pages/News/__snapshots__/News.test.tsx.snap
+++ b/src/domains/news/pages/News/__snapshots__/News.test.tsx.snap
@@ -388,7 +388,7 @@ exports[`News should filter results based on category query and asset 1`] = `
                         class="Divider-sc-19q4mlo-0 daSmjL border-theme-secondary-300 dark:border-theme-secondary-800"
                         type="horizontal"
                       />
-                      <p
+                      <div
                         class="whitespace-pre-line text-theme-secondary-text"
                         data-testid="NewsCard__content"
                       >
@@ -405,8 +405,18 @@ exports[`News should filter results based on category query and asset 1`] = `
                           >
                             https://organize.mlh.io/participants/events/3858-build-a-blockchain-taco-shop-with-ark-io
                           </span>
+                          <div
+                            class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                            data-testid="Link__external"
+                            height="1em"
+                            width="1em"
+                          >
+                            <svg>
+                              redirect.svg
+                            </svg>
+                          </div>
                         </a>
-                      </p>
+                      </div>
                     </div>
                     <div
                       class="flex absolute -top-1 -right-1 items-center m-4 space-x-1"
@@ -1202,7 +1212,7 @@ exports[`News should filter results based on category query and asset 2`] = `
                         class="Divider-sc-19q4mlo-0 daSmjL border-theme-secondary-300 dark:border-theme-secondary-800"
                         type="horizontal"
                       />
-                      <p
+                      <div
                         class="whitespace-pre-line text-theme-secondary-text"
                         data-testid="NewsCard__content"
                       >
@@ -1218,8 +1228,18 @@ exports[`News should filter results based on category query and asset 2`] = `
                           >
                             https://blog.ark.io/ark-platform-sdk-modernization-of-blockchain-network-interactions-b5a7d70c2461
                           </span>
+                          <div
+                            class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                            data-testid="Link__external"
+                            height="1em"
+                            width="1em"
+                          >
+                            <svg>
+                              redirect.svg
+                            </svg>
+                          </div>
                         </a>
-                      </p>
+                      </div>
                     </div>
                     <div
                       class="flex absolute -top-1 -right-1 items-center m-4 space-x-1"

--- a/src/domains/transaction/components/DelegateRegistrationDetail/__snapshots__/DelegateRegistrationDetail.test.tsx.snap
+++ b/src/domains/transaction/components/DelegateRegistrationDetail/__snapshots__/DelegateRegistrationDetail.test.tsx.snap
@@ -239,6 +239,16 @@ exports[`DelegateRegistrationDetail should render a modal 1`] = `
                         ee4175091d9f4 … 9d09bcf3ecefe
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -296,6 +306,16 @@ exports[`DelegateRegistrationDetail should render a modal 1`] = `
                         71fd1a494ded5 … 972b8075d67e9
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -565,6 +585,16 @@ exports[`DelegateRegistrationDetail should render as confirmed 1`] = `
                         ee4175091d9f4 … 9d09bcf3ecefe
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -622,6 +652,16 @@ exports[`DelegateRegistrationDetail should render as confirmed 1`] = `
                         71fd1a494ded5 … 972b8075d67e9
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"

--- a/src/domains/transaction/components/DelegateResignationDetail/__snapshots__/DelegateResignationDetail.test.tsx.snap
+++ b/src/domains/transaction/components/DelegateResignationDetail/__snapshots__/DelegateResignationDetail.test.tsx.snap
@@ -239,6 +239,16 @@ exports[`DelegateResignationDetail should render a modal 1`] = `
                         ee4175091d9f4 … 9d09bcf3ecefe
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -296,6 +306,16 @@ exports[`DelegateResignationDetail should render a modal 1`] = `
                         71fd1a494ded5 … 972b8075d67e9
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -565,6 +585,16 @@ exports[`DelegateResignationDetail should render as confirmed 1`] = `
                         ee4175091d9f4 … 9d09bcf3ecefe
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -622,6 +652,16 @@ exports[`DelegateResignationDetail should render as confirmed 1`] = `
                         71fd1a494ded5 … 972b8075d67e9
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"

--- a/src/domains/transaction/components/EntityDetail/__snapshots__/EntityDetail.test.tsx.snap
+++ b/src/domains/transaction/components/EntityDetail/__snapshots__/EntityDetail.test.tsx.snap
@@ -220,6 +220,16 @@ exports[`EntityDetail should render a business entity resignation modal 1`] = `
                         ee4175091d9f4 … 9d09bcf3ecefe
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -277,6 +287,16 @@ exports[`EntityDetail should render a business entity resignation modal 1`] = `
                         71fd1a494ded5 … 972b8075d67e9
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -525,6 +545,16 @@ exports[`EntityDetail should render a business entity update modal 1`] = `
                         ee4175091d9f4 … 9d09bcf3ecefe
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -582,6 +612,16 @@ exports[`EntityDetail should render a business entity update modal 1`] = `
                         71fd1a494ded5 … 972b8075d67e9
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -830,6 +870,16 @@ exports[`EntityDetail should render a modal 1`] = `
                         ee4175091d9f4 … 9d09bcf3ecefe
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -887,6 +937,16 @@ exports[`EntityDetail should render a modal 1`] = `
                         71fd1a494ded5 … 972b8075d67e9
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -1129,6 +1189,16 @@ exports[`EntityDetail should render a modal without a wallet alias 1`] = `
                         ee4175091d9f4 … 9d09bcf3ecefe
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -1186,6 +1256,16 @@ exports[`EntityDetail should render a modal without a wallet alias 1`] = `
                         71fd1a494ded5 … 972b8075d67e9
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -1434,6 +1514,16 @@ exports[`EntityDetail should render a module entity registration modal 1`] = `
                         ee4175091d9f4 … 9d09bcf3ecefe
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -1491,6 +1581,16 @@ exports[`EntityDetail should render a module entity registration modal 1`] = `
                         71fd1a494ded5 … 972b8075d67e9
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -1739,6 +1839,16 @@ exports[`EntityDetail should render a module entity resignation modal 1`] = `
                         ee4175091d9f4 … 9d09bcf3ecefe
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -1796,6 +1906,16 @@ exports[`EntityDetail should render a module entity resignation modal 1`] = `
                         71fd1a494ded5 … 972b8075d67e9
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -2044,6 +2164,16 @@ exports[`EntityDetail should render a module entity update modal 1`] = `
                         ee4175091d9f4 … 9d09bcf3ecefe
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -2101,6 +2231,16 @@ exports[`EntityDetail should render a module entity update modal 1`] = `
                         71fd1a494ded5 … 972b8075d67e9
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -2349,6 +2489,16 @@ exports[`EntityDetail should render a plugin entity registration modal 1`] = `
                         ee4175091d9f4 … 9d09bcf3ecefe
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -2406,6 +2556,16 @@ exports[`EntityDetail should render a plugin entity registration modal 1`] = `
                         71fd1a494ded5 … 972b8075d67e9
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -2654,6 +2814,16 @@ exports[`EntityDetail should render a plugin entity resignation modal 1`] = `
                         ee4175091d9f4 … 9d09bcf3ecefe
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -2711,6 +2881,16 @@ exports[`EntityDetail should render a plugin entity resignation modal 1`] = `
                         71fd1a494ded5 … 972b8075d67e9
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -2959,6 +3139,16 @@ exports[`EntityDetail should render a plugin entity update modal 1`] = `
                         ee4175091d9f4 … 9d09bcf3ecefe
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -3016,6 +3206,16 @@ exports[`EntityDetail should render a plugin entity update modal 1`] = `
                         71fd1a494ded5 … 972b8075d67e9
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -3264,6 +3464,16 @@ exports[`EntityDetail should render a product entity registration modal 1`] = `
                         ee4175091d9f4 … 9d09bcf3ecefe
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -3321,6 +3531,16 @@ exports[`EntityDetail should render a product entity registration modal 1`] = `
                         71fd1a494ded5 … 972b8075d67e9
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -3569,6 +3789,16 @@ exports[`EntityDetail should render a product entity resignation modal 1`] = `
                         ee4175091d9f4 … 9d09bcf3ecefe
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -3626,6 +3856,16 @@ exports[`EntityDetail should render a product entity resignation modal 1`] = `
                         71fd1a494ded5 … 972b8075d67e9
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -3874,6 +4114,16 @@ exports[`EntityDetail should render a product entity update modal 1`] = `
                         ee4175091d9f4 … 9d09bcf3ecefe
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -3931,6 +4181,16 @@ exports[`EntityDetail should render a product entity update modal 1`] = `
                         71fd1a494ded5 … 972b8075d67e9
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -4181,6 +4441,16 @@ exports[`EntityDetail should render as confirmed 1`] = `
                         ee4175091d9f4 … 9d09bcf3ecefe
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -4238,6 +4508,16 @@ exports[`EntityDetail should render as confirmed 1`] = `
                         71fd1a494ded5 … 972b8075d67e9
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"

--- a/src/domains/transaction/components/IpfsDetail/__snapshots__/IpfsDetail.test.tsx.snap
+++ b/src/domains/transaction/components/IpfsDetail/__snapshots__/IpfsDetail.test.tsx.snap
@@ -252,6 +252,16 @@ exports[`IpfsDetail should render a modal 1`] = `
                         ee4175091d9f4 … 9d09bcf3ecefe
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -309,6 +319,16 @@ exports[`IpfsDetail should render a modal 1`] = `
                         71fd1a494ded5 … 972b8075d67e9
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -583,6 +603,16 @@ exports[`IpfsDetail should render a modal without a wallet alias 1`] = `
                         ee4175091d9f4 … 9d09bcf3ecefe
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -640,6 +670,16 @@ exports[`IpfsDetail should render a modal without a wallet alias 1`] = `
                         71fd1a494ded5 … 972b8075d67e9
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -922,6 +962,16 @@ exports[`IpfsDetail should render as confirmed 1`] = `
                         ee4175091d9f4 … 9d09bcf3ecefe
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -979,6 +1029,16 @@ exports[`IpfsDetail should render as confirmed 1`] = `
                         71fd1a494ded5 … 972b8075d67e9
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"

--- a/src/domains/transaction/components/LegacyMagistrateDetail/__snapshots__/LegacyMagistrateDetail.test.tsx.snap
+++ b/src/domains/transaction/components/LegacyMagistrateDetail/__snapshots__/LegacyMagistrateDetail.test.tsx.snap
@@ -218,6 +218,16 @@ exports[`LegacyMagistrateDetail Legacy Bridgechain Transactions should render a 
                         ee4175091d9f4 … 9d09bcf3ecefe
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -275,6 +285,16 @@ exports[`LegacyMagistrateDetail Legacy Bridgechain Transactions should render a 
                         71fd1a494ded5 … 972b8075d67e9
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -523,6 +543,16 @@ exports[`LegacyMagistrateDetail Legacy Bridgechain Transactions should render a 
                         ee4175091d9f4 … 9d09bcf3ecefe
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -580,6 +610,16 @@ exports[`LegacyMagistrateDetail Legacy Bridgechain Transactions should render a 
                         71fd1a494ded5 … 972b8075d67e9
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -828,6 +868,16 @@ exports[`LegacyMagistrateDetail Legacy Bridgechain Transactions should render a 
                         ee4175091d9f4 … 9d09bcf3ecefe
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -885,6 +935,16 @@ exports[`LegacyMagistrateDetail Legacy Bridgechain Transactions should render a 
                         71fd1a494ded5 … 972b8075d67e9
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -1133,6 +1193,16 @@ exports[`LegacyMagistrateDetail Legacy Business Transactions should render a leg
                         ee4175091d9f4 … 9d09bcf3ecefe
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -1190,6 +1260,16 @@ exports[`LegacyMagistrateDetail Legacy Business Transactions should render a leg
                         71fd1a494ded5 … 972b8075d67e9
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -1438,6 +1518,16 @@ exports[`LegacyMagistrateDetail Legacy Business Transactions should render a leg
                         ee4175091d9f4 … 9d09bcf3ecefe
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -1495,6 +1585,16 @@ exports[`LegacyMagistrateDetail Legacy Business Transactions should render a leg
                         71fd1a494ded5 … 972b8075d67e9
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -1743,6 +1843,16 @@ exports[`LegacyMagistrateDetail Legacy Business Transactions should render a leg
                         ee4175091d9f4 … 9d09bcf3ecefe
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -1800,6 +1910,16 @@ exports[`LegacyMagistrateDetail Legacy Business Transactions should render a leg
                         71fd1a494ded5 … 972b8075d67e9
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"

--- a/src/domains/transaction/components/MultiPaymentDetail/__snapshots__/MultiPaymentDetail.test.tsx.snap
+++ b/src/domains/transaction/components/MultiPaymentDetail/__snapshots__/MultiPaymentDetail.test.tsx.snap
@@ -303,6 +303,16 @@ exports[`MultiPaymentDetail should render a modal 1`] = `
                         ee4175091d9f4 … 9d09bcf3ecefe
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -360,6 +370,16 @@ exports[`MultiPaymentDetail should render a modal 1`] = `
                         adsad12312xsd1w312e1s13203e12
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -947,6 +967,16 @@ exports[`MultiPaymentDetail should render with recipients 1`] = `
                         ee4175091d9f4 … 9d09bcf3ecefe
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -1004,6 +1034,16 @@ exports[`MultiPaymentDetail should render with recipients 1`] = `
                         adsad12312xsd1w312e1s13203e12
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"

--- a/src/domains/transaction/components/MultiSignatureDetail/__snapshots__/MultiSignatureRegistrationDetail.test.tsx.snap
+++ b/src/domains/transaction/components/MultiSignatureDetail/__snapshots__/MultiSignatureRegistrationDetail.test.tsx.snap
@@ -287,6 +287,16 @@ exports[`MultiSignatureRegistrationDetail should render 1`] = `
                         ee4175091d9f4 … 9d09bcf3ecefe
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -344,6 +354,16 @@ exports[`MultiSignatureRegistrationDetail should render 1`] = `
                         71fd1a494ded5 … 972b8075d67e9
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"

--- a/src/domains/transaction/components/SecondSignatureDetail/__snapshots__/SecondSignatureDetail.test.tsx.snap
+++ b/src/domains/transaction/components/SecondSignatureDetail/__snapshots__/SecondSignatureDetail.test.tsx.snap
@@ -220,6 +220,16 @@ exports[`SecondSignatureDetail should render a modal 1`] = `
                         ee4175091d9f4 … 9d09bcf3ecefe
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -277,6 +287,16 @@ exports[`SecondSignatureDetail should render a modal 1`] = `
                         71fd1a494ded5 … 972b8075d67e9
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -519,6 +539,16 @@ exports[`SecondSignatureDetail should render a modal without a wallet alias 1`] 
                         ee4175091d9f4 … 9d09bcf3ecefe
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -576,6 +606,16 @@ exports[`SecondSignatureDetail should render a modal without a wallet alias 1`] 
                         71fd1a494ded5 … 972b8075d67e9
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -826,6 +866,16 @@ exports[`SecondSignatureDetail should render as confirmed 1`] = `
                         ee4175091d9f4 … 9d09bcf3ecefe
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -883,6 +933,16 @@ exports[`SecondSignatureDetail should render as confirmed 1`] = `
                         71fd1a494ded5 … 972b8075d67e9
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"

--- a/src/domains/transaction/components/TransactionDetail/TransactionExplorerLink/TransactionExplorerLink.tsx
+++ b/src/domains/transaction/components/TransactionDetail/TransactionExplorerLink/TransactionExplorerLink.tsx
@@ -21,7 +21,7 @@ export const TransactionExplorerLink = ({ id, link, variant, ...props }: Transac
 	return (
 		<TransactionDetail label={isTransactionLink() ? t("TRANSACTION.ID") : t("TRANSACTION.BLOCK_ID")} {...props}>
 			<div className="flex items-center space-x-3">
-				<Link to={link} isExternal showExternalIcon={false}>
+				<Link to={link} isExternal>
 					<TruncateMiddle text={id} maxChars={30} className="text-theme-primary-700" />
 				</Link>
 

--- a/src/domains/transaction/components/TransactionDetail/TransactionExplorerLink/__snapshots__/TransactionExplorerLink.test.tsx.snap
+++ b/src/domains/transaction/components/TransactionDetail/TransactionExplorerLink/__snapshots__/TransactionExplorerLink.test.tsx.snap
@@ -36,6 +36,16 @@ exports[`TransactionExplorerLink should render a 'block' link 1`] = `
                 test-id
               </span>
             </span>
+            <div
+              class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+              data-testid="Link__external"
+              height="1em"
+              width="1em"
+            >
+              <svg>
+                redirect.svg
+              </svg>
+            </div>
           </a>
           <span
             class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -98,6 +108,16 @@ exports[`TransactionExplorerLink should render a 'transaction' link 1`] = `
                 test-id
               </span>
             </span>
+            <div
+              class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+              data-testid="Link__external"
+              height="1em"
+              width="1em"
+            >
+              <svg>
+                redirect.svg
+              </svg>
+            </div>
           </a>
           <span
             class="flex text-theme-primary-300 dark:text-theme-secondary-600"

--- a/src/domains/transaction/components/TransactionDetailModal/__snapshots__/TransactionDetailModal.test.tsx.snap
+++ b/src/domains/transaction/components/TransactionDetailModal/__snapshots__/TransactionDetailModal.test.tsx.snap
@@ -239,6 +239,16 @@ exports[`TransactionDetailModal should render a delegate registration modal 1`] 
                         ee4175091d9f4 … 9d09bcf3ecefe
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -296,6 +306,16 @@ exports[`TransactionDetailModal should render a delegate registration modal 1`] 
                         as32d1as65d1a … as3d2as165das
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -564,6 +584,16 @@ exports[`TransactionDetailModal should render a delegate resignation modal 1`] =
                         ee4175091d9f4 … 9d09bcf3ecefe
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -621,6 +651,16 @@ exports[`TransactionDetailModal should render a delegate resignation modal 1`] =
                         as32d1as65d1a … as3d2as165das
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -870,6 +910,16 @@ exports[`TransactionDetailModal should render a entity modal 1`] = `
                         ee4175091d9f4 … 9d09bcf3ecefe
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -927,6 +977,16 @@ exports[`TransactionDetailModal should render a entity modal 1`] = `
                         as32d1as65d1a … as3d2as165das
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -1208,6 +1268,16 @@ exports[`TransactionDetailModal should render a ipfs modal 1`] = `
                         ee4175091d9f4 … 9d09bcf3ecefe
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -1265,6 +1335,16 @@ exports[`TransactionDetailModal should render a ipfs modal 1`] = `
                         71fd1a494ded5 … 972b8075d67e9
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -1514,6 +1594,16 @@ exports[`TransactionDetailModal should render a legacy magistrate modal 1`] = `
                         ee4175091d9f4 … 9d09bcf3ecefe
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -1571,6 +1661,16 @@ exports[`TransactionDetailModal should render a legacy magistrate modal 1`] = `
                         as32d1as65d1a … as3d2as165das
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -1903,6 +2003,16 @@ exports[`TransactionDetailModal should render a multi payment modal 1`] = `
                         ee4175091d9f4 … 9d09bcf3ecefe
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -1960,6 +2070,16 @@ exports[`TransactionDetailModal should render a multi payment modal 1`] = `
                         as32d1as65d1a … as3d2as165das
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -2276,6 +2396,16 @@ exports[`TransactionDetailModal should render a multi signature modal 1`] = `
                         ee4175091d9f4 … 9d09bcf3ecefe
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -2333,6 +2463,16 @@ exports[`TransactionDetailModal should render a multi signature modal 1`] = `
                         as32d1as65d1a … as3d2as165das
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -2582,6 +2722,16 @@ exports[`TransactionDetailModal should render a second signature modal 1`] = `
                         ee4175091d9f4 … 9d09bcf3ecefe
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -2639,6 +2789,16 @@ exports[`TransactionDetailModal should render a second signature modal 1`] = `
                         as32d1as65d1a … as3d2as165das
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -3013,6 +3173,16 @@ exports[`TransactionDetailModal should render a transfer modal 1`] = `
                         ee4175091d9f4 … 9d09bcf3ecefe
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -3070,6 +3240,16 @@ exports[`TransactionDetailModal should render a transfer modal 1`] = `
                         as32d1as65d1a … as3d2as165das
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -3471,6 +3651,16 @@ exports[`TransactionDetailModal should render a unvote modal 1`] = `
                         ee4175091d9f4 … 9d09bcf3ecefe
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -3528,6 +3718,16 @@ exports[`TransactionDetailModal should render a unvote modal 1`] = `
                         as32d1as65d1a … as3d2as165das
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -3929,6 +4129,16 @@ exports[`TransactionDetailModal should render a vote modal 1`] = `
                         ee4175091d9f4 … 9d09bcf3ecefe
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -3986,6 +4196,16 @@ exports[`TransactionDetailModal should render a vote modal 1`] = `
                         as32d1as65d1a … as3d2as165das
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"

--- a/src/domains/transaction/components/TransactionTable/TransactionRow/TransactionRow.tsx
+++ b/src/domains/transaction/components/TransactionTable/TransactionRow/TransactionRow.tsx
@@ -64,7 +64,6 @@ export const TransactionRow = ({
 						data-testid="TransactionRow__ID"
 						to={transaction.explorerLink()}
 						tooltip={transaction.id()}
-						showExternalIcon={false}
 						isExternal
 					>
 						<Icon name="Id" />

--- a/src/domains/transaction/components/TransactionTable/__snapshots__/TransactionTable.test.tsx.snap
+++ b/src/domains/transaction/components/TransactionTable/__snapshots__/TransactionTable.test.tsx.snap
@@ -3581,6 +3581,16 @@ exports[`TransactionTable should render 1`] = `
                       </svg>
                     </div>
                   </span>
+                  <div
+                    class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                    data-testid="Link__external"
+                    height="1em"
+                    width="1em"
+                  >
+                    <svg>
+                      redirect.svg
+                    </svg>
+                  </div>
                 </a>
               </div>
             </td>
@@ -3743,6 +3753,16 @@ exports[`TransactionTable should render 1`] = `
                       </svg>
                     </div>
                   </span>
+                  <div
+                    class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                    data-testid="Link__external"
+                    height="1em"
+                    width="1em"
+                  >
+                    <svg>
+                      redirect.svg
+                    </svg>
+                  </div>
                 </a>
               </div>
             </td>
@@ -4297,6 +4317,16 @@ exports[`TransactionTable should render with sign 1`] = `
                       </svg>
                     </div>
                   </span>
+                  <div
+                    class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                    data-testid="Link__external"
+                    height="1em"
+                    width="1em"
+                  >
+                    <svg>
+                      redirect.svg
+                    </svg>
+                  </div>
                 </a>
               </div>
             </td>
@@ -4478,6 +4508,16 @@ exports[`TransactionTable should render with sign 1`] = `
                       </svg>
                     </div>
                   </span>
+                  <div
+                    class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                    data-testid="Link__external"
+                    height="1em"
+                    width="1em"
+                  >
+                    <svg>
+                      redirect.svg
+                    </svg>
+                  </div>
                 </a>
               </div>
             </td>

--- a/src/domains/transaction/components/TransferDetail/__snapshots__/TransferDetail.test.tsx.snap
+++ b/src/domains/transaction/components/TransferDetail/__snapshots__/TransferDetail.test.tsx.snap
@@ -345,6 +345,16 @@ exports[`TransferDetail should render a modal 1`] = `
                         ee4175091d9f4 … 9d09bcf3ecefe
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -402,6 +412,16 @@ exports[`TransferDetail should render a modal 1`] = `
                         adsad12312xsd1w312e1s13203e12
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -777,6 +797,16 @@ exports[`TransferDetail should render as confirmed 1`] = `
                         ee4175091d9f4 … 9d09bcf3ecefe
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -834,6 +864,16 @@ exports[`TransferDetail should render as confirmed 1`] = `
                         adsad12312xsd1w312e1s13203e12
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -1207,6 +1247,16 @@ exports[`TransferDetail should render as not is sent 1`] = `
                         ee4175091d9f4 … 9d09bcf3ecefe
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -1264,6 +1314,16 @@ exports[`TransferDetail should render as not is sent 1`] = `
                         adsad12312xsd1w312e1s13203e12
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -1637,6 +1697,16 @@ exports[`TransferDetail should render with wallet alias 1`] = `
                         ee4175091d9f4 … 9d09bcf3ecefe
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -1694,6 +1764,16 @@ exports[`TransferDetail should render with wallet alias 1`] = `
                         adsad12312xsd1w312e1s13203e12
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"

--- a/src/domains/transaction/components/VoteDetail/__snapshots__/VoteDetail.test.tsx.snap
+++ b/src/domains/transaction/components/VoteDetail/__snapshots__/VoteDetail.test.tsx.snap
@@ -312,6 +312,16 @@ exports[`VoteDetail should render a modal with unvotes 1`] = `
                         ee4175091d9f4 … 9d09bcf3ecefe
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -369,6 +379,16 @@ exports[`VoteDetail should render a modal with unvotes 1`] = `
                         71fd1a494ded5 … 972b8075d67e9
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -709,6 +729,16 @@ exports[`VoteDetail should render a modal with votes 1`] = `
                         ee4175091d9f4 … 9d09bcf3ecefe
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -766,6 +796,16 @@ exports[`VoteDetail should render a modal with votes 1`] = `
                         71fd1a494ded5 … 972b8075d67e9
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -1166,6 +1206,16 @@ exports[`VoteDetail should render a modal with votes and unvotes 1`] = `
                         ee4175091d9f4 … 9d09bcf3ecefe
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -1223,6 +1273,16 @@ exports[`VoteDetail should render a modal with votes and unvotes 1`] = `
                         71fd1a494ded5 … 972b8075d67e9
                       </span>
                     </span>
+                    <div
+                      class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                      data-testid="Link__external"
+                      height="1em"
+                      width="1em"
+                    >
+                      <svg>
+                        redirect.svg
+                      </svg>
+                    </div>
                   </a>
                   <span
                     class="flex text-theme-primary-300 dark:text-theme-secondary-600"

--- a/src/domains/transaction/pages/SendDelegateResignation/__snapshots__/SendDelegateResignation.test.tsx.snap
+++ b/src/domains/transaction/pages/SendDelegateResignation/__snapshots__/SendDelegateResignation.test.tsx.snap
@@ -4013,6 +4013,16 @@ exports[`SendDelegateResignation Delegate Resignation should successfully sign a
                                       8f913b6b719e7 … f1b89abb49877
                                     </span>
                                   </span>
+                                  <div
+                                    class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                                    data-testid="Link__external"
+                                    height="1em"
+                                    width="1em"
+                                  >
+                                    <svg>
+                                      redirect.svg
+                                    </svg>
+                                  </div>
                                 </a>
                                 <span
                                   class="flex text-theme-primary-300 dark:text-theme-secondary-600"

--- a/src/domains/transaction/pages/SendIpfs/__snapshots__/SendIpfs.test.tsx.snap
+++ b/src/domains/transaction/pages/SendIpfs/__snapshots__/SendIpfs.test.tsx.snap
@@ -1456,6 +1456,16 @@ exports[`SendIpfs should send an IPFS transaction and go back to wallet page 1`]
                                     1e9b975eff66a … db3d69131067e
                                   </span>
                                 </span>
+                                <div
+                                  class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                                  data-testid="Link__external"
+                                  height="1em"
+                                  width="1em"
+                                >
+                                  <svg>
+                                    redirect.svg
+                                  </svg>
+                                </div>
                               </a>
                               <span
                                 class="flex text-theme-primary-300 dark:text-theme-secondary-600"

--- a/src/domains/transaction/pages/SendTransfer/__snapshots__/SendTransfer.test.tsx.snap
+++ b/src/domains/transaction/pages/SendTransfer/__snapshots__/SendTransfer.test.tsx.snap
@@ -2950,6 +2950,16 @@ exports[`SendTransfer should render 4th step (summary) 1`] = `
                     8f913b6b719e7 … f1b89abb49877
                   </span>
                 </span>
+                <div
+                  class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                  data-testid="Link__external"
+                  height="1em"
+                  width="1em"
+                >
+                  <svg>
+                    redirect.svg
+                  </svg>
+                </div>
               </a>
               <span
                 class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -6922,6 +6932,16 @@ exports[`SendTransfer should send a single transfer 1`] = `
                                     8f913b6b719e7 … f1b89abb49877
                                   </span>
                                 </span>
+                                <div
+                                  class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                                  data-testid="Link__external"
+                                  height="1em"
+                                  width="1em"
+                                >
+                                  <svg>
+                                    redirect.svg
+                                  </svg>
+                                </div>
                               </a>
                               <span
                                 class="flex text-theme-primary-300 dark:text-theme-secondary-600"

--- a/src/domains/transaction/pages/SendVote/__snapshots__/SendVote.test.tsx.snap
+++ b/src/domains/transaction/pages/SendVote/__snapshots__/SendVote.test.tsx.snap
@@ -1158,6 +1158,16 @@ exports[`SendVote should send a unvote transaction 1`] = `
                                     32e5278cb72f2 … f7660a2ee2faf
                                   </span>
                                 </span>
+                                <div
+                                  class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                                  data-testid="Link__external"
+                                  height="1em"
+                                  width="1em"
+                                >
+                                  <svg>
+                                    redirect.svg
+                                  </svg>
+                                </div>
                               </a>
                               <span
                                 class="flex text-theme-primary-300 dark:text-theme-secondary-600"

--- a/src/domains/transaction/pages/SendVote/__snapshots__/SendVote.test.tsx.snap
+++ b/src/domains/transaction/pages/SendVote/__snapshots__/SendVote.test.tsx.snap
@@ -421,6 +421,16 @@ exports[`SendVote should send a unvote & vote transaction 1`] = `
                                     d819c5199e323 … 6b8518ad1e493
                                   </span>
                                 </span>
+                                <div
+                                  class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                                  data-testid="Link__external"
+                                  height="1em"
+                                  width="1em"
+                                >
+                                  <svg>
+                                    redirect.svg
+                                  </svg>
+                                </div>
                               </a>
                               <span
                                 class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -1845,6 +1855,16 @@ exports[`SendVote should send a vote transaction 1`] = `
                                     d819c5199e323 … 6b8518ad1e493
                                   </span>
                                 </span>
+                                <div
+                                  class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                                  data-testid="Link__external"
+                                  height="1em"
+                                  width="1em"
+                                >
+                                  <svg>
+                                    redirect.svg
+                                  </svg>
+                                </div>
                               </a>
                               <span
                                 class="flex text-theme-primary-300 dark:text-theme-secondary-600"
@@ -2522,6 +2542,16 @@ exports[`SendVote should send a vote transaction 2`] = `
                                     d819c5199e323 … 6b8518ad1e493
                                   </span>
                                 </span>
+                                <div
+                                  class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                                  data-testid="Link__external"
+                                  height="1em"
+                                  width="1em"
+                                >
+                                  <svg>
+                                    redirect.svg
+                                  </svg>
+                                </div>
                               </a>
                               <span
                                 class="flex text-theme-primary-300 dark:text-theme-secondary-600"

--- a/src/domains/wallet/pages/WalletDetails/__snapshots__/WalletDetails.test.tsx.snap
+++ b/src/domains/wallet/pages/WalletDetails/__snapshots__/WalletDetails.test.tsx.snap
@@ -949,6 +949,16 @@ exports[`WalletDetails should not fail if the votes have not yet been synchroniz
                                 </svg>
                               </div>
                             </span>
+                            <div
+                              class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                              data-testid="Link__external"
+                              height="1em"
+                              width="1em"
+                            >
+                              <svg>
+                                redirect.svg
+                              </svg>
+                            </div>
                           </a>
                         </div>
                       </td>
@@ -2049,6 +2059,16 @@ exports[`WalletDetails should open detail modal on transaction row click 1`] = `
                                 </svg>
                               </div>
                             </span>
+                            <div
+                              class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                              data-testid="Link__external"
+                              height="1em"
+                              width="1em"
+                            >
+                              <svg>
+                                redirect.svg
+                              </svg>
+                            </div>
                           </a>
                         </div>
                       </td>
@@ -3149,6 +3169,16 @@ exports[`WalletDetails should remove wallet name 1`] = `
                                 </svg>
                               </div>
                             </span>
+                            <div
+                              class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                              data-testid="Link__external"
+                              height="1em"
+                              width="1em"
+                            >
+                              <svg>
+                                redirect.svg
+                              </svg>
+                            </div>
                           </a>
                         </div>
                       </td>
@@ -4249,6 +4279,16 @@ exports[`WalletDetails should render when wallet not found for votes 1`] = `
                                 </svg>
                               </div>
                             </span>
+                            <div
+                              class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                              data-testid="Link__external"
+                              height="1em"
+                              width="1em"
+                            >
+                              <svg>
+                                redirect.svg
+                              </svg>
+                            </div>
                           </a>
                         </div>
                       </td>
@@ -5349,6 +5389,16 @@ exports[`WalletDetails should star and unstar a wallet 1`] = `
                                 </svg>
                               </div>
                             </span>
+                            <div
+                              class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                              data-testid="Link__external"
+                              height="1em"
+                              width="1em"
+                            >
+                              <svg>
+                                redirect.svg
+                              </svg>
+                            </div>
                           </a>
                         </div>
                       </td>
@@ -6455,6 +6505,16 @@ exports[`WalletDetails should update wallet name 1`] = `
                                 </svg>
                               </div>
                             </span>
+                            <div
+                              class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
+                              data-testid="Link__external"
+                              height="1em"
+                              width="1em"
+                            >
+                              <svg>
+                                redirect.svg
+                              </svg>
+                            </div>
                           </a>
                         </div>
                       </td>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
-   [x] Use external icon in Explorer links
-   [x] Use external icon in News links

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [x] My changes look good in both light AND dark mode
-   [x] The change is not hardcoded to a single network, but has multi-asset in mind
-   [x] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [x] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
