### PR TITLE
chore: add external icon to `Learn more` link

### DIFF
--- a/src/domains/wallet/pages/WalletDetails/__snapshots__/WalletDetails.test.tsx.snap
+++ b/src/domains/wallet/pages/WalletDetails/__snapshots__/WalletDetails.test.tsx.snap
@@ -553,6 +553,16 @@ exports[`WalletDetails should not fail if the votes have not yet been synchroniz
                           Learn more
                         </span>
                       </span>
+                      <div
+                        class="sc-gsTCUz cXMmJt flex-shrink-0 ml-2 text-sm"
+                        data-testid="Link__external"
+                        height="1em"
+                        width="1em"
+                      >
+                        <svg>
+                          redirect.svg
+                        </svg>
+                      </div>
                     </a>
                   </span>
                 </div>
@@ -3602,6 +3612,16 @@ exports[`WalletDetails should render when wallet not found for votes 1`] = `
                           Learn more
                         </span>
                       </span>
+                      <div
+                        class="sc-gsTCUz cXMmJt flex-shrink-0 ml-2 text-sm"
+                        data-testid="Link__external"
+                        height="1em"
+                        width="1em"
+                      >
+                        <svg>
+                          redirect.svg
+                        </svg>
+                      </div>
                     </a>
                   </span>
                 </div>

--- a/src/domains/wallet/pages/WalletDetails/components/WalletVote/WalletVote.tsx
+++ b/src/domains/wallet/pages/WalletDetails/components/WalletVote/WalletVote.tsx
@@ -178,7 +178,7 @@ export const WalletVote = ({ isLoading, wallet, onButtonClick }: WalletVoteProps
 								<span className="mr-1 text-sm text-theme-secondary-500 dark:text-theme-secondary-700">
 									{t("WALLETS.PAGE_WALLET_DETAILS.VOTES.EMPTY_DESCRIPTION")}
 								</span>
-								<Link to={votesHelpLink} showExternalIcon={false} isExternal>
+								<Link to={votesHelpLink} isExternal>
 									<span className="text-sm">{t("COMMON.LEARN_MORE")}</span>
 								</Link>
 							</span>

--- a/src/domains/wallet/pages/WalletDetails/components/WalletVote/__snapshots__/WalletVote.test.tsx.snap
+++ b/src/domains/wallet/pages/WalletDetails/components/WalletVote/__snapshots__/WalletVote.test.tsx.snap
@@ -539,6 +539,16 @@ exports[`WalletVote should render the maximum votes 1`] = `
                 Learn more
               </span>
             </span>
+            <div
+              class="sc-gsTCUz cXMmJt flex-shrink-0 ml-2 text-sm"
+              data-testid="Link__external"
+              height="1em"
+              width="1em"
+            >
+              <svg>
+                redirect.svg
+              </svg>
+            </div>
           </a>
         </span>
       </div>
@@ -623,6 +633,16 @@ exports[`WalletVote should render without votes 1`] = `
                 Learn more
               </span>
             </span>
+            <div
+              class="sc-gsTCUz cXMmJt flex-shrink-0 ml-2 text-sm"
+              data-testid="Link__external"
+              height="1em"
+              width="1em"
+            >
+              <svg>
+                redirect.svg
+              </svg>
+            </div>
           </a>
         </span>
       </div>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/cpz5b2

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [x] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
