### PR TITLE
fix: remove external icon from transaction rows

### DIFF
--- a/src/domains/dashboard/components/Transactions/__snapshots__/Transactions.test.tsx.snap
+++ b/src/domains/dashboard/components/Transactions/__snapshots__/Transactions.test.tsx.snap
@@ -268,16 +268,6 @@ exports[`Transactions should fetch more transactions 1`] = `
                           </svg>
                         </div>
                       </span>
-                      <div
-                        class="sc-gsTCUz cXMmJt flex-shrink-0 ml-2 text-sm"
-                        data-testid="Link__external"
-                        height="1em"
-                        width="1em"
-                      >
-                        <svg>
-                          redirect.svg
-                        </svg>
-                      </div>
                     </a>
                   </div>
                 </td>
@@ -437,16 +427,6 @@ exports[`Transactions should fetch more transactions 1`] = `
                           </svg>
                         </div>
                       </span>
-                      <div
-                        class="sc-gsTCUz cXMmJt flex-shrink-0 ml-2 text-sm"
-                        data-testid="Link__external"
-                        height="1em"
-                        width="1em"
-                      >
-                        <svg>
-                          redirect.svg
-                        </svg>
-                      </div>
                     </a>
                   </div>
                 </td>
@@ -606,16 +586,6 @@ exports[`Transactions should fetch more transactions 1`] = `
                           </svg>
                         </div>
                       </span>
-                      <div
-                        class="sc-gsTCUz cXMmJt flex-shrink-0 ml-2 text-sm"
-                        data-testid="Link__external"
-                        height="1em"
-                        width="1em"
-                      >
-                        <svg>
-                          redirect.svg
-                        </svg>
-                      </div>
                     </a>
                   </div>
                 </td>
@@ -775,16 +745,6 @@ exports[`Transactions should fetch more transactions 1`] = `
                           </svg>
                         </div>
                       </span>
-                      <div
-                        class="sc-gsTCUz cXMmJt flex-shrink-0 ml-2 text-sm"
-                        data-testid="Link__external"
-                        height="1em"
-                        width="1em"
-                      >
-                        <svg>
-                          redirect.svg
-                        </svg>
-                      </div>
                     </a>
                   </div>
                 </td>
@@ -944,16 +904,6 @@ exports[`Transactions should fetch more transactions 1`] = `
                           </svg>
                         </div>
                       </span>
-                      <div
-                        class="sc-gsTCUz cXMmJt flex-shrink-0 ml-2 text-sm"
-                        data-testid="Link__external"
-                        height="1em"
-                        width="1em"
-                      >
-                        <svg>
-                          redirect.svg
-                        </svg>
-                      </div>
                     </a>
                   </div>
                 </td>
@@ -1113,16 +1063,6 @@ exports[`Transactions should fetch more transactions 1`] = `
                           </svg>
                         </div>
                       </span>
-                      <div
-                        class="sc-gsTCUz cXMmJt flex-shrink-0 ml-2 text-sm"
-                        data-testid="Link__external"
-                        height="1em"
-                        width="1em"
-                      >
-                        <svg>
-                          redirect.svg
-                        </svg>
-                      </div>
                     </a>
                   </div>
                 </td>
@@ -1282,16 +1222,6 @@ exports[`Transactions should fetch more transactions 1`] = `
                           </svg>
                         </div>
                       </span>
-                      <div
-                        class="sc-gsTCUz cXMmJt flex-shrink-0 ml-2 text-sm"
-                        data-testid="Link__external"
-                        height="1em"
-                        width="1em"
-                      >
-                        <svg>
-                          redirect.svg
-                        </svg>
-                      </div>
                     </a>
                   </div>
                 </td>
@@ -1451,16 +1381,6 @@ exports[`Transactions should fetch more transactions 1`] = `
                           </svg>
                         </div>
                       </span>
-                      <div
-                        class="sc-gsTCUz cXMmJt flex-shrink-0 ml-2 text-sm"
-                        data-testid="Link__external"
-                        height="1em"
-                        width="1em"
-                      >
-                        <svg>
-                          redirect.svg
-                        </svg>
-                      </div>
                     </a>
                   </div>
                 </td>
@@ -1877,16 +1797,6 @@ exports[`Transactions should open detail modal on transaction row click 1`] = `
                           </svg>
                         </div>
                       </span>
-                      <div
-                        class="sc-gsTCUz cXMmJt flex-shrink-0 ml-2 text-sm"
-                        data-testid="Link__external"
-                        height="1em"
-                        width="1em"
-                      >
-                        <svg>
-                          redirect.svg
-                        </svg>
-                      </div>
                     </a>
                   </div>
                 </td>
@@ -2046,16 +1956,6 @@ exports[`Transactions should open detail modal on transaction row click 1`] = `
                           </svg>
                         </div>
                       </span>
-                      <div
-                        class="sc-gsTCUz cXMmJt flex-shrink-0 ml-2 text-sm"
-                        data-testid="Link__external"
-                        height="1em"
-                        width="1em"
-                      >
-                        <svg>
-                          redirect.svg
-                        </svg>
-                      </div>
                     </a>
                   </div>
                 </td>
@@ -2215,16 +2115,6 @@ exports[`Transactions should open detail modal on transaction row click 1`] = `
                           </svg>
                         </div>
                       </span>
-                      <div
-                        class="sc-gsTCUz cXMmJt flex-shrink-0 ml-2 text-sm"
-                        data-testid="Link__external"
-                        height="1em"
-                        width="1em"
-                      >
-                        <svg>
-                          redirect.svg
-                        </svg>
-                      </div>
                     </a>
                   </div>
                 </td>
@@ -2384,16 +2274,6 @@ exports[`Transactions should open detail modal on transaction row click 1`] = `
                           </svg>
                         </div>
                       </span>
-                      <div
-                        class="sc-gsTCUz cXMmJt flex-shrink-0 ml-2 text-sm"
-                        data-testid="Link__external"
-                        height="1em"
-                        width="1em"
-                      >
-                        <svg>
-                          redirect.svg
-                        </svg>
-                      </div>
                     </a>
                   </div>
                 </td>
@@ -2810,16 +2690,6 @@ exports[`Transactions should render 1`] = `
                           </svg>
                         </div>
                       </span>
-                      <div
-                        class="sc-gsTCUz cXMmJt flex-shrink-0 ml-2 text-sm"
-                        data-testid="Link__external"
-                        height="1em"
-                        width="1em"
-                      >
-                        <svg>
-                          redirect.svg
-                        </svg>
-                      </div>
                     </a>
                   </div>
                 </td>
@@ -2979,16 +2849,6 @@ exports[`Transactions should render 1`] = `
                           </svg>
                         </div>
                       </span>
-                      <div
-                        class="sc-gsTCUz cXMmJt flex-shrink-0 ml-2 text-sm"
-                        data-testid="Link__external"
-                        height="1em"
-                        width="1em"
-                      >
-                        <svg>
-                          redirect.svg
-                        </svg>
-                      </div>
                     </a>
                   </div>
                 </td>
@@ -3148,16 +3008,6 @@ exports[`Transactions should render 1`] = `
                           </svg>
                         </div>
                       </span>
-                      <div
-                        class="sc-gsTCUz cXMmJt flex-shrink-0 ml-2 text-sm"
-                        data-testid="Link__external"
-                        height="1em"
-                        width="1em"
-                      >
-                        <svg>
-                          redirect.svg
-                        </svg>
-                      </div>
                     </a>
                   </div>
                 </td>
@@ -3317,16 +3167,6 @@ exports[`Transactions should render 1`] = `
                           </svg>
                         </div>
                       </span>
-                      <div
-                        class="sc-gsTCUz cXMmJt flex-shrink-0 ml-2 text-sm"
-                        data-testid="Link__external"
-                        height="1em"
-                        width="1em"
-                      >
-                        <svg>
-                          redirect.svg
-                        </svg>
-                      </div>
                     </a>
                   </div>
                 </td>

--- a/src/domains/dashboard/pages/Dashboard/__snapshots__/Dashboard.test.tsx.snap
+++ b/src/domains/dashboard/pages/Dashboard/__snapshots__/Dashboard.test.tsx.snap
@@ -954,16 +954,6 @@ exports[`Dashboard should render 1`] = `
                               </svg>
                             </div>
                           </span>
-                          <div
-                            class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
-                            data-testid="Link__external"
-                            height="1em"
-                            width="1em"
-                          >
-                            <svg>
-                              redirect.svg
-                            </svg>
-                          </div>
                         </a>
                       </div>
                     </td>
@@ -1123,16 +1113,6 @@ exports[`Dashboard should render 1`] = `
                               </svg>
                             </div>
                           </span>
-                          <div
-                            class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
-                            data-testid="Link__external"
-                            height="1em"
-                            width="1em"
-                          >
-                            <svg>
-                              redirect.svg
-                            </svg>
-                          </div>
                         </a>
                       </div>
                     </td>
@@ -1292,16 +1272,6 @@ exports[`Dashboard should render 1`] = `
                               </svg>
                             </div>
                           </span>
-                          <div
-                            class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
-                            data-testid="Link__external"
-                            height="1em"
-                            width="1em"
-                          >
-                            <svg>
-                              redirect.svg
-                            </svg>
-                          </div>
                         </a>
                       </div>
                     </td>
@@ -1461,16 +1431,6 @@ exports[`Dashboard should render 1`] = `
                               </svg>
                             </div>
                           </span>
-                          <div
-                            class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
-                            data-testid="Link__external"
-                            height="1em"
-                            width="1em"
-                          >
-                            <svg>
-                              redirect.svg
-                            </svg>
-                          </div>
                         </a>
                       </div>
                     </td>

--- a/src/domains/transaction/components/TransactionTable/TransactionRow/TransactionRow.tsx
+++ b/src/domains/transaction/components/TransactionTable/TransactionRow/TransactionRow.tsx
@@ -64,6 +64,7 @@ export const TransactionRow = ({
 						data-testid="TransactionRow__ID"
 						to={transaction.explorerLink()}
 						tooltip={transaction.id()}
+						showExternalIcon={false}
 						isExternal
 					>
 						<Icon name="Id" />

--- a/src/domains/transaction/components/TransactionTable/__snapshots__/TransactionTable.test.tsx.snap
+++ b/src/domains/transaction/components/TransactionTable/__snapshots__/TransactionTable.test.tsx.snap
@@ -3581,16 +3581,6 @@ exports[`TransactionTable should render 1`] = `
                       </svg>
                     </div>
                   </span>
-                  <div
-                    class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
-                    data-testid="Link__external"
-                    height="1em"
-                    width="1em"
-                  >
-                    <svg>
-                      redirect.svg
-                    </svg>
-                  </div>
                 </a>
               </div>
             </td>
@@ -3753,16 +3743,6 @@ exports[`TransactionTable should render 1`] = `
                       </svg>
                     </div>
                   </span>
-                  <div
-                    class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
-                    data-testid="Link__external"
-                    height="1em"
-                    width="1em"
-                  >
-                    <svg>
-                      redirect.svg
-                    </svg>
-                  </div>
                 </a>
               </div>
             </td>
@@ -4317,16 +4297,6 @@ exports[`TransactionTable should render with sign 1`] = `
                       </svg>
                     </div>
                   </span>
-                  <div
-                    class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
-                    data-testid="Link__external"
-                    height="1em"
-                    width="1em"
-                  >
-                    <svg>
-                      redirect.svg
-                    </svg>
-                  </div>
                 </a>
               </div>
             </td>
@@ -4508,16 +4478,6 @@ exports[`TransactionTable should render with sign 1`] = `
                       </svg>
                     </div>
                   </span>
-                  <div
-                    class="sc-bdfBwQ fPrsah flex-shrink-0 ml-2 text-sm"
-                    data-testid="Link__external"
-                    height="1em"
-                    width="1em"
-                  >
-                    <svg>
-                      redirect.svg
-                    </svg>
-                  </div>
                 </a>
               </div>
             </td>

--- a/src/domains/wallet/pages/WalletDetails/__snapshots__/WalletDetails.test.tsx.snap
+++ b/src/domains/wallet/pages/WalletDetails/__snapshots__/WalletDetails.test.tsx.snap
@@ -846,16 +846,6 @@ exports[`WalletDetails should not fail if the votes have not yet been synchroniz
                                 </svg>
                               </div>
                             </span>
-                            <div
-                              class="sc-gsTCUz cXMmJt flex-shrink-0 ml-2 text-sm"
-                              data-testid="Link__external"
-                              height="1em"
-                              width="1em"
-                            >
-                              <svg>
-                                redirect.svg
-                              </svg>
-                            </div>
                           </a>
                         </div>
                       </td>
@@ -1867,16 +1857,6 @@ exports[`WalletDetails should open detail modal on transaction row click 1`] = `
                                 </svg>
                               </div>
                             </span>
-                            <div
-                              class="sc-gsTCUz cXMmJt flex-shrink-0 ml-2 text-sm"
-                              data-testid="Link__external"
-                              height="1em"
-                              width="1em"
-                            >
-                              <svg>
-                                redirect.svg
-                              </svg>
-                            </div>
                           </a>
                         </div>
                       </td>
@@ -2888,16 +2868,6 @@ exports[`WalletDetails should remove wallet name 1`] = `
                                 </svg>
                               </div>
                             </span>
-                            <div
-                              class="sc-gsTCUz cXMmJt flex-shrink-0 ml-2 text-sm"
-                              data-testid="Link__external"
-                              height="1em"
-                              width="1em"
-                            >
-                              <svg>
-                                redirect.svg
-                              </svg>
-                            </div>
                           </a>
                         </div>
                       </td>
@@ -3895,16 +3865,6 @@ exports[`WalletDetails should render when wallet not found for votes 1`] = `
                                 </svg>
                               </div>
                             </span>
-                            <div
-                              class="sc-gsTCUz cXMmJt flex-shrink-0 ml-2 text-sm"
-                              data-testid="Link__external"
-                              height="1em"
-                              width="1em"
-                            >
-                              <svg>
-                                redirect.svg
-                              </svg>
-                            </div>
                           </a>
                         </div>
                       </td>
@@ -4916,16 +4876,6 @@ exports[`WalletDetails should star and unstar a wallet 1`] = `
                                 </svg>
                               </div>
                             </span>
-                            <div
-                              class="sc-gsTCUz cXMmJt flex-shrink-0 ml-2 text-sm"
-                              data-testid="Link__external"
-                              height="1em"
-                              width="1em"
-                            >
-                              <svg>
-                                redirect.svg
-                              </svg>
-                            </div>
                           </a>
                         </div>
                       </td>
@@ -5943,16 +5893,6 @@ exports[`WalletDetails should update wallet name 1`] = `
                                 </svg>
                               </div>
                             </span>
-                            <div
-                              class="sc-gsTCUz cXMmJt flex-shrink-0 ml-2 text-sm"
-                              data-testid="Link__external"
-                              height="1em"
-                              width="1em"
-                            >
-                              <svg>
-                                redirect.svg
-                              </svg>
-                            </div>
                           </a>
                         </div>
                       </td>


### PR DESCRIPTION

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Remove the external link icon from transaction rows
![image (1)](https://user-images.githubusercontent.com/22020168/105720861-98b30180-5f2c-11eb-96cc-62a3606141eb.png)

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [x] My changes look good in both light AND dark mode
-   [x] The change is not hardcoded to a single network, but has multi-asset in mind
-   [x] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [x] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
