### PR TITLE
chore: use i18n keys in `TransactionRowInfo`

### DIFF
--- a/src/domains/transaction/components/TransactionTable/TransactionRow/TransactionRowInfo.tsx
+++ b/src/domains/transaction/components/TransactionTable/TransactionRow/TransactionRowInfo.tsx
@@ -2,6 +2,7 @@ import { ExtendedTransactionData } from "@arkecosystem/platform-sdk-profiles";
 import { Icon } from "app/components/Icon";
 import { Tooltip } from "app/components/Tooltip";
 import React from "react";
+import { useTranslation } from "react-i18next";
 
 type Props = {
 	memo?: string;
@@ -9,39 +10,37 @@ type Props = {
 	isLedger?: boolean;
 };
 
-const VendorField = ({ vendorField }: { vendorField: string | undefined }) => (
-	<Tooltip className="break-all" content={vendorField}>
-		<span className="p-1">
-			<Icon data-testid="TransactionRowInfo__vendorField" name="Smartbridge" width={17} height={16} />
-		</span>
-	</Tooltip>
-);
+export const BaseTransactionRowInfo = ({ memo, isMultiSignature, isLedger }: Props) => {
+	const { t } = useTranslation();
 
-const Ledger = () => (
-	// TODO: i18n
-	<Tooltip content="Ledger">
-		<span className="p-1">
-			<Icon data-testid="TransactionRowInfo__ledger" name="Ledger" />
-		</span>
-	</Tooltip>
-);
+	return (
+		<div data-testid="TransactionRowInfo" className="inline-flex space-x-1 align-middle">
+			{isLedger && (
+				<Tooltip content={t("COMMON.LEDGER")}>
+					<span className="p-1">
+						<Icon data-testid="TransactionRowInfo__ledger" name="Ledger" />
+					</span>
+				</Tooltip>
+			)}
 
-const MultiSignature = () => (
-	// TODO: i18n
-	<Tooltip content="MultiSignature">
-		<span className="p-1">
-			<Icon data-testid="TransactionRowInfo__multiSignature" name="Multisig" width={22} height={14} />
-		</span>
-	</Tooltip>
-);
+			{isMultiSignature && (
+				<Tooltip content={t("COMMON.MULTISIGNATURE")}>
+					<span className="p-1">
+						<Icon data-testid="TransactionRowInfo__multiSignature" name="Multisig" width={22} height={14} />
+					</span>
+				</Tooltip>
+			)}
 
-export const BaseTransactionRowInfo = ({ memo, isMultiSignature, isLedger }: Props) => (
-	<div data-testid="TransactionRowInfo" className="inline-flex space-x-1 align-middle">
-		{isLedger && <Ledger />}
-		{isMultiSignature && <MultiSignature />}
-		{memo && <VendorField vendorField={memo} />}
-	</div>
-);
+			{memo && (
+				<Tooltip className="break-all" content={memo}>
+					<span className="p-1">
+						<Icon data-testid="TransactionRowInfo__vendorField" name="Smartbridge" width={17} height={16} />
+					</span>
+				</Tooltip>
+			)}
+		</div>
+	);
+};
 
 export const TransactionRowInfo = ({ transaction }: { transaction: ExtendedTransactionData }) => (
 	<BaseTransactionRowInfo


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/d1121u

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
