### PR TITLE
fix: focus on search icon

### DIFF
--- a/src/app/components/Form/FormField.tsx
+++ b/src/app/components/Form/FormField.tsx
@@ -9,7 +9,7 @@ type FormFieldProps = {
 	name: string;
 } & React.FieldsetHTMLAttributes<any>;
 
-export const FormFieldStyled = styled.q<{ isInvalid: boolean }>`
+export const FormFieldStyled = styled.fieldset<{ isInvalid: boolean }>`
 	&:hover .FormLabel {
 		${({ isInvalid }) => !isInvalid && tw`text-theme-primary-600`};
 	}

--- a/src/app/components/Form/FormField.tsx
+++ b/src/app/components/Form/FormField.tsx
@@ -9,7 +9,7 @@ type FormFieldProps = {
 	name: string;
 } & React.FieldsetHTMLAttributes<any>;
 
-export const FormFieldStyled = styled.fieldset<{ isInvalid: boolean }>`
+export const FormFieldStyled = styled.q<{ isInvalid: boolean }>`
 	&:hover .FormLabel {
 		${({ isInvalid }) => !isInvalid && tw`text-theme-primary-600`};
 	}

--- a/src/app/components/Header/HeaderSearchBar/HeaderSearchBar.tsx
+++ b/src/app/components/Header/HeaderSearchBar/HeaderSearchBar.tsx
@@ -101,6 +101,7 @@ export const HeaderSearchBar = ({
 							className="pl-3 border-none shadow-none HeaderSearchBar__input"
 							placeholder={placeholder}
 							value={query}
+							isFocused
 							onChange={(e) => setQuery((e.target as HTMLInputElement).value)}
 						/>
 					</div>

--- a/src/app/components/Input/Input.tsx
+++ b/src/app/components/Input/Input.tsx
@@ -34,7 +34,7 @@ export const Input = React.forwardRef<InputElement, InputProps>(
 		const fieldContext = useFormField();
 
 		const focusRef = useRef<InputElement>(null);
-		const inputRef = isFocused ? focusRef : ref;
+		ref = isFocused ? focusRef : ref;
 		useEffect(() => {
 			if (isFocused && focusRef.current) {
 				focusRef.current.focus();

--- a/src/app/components/Input/Input.tsx
+++ b/src/app/components/Input/Input.tsx
@@ -1,9 +1,9 @@
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import tw, { styled } from "twin.macro";
 
 import { useFormField } from "../Form/useFormField";
 
-type InputProps = { as?: React.ElementType; isInvalid?: boolean } & React.HTMLProps<any>;
+type InputProps = { as?: React.ElementType; isInvalid?: boolean; isFocused?: boolean } & React.HTMLProps<any>;
 
 const InputStyled = styled.input`
 	&:focus {
@@ -30,8 +30,16 @@ const InputStyled = styled.input`
 type InputElement = HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement;
 
 export const Input = React.forwardRef<InputElement, InputProps>(
-	({ isInvalid, className, ...props }: InputProps, ref) => {
+	({ isInvalid, className, isFocused, ...props }: InputProps, ref) => {
 		const fieldContext = useFormField();
+
+		const focusRef = useRef<InputElement>(null);
+		const inputRef = isFocused ? focusRef : ref;
+		useEffect(() => {
+			if (isFocused && focusRef.current) {
+				focusRef.current.focus();
+			}
+		}, [focusRef, isFocused]);
 
 		return (
 			<InputStyled


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
This changes fixed bug with input focus when users clicked on the search icon

<!-- Why are these changes necessary? -->
With these changes, users don't need to set focus on input manually

<!-- How were these changes implemented? -->
I added a new prop isFocused for the Input component. In the Input component, I created a ref via React hook useRef.  
On the component render via React hook useEffect I check if the prop isFocused is true. And then I call the focus method for current ref.

## Checklist

<!-- Have you done all of these things?  -->

-   [x] My changes look good in both light AND dark mode
-   [x] The change is not hardcoded to a single network, but has multi-asset in mind
-   [x] I checked my changes for obvious issues, debug statements and commented code
-   [x] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
