### PR TITLE
fix: empty dropdown options groups

### DIFF
--- a/src/app/components/Dropdown/Dropdown.tsx
+++ b/src/app/components/Dropdown/Dropdown.tsx
@@ -59,7 +59,7 @@ const renderOptionGroup = ({ key, hasDivider, title, options }: DropdownOptionGr
 );
 
 const renderOptions = (options: DropdownOption[] | DropdownOptionGroup[], onSelect: any, key?: string) => {
-	if (isOptionGroup(options[0])) {
+	if (options[0] && isOptionGroup(options[0])) {
 		return (
 			<div className="pt-5 pb-1">
 				{(options as DropdownOptionGroup[]).map((optionGroup: DropdownOptionGroup) =>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Fixes the DW from crashing if a dropdown option group is used without options.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
