### PR TITLE
chore: use correct background color

### DIFF
--- a/src/domains/transaction/components/DelegateRegistrationForm/__snapshots__/DelegateRegistrationForm.test.tsx.snap
+++ b/src/domains/transaction/components/DelegateRegistrationForm/__snapshots__/DelegateRegistrationForm.test.tsx.snap
@@ -694,7 +694,7 @@ exports[`DelegateRegistrationForm should render review step 1`] = `
                 </div>
               </div>
               <div
-                class="flex flex-col items-center py-6 rounded-b-lg border-t border-theme-secondary-300 dark:border-theme-secondary-800 justfiy-center bg-theme-secondary-300 dark:bg-theme-secondary-800"
+                class="flex flex-col items-center py-6 rounded-b-lg border-t border-theme-secondary-300 dark:border-theme-secondary-800 justfiy-center bg-theme-secondary-100 dark:bg-theme-secondary-800"
               >
                 <span
                   class="TotalAmountBox__AmountLabel-sc-178fnso-0 gGuMGd"

--- a/src/domains/transaction/components/MultiSignatureRegistrationForm/__snapshots__/MultiSignatureRegistrationForm.test.tsx.snap
+++ b/src/domains/transaction/components/MultiSignatureRegistrationForm/__snapshots__/MultiSignatureRegistrationForm.test.tsx.snap
@@ -790,7 +790,7 @@ exports[`MultiSignature Registration Form should render review step 1`] = `
                   </div>
                 </div>
                 <div
-                  class="flex flex-col items-center py-6 rounded-b-lg border-t border-theme-secondary-300 dark:border-theme-secondary-800 justfiy-center bg-theme-secondary-300 dark:bg-theme-secondary-800"
+                  class="flex flex-col items-center py-6 rounded-b-lg border-t border-theme-secondary-300 dark:border-theme-secondary-800 justfiy-center bg-theme-secondary-100 dark:bg-theme-secondary-800"
                 >
                   <span
                     class="TotalAmountBox__AmountLabel-sc-178fnso-0 gGuMGd"

--- a/src/domains/transaction/components/TotalAmountBox/TotalAmountBox.tsx
+++ b/src/domains/transaction/components/TotalAmountBox/TotalAmountBox.tsx
@@ -53,7 +53,7 @@ export const TotalAmountBox = ({ amount, fee, ticker }: Props) => {
 				<Amount
 					ticker={ticker}
 					value={amount.plus(fee)}
-					className="font-bold text-2xl"
+					className="text-2xl font-bold"
 					data-testid="total-amount-box__total"
 				/>
 			</div>

--- a/src/domains/transaction/components/TotalAmountBox/TotalAmountBox.tsx
+++ b/src/domains/transaction/components/TotalAmountBox/TotalAmountBox.tsx
@@ -48,12 +48,12 @@ export const TotalAmountBox = ({ amount, fee, ticker }: Props) => {
 				</div>
 			</div>
 
-			<div className="flex flex-col items-center py-6 rounded-b-lg border-t border-theme-secondary-300 dark:border-theme-secondary-800 justfiy-center bg-theme-secondary-300 dark:bg-theme-secondary-800">
+			<div className="flex flex-col items-center py-6 rounded-b-lg border-t border-theme-secondary-300 dark:border-theme-secondary-800 justfiy-center bg-theme-secondary-100 dark:bg-theme-secondary-800">
 				<AmountLabel>{t("TRANSACTION.TOTAL_AMOUNT")}</AmountLabel>
 				<Amount
 					ticker={ticker}
 					value={amount.plus(fee)}
-					className="text-2xl font-bold"
+					className="font-bold text-2xl"
 					data-testid="total-amount-box__total"
 				/>
 			</div>

--- a/src/domains/transaction/components/TotalAmountBox/__snapshots__/TotalAmountBox.test.tsx.snap
+++ b/src/domains/transaction/components/TotalAmountBox/__snapshots__/TotalAmountBox.test.tsx.snap
@@ -61,7 +61,7 @@ exports[`TotalAmountBox should render 1`] = `
       </div>
     </div>
     <div
-      class="flex flex-col items-center py-6 rounded-b-lg border-t border-theme-secondary-300 dark:border-theme-secondary-800 justfiy-center bg-theme-secondary-300 dark:bg-theme-secondary-800"
+      class="flex flex-col items-center py-6 rounded-b-lg border-t border-theme-secondary-300 dark:border-theme-secondary-800 justfiy-center bg-theme-secondary-100 dark:bg-theme-secondary-800"
     >
       <span
         class="TotalAmountBox__AmountLabel-sc-178fnso-0 gGuMGd"

--- a/src/domains/transaction/pages/SendDelegateResignation/__snapshots__/SendDelegateResignation.test.tsx.snap
+++ b/src/domains/transaction/pages/SendDelegateResignation/__snapshots__/SendDelegateResignation.test.tsx.snap
@@ -1774,7 +1774,7 @@ exports[`SendDelegateResignation Delegate Resignation should render 2nd step 1`]
                             </div>
                           </div>
                           <div
-                            class="flex flex-col items-center py-6 rounded-b-lg border-t border-theme-secondary-300 dark:border-theme-secondary-800 justfiy-center bg-theme-secondary-300 dark:bg-theme-secondary-800"
+                            class="flex flex-col items-center py-6 rounded-b-lg border-t border-theme-secondary-300 dark:border-theme-secondary-800 justfiy-center bg-theme-secondary-100 dark:bg-theme-secondary-800"
                           >
                             <span
                               class="TotalAmountBox__AmountLabel-sc-178fnso-0 gGuMGd"

--- a/src/domains/transaction/pages/SendIpfs/__snapshots__/SendIpfs.test.tsx.snap
+++ b/src/domains/transaction/pages/SendIpfs/__snapshots__/SendIpfs.test.tsx.snap
@@ -992,7 +992,7 @@ exports[`SendIpfs should render review step 1`] = `
             </div>
           </div>
           <div
-            class="flex flex-col items-center py-6 rounded-b-lg border-t border-theme-secondary-300 dark:border-theme-secondary-800 justfiy-center bg-theme-secondary-300 dark:bg-theme-secondary-800"
+            class="flex flex-col items-center py-6 rounded-b-lg border-t border-theme-secondary-300 dark:border-theme-secondary-800 justfiy-center bg-theme-secondary-100 dark:bg-theme-secondary-800"
           >
             <span
               class="TotalAmountBox__AmountLabel-sc-178fnso-0 gGuMGd"

--- a/src/domains/transaction/pages/SendTransfer/__snapshots__/SendTransfer.test.tsx.snap
+++ b/src/domains/transaction/pages/SendTransfer/__snapshots__/SendTransfer.test.tsx.snap
@@ -2944,7 +2944,7 @@ exports[`SendTransfer should render 2nd step (review) 1`] = `
           </div>
         </div>
         <div
-          class="flex flex-col items-center py-6 rounded-b-lg border-t border-theme-secondary-300 dark:border-theme-secondary-800 justfiy-center bg-theme-secondary-300 dark:bg-theme-secondary-800"
+          class="flex flex-col items-center py-6 rounded-b-lg border-t border-theme-secondary-300 dark:border-theme-secondary-800 justfiy-center bg-theme-secondary-100 dark:bg-theme-secondary-800"
         >
           <span
             class="TotalAmountBox__AmountLabel-sc-178fnso-0 gGuMGd"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Fixes the background color of the `TotalAmountBox` component.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
