### PR TITLE
fix: calculate correct converted balance

### DIFF
--- a/src/app/components/Amount/Amount.tsx
+++ b/src/app/components/Amount/Amount.tsx
@@ -8,6 +8,7 @@ type AmountProps = {
 	value: BigNumber;
 	locale?: string;
 	showSign?: boolean;
+	normalize?: boolean;
 	isNegative?: boolean;
 };
 type FormatProps = AmountProps & { decimals: number };
@@ -28,13 +29,12 @@ const formatFiat = ({ ticker, value, decimals }: FormatProps): string => {
 	return money.format();
 };
 
-const formatCrypto = ({ ticker, value, decimals, locale }: FormatProps): string => {
-	const human = value.toHuman(decimals);
+const formatCrypto = ({ ticker, value, decimals, locale, normalize }: FormatProps): string => {
 	const numeral = Numeral.make(locale!, {
 		minimumFractionDigits: 0,
 		maximumFractionDigits: decimals,
 		currencyDisplay: "name",
-	}).formatAsCurrency(+human, "BTC");
+	}).formatAsCurrency(normalize ? +value.toHuman(decimals) : +value, "BTC");
 
 	/**
 	 * Intl.NumberFormat throws error for some tickers like DARK (?)
@@ -43,11 +43,11 @@ const formatCrypto = ({ ticker, value, decimals, locale }: FormatProps): string 
 	return money;
 };
 
-export const Amount = ({ ticker, value, locale, showSign, isNegative, ...props }: Props) => {
+export const Amount = ({ ticker, value, locale, showSign, normalize, isNegative, ...props }: Props) => {
 	const tickerConfig: CurrencyConfig | undefined = CURRENCIES[ticker as ExchangeCurrencyList];
 	const decimals = tickerConfig?.decimals || 8;
 	const isFiat = decimals <= 2;
-	const amount = (isFiat ? formatFiat : formatCrypto)({ ticker, value, locale, decimals });
+	const amount = (isFiat ? formatFiat : formatCrypto)({ ticker, value, locale, decimals, normalize });
 
 	return (
 		<span data-testid="Amount" {...props}>
@@ -58,4 +58,5 @@ export const Amount = ({ ticker, value, locale, showSign, isNegative, ...props }
 
 Amount.defaultProps = {
 	locale: "en",
+	normalize: true,
 };

--- a/src/app/components/NavigationBar/NavigationBar.tsx
+++ b/src/app/components/NavigationBar/NavigationBar.tsx
@@ -251,12 +251,13 @@ export const NavigationBar = ({ title, profile, variant, menu, userActions }: Na
 									<div className="text-xs font-semibold text-theme-secondary-700">
 										{t("COMMON.YOUR_BALANCE")}
 									</div>
-									<div className="text-sm font-bold text-theme-secondary-text dark:text-theme-text">
+									<div className="font-bold text-theme-secondary-text dark:text-theme-text text-sm">
 										<Amount
 											value={profile?.convertedBalance() || BigNumber.ZERO}
 											ticker={
 												profile?.settings().get<string>(ProfileSetting.ExchangeCurrency) || ""
 											}
+											normalize={false}
 										/>
 									</div>
 								</div>

--- a/src/app/components/WalletListItem/WalletListItem.tsx
+++ b/src/app/components/WalletListItem/WalletListItem.tsx
@@ -63,7 +63,11 @@ export const WalletListItem = ({ wallet, activeWalletId, variant, onClick }: Wal
 			</TableCell>
 
 			<TableCell variant="end" innerClassName="justify-end text-theme-secondary-400">
-				<Amount value={wallet.convertedBalance()} ticker={wallet.exchangeCurrency() || "BTC"} normalize={false} />
+				<Amount
+					value={wallet.convertedBalance()}
+					ticker={wallet.exchangeCurrency() || "BTC"}
+					normalize={false}
+				/>
 			</TableCell>
 		</TableRow>
 	);

--- a/src/app/components/WalletListItem/WalletListItem.tsx
+++ b/src/app/components/WalletListItem/WalletListItem.tsx
@@ -63,7 +63,7 @@ export const WalletListItem = ({ wallet, activeWalletId, variant, onClick }: Wal
 			</TableCell>
 
 			<TableCell variant="end" innerClassName="justify-end text-theme-secondary-400">
-				<Amount value={wallet.convertedBalance()} ticker={wallet.exchangeCurrency() || "BTC"} />
+				<Amount value={wallet.convertedBalance()} ticker={wallet.exchangeCurrency() || "BTC"} normalize={false} />
 			</TableCell>
 		</TableRow>
 	);

--- a/src/domains/wallet/components/SearchWallet/SearchWallet.tsx
+++ b/src/domains/wallet/components/SearchWallet/SearchWallet.tsx
@@ -61,7 +61,7 @@ const SearchWalletListItem = ({
 
 			{showFiatValue && (
 				<TableCell innerClassName="text-theme-secondary-400 justify-end">
-					<Amount value={convertedBalance} ticker={exchangeCurrency} />
+					<Amount value={convertedBalance} ticker={exchangeCurrency} normalize={false} />
 				</TableCell>
 			)}
 

--- a/src/domains/wallet/pages/WalletDetails/components/WalletHeader/WalletHeader.tsx
+++ b/src/domains/wallet/pages/WalletDetails/components/WalletHeader/WalletHeader.tsx
@@ -284,6 +284,7 @@ export const WalletHeader = ({ profile, wallet, currencyDelta, onSend }: WalletH
 											ticker={profile.settings().get<string>(ProfileSetting.ExchangeCurrency)!}
 											data-testid="WalletHeader__currency-balance"
 											className="ml-1"
+											normalize={false}
 										/>
 									)}
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

The balance is divided by 1e8 once already in the SDKs `convertedBalance` method, there's no need to do that again when in the DW while formatting a converted balance in a cryptocurrency.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
