### PR TITLE
chore: remove labelExtra prop from `TransactionDetail`

### DIFF
--- a/src/domains/transaction/components/TransactionDetail/TransactionDetail.test.tsx
+++ b/src/domains/transaction/components/TransactionDetail/TransactionDetail.test.tsx
@@ -36,16 +36,6 @@ describe("TransactionDetail", () => {
 		expect(container).toMatchSnapshot();
 	});
 
-	it("should render with extra label", () => {
-		const { container } = render(
-			<TransactionDetail label="Test" padding={false} labelExtra="Label extra">
-				test
-			</TransactionDetail>,
-		);
-
-		expect(container).toMatchSnapshot();
-	});
-
 	it("should render with extra children", () => {
 		const { container, getByTestId } = render(
 			<TransactionDetail label="Test" padding={false} extra={<div data-testid="TEST_CHILD" />}>

--- a/src/domains/transaction/components/TransactionDetail/TransactionDetail.tsx
+++ b/src/domains/transaction/components/TransactionDetail/TransactionDetail.tsx
@@ -31,7 +31,7 @@ export const TransactionDetail = ({
 		paddingPosition={paddingPosition}
 		className={`${className} no-ligatures`}
 	>
-		<div className="space-y-2 flex-1">
+		<div className="flex-1 space-y-2">
 			{label && <div className="text-sm font-semibold text-theme-secondary-700">{label}</div>}
 
 			<div className="font-semibold">{children}</div>

--- a/src/domains/transaction/components/TransactionDetail/TransactionDetail.tsx
+++ b/src/domains/transaction/components/TransactionDetail/TransactionDetail.tsx
@@ -1,4 +1,3 @@
-import { Label } from "app/components/Label";
 import React from "react";
 import { styled } from "twin.macro";
 
@@ -6,9 +5,7 @@ import { getStyles } from "./TransactionDetail.styles";
 
 export type TransactionDetailProps = {
 	children?: React.ReactNode;
-	label?: any;
-	labelExtra?: string;
-	labelExtraColor?: "primary" | "success" | "danger" | "warning";
+	label?: string;
 	extra?: React.ReactNode;
 	border?: boolean;
 	borderPosition?: "top" | "bottom" | "both";
@@ -25,8 +22,6 @@ export const TransactionDetail = ({
 	className,
 	extra,
 	label,
-	labelExtra,
-	labelExtraColor,
 	paddingPosition,
 }: TransactionDetailProps) => (
 	<TransactionDetailStyled
@@ -36,21 +31,8 @@ export const TransactionDetail = ({
 		paddingPosition={paddingPosition}
 		className={`${className} no-ligatures`}
 	>
-		<div className="flex-1 space-y-2">
-			{label && (
-				<div className="text-sm font-semibold text-theme-secondary-700">
-					{labelExtra ? (
-						<>
-							<span className="mr-1">{label}</span>
-							<Label color={labelExtraColor || "warning"} variant="solid">
-								<span className="text-sm">{labelExtra}</span>
-							</Label>
-						</>
-					) : (
-						label
-					)}
-				</div>
-			)}
+		<div className="space-y-2 flex-1">
+			{label && <div className="text-sm font-semibold text-theme-secondary-700">{label}</div>}
 
 			<div className="font-semibold">{children}</div>
 		</div>

--- a/src/domains/transaction/components/TransactionDetail/__snapshots__/TransactionDetail.test.tsx.snap
+++ b/src/domains/transaction/components/TransactionDetail/__snapshots__/TransactionDetail.test.tsx.snap
@@ -75,44 +75,6 @@ exports[`TransactionDetail should render with extra children 1`] = `
 </div>
 `;
 
-exports[`TransactionDetail should render with extra label 1`] = `
-<div>
-  <div
-    class="TransactionDetail__TransactionDetailStyled-sc-15h16fu-0 hqOyLp undefined no-ligatures"
-    data-testid="TransactionDetail"
-  >
-    <div
-      class="flex-1 space-y-2"
-    >
-      <div
-        class="text-sm font-semibold text-theme-secondary-700"
-      >
-        <span
-          class="mr-1"
-        >
-          Test
-        </span>
-        <div
-          class="Label-sc-1tj9hzr-0 ftOOah"
-          color="warning"
-        >
-          <span
-            class="text-sm"
-          >
-            Label extra
-          </span>
-        </div>
-      </div>
-      <div
-        class="font-semibold"
-      >
-        test
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
 exports[`TransactionDetail should render with top border 1`] = `
 <div>
   <div


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Removes the unused `labelExtra` prop from the `TransactionDetail` component.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [x] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
