### PR TITLE
refactor: remove outdated todos in transaction builder

### DIFF
--- a/src/app/components/NavigationBar/NavigationBar.tsx
+++ b/src/app/components/NavigationBar/NavigationBar.tsx
@@ -251,7 +251,7 @@ export const NavigationBar = ({ title, profile, variant, menu, userActions }: Na
 									<div className="text-xs font-semibold text-theme-secondary-700">
 										{t("COMMON.YOUR_BALANCE")}
 									</div>
-									<div className="font-bold text-theme-secondary-text dark:text-theme-text text-sm">
+									<div className="text-sm font-bold text-theme-secondary-text dark:text-theme-text">
 										<Amount
 											value={profile?.convertedBalance() || BigNumber.ZERO}
 											ticker={

--- a/src/domains/transaction/hooks/use-transaction-builder.ts
+++ b/src/domains/transaction/hooks/use-transaction-builder.ts
@@ -57,8 +57,6 @@ export const useTransactionBuilder = (profile: Profile) => {
 			abortSignal?: AbortSignal;
 		},
 	): Promise<Contracts.SignedTransactionData> => {
-		// TODO: Proper handle errors
-
 		const wallet = profile.wallets().findByAddress(input.from)!;
 		const service = wallet.transaction();
 
@@ -79,8 +77,6 @@ export const useTransactionBuilder = (profile: Profile) => {
 	};
 
 	const broadcast = (id: string, input: Contracts.TransactionInputs) => {
-		// TODO: Proper handle errors
-
 		const wallet = profile.wallets().findByAddress(input.from)!;
 		return wallet.transaction().broadcast(id);
 	};


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Seems outdated, as the transaction forms that use this hook already handle the errors in their scope.
* SendTransfer: https://github.com/ArkEcosystem/desktop-wallet/blob/develop/src/domains/transaction/pages/SendTransfer/SendTransfer.tsx#L144
* SendVote: https://github.com/ArkEcosystem/desktop-wallet/blob/develop/src/domains/transaction/pages/SendVote/SendVote.tsx#L244
* SendIpfs: https://github.com/ArkEcosystem/desktop-wallet/blob/develop/src/domains/transaction/pages/SendIpfs/SendIpfs.tsx#L88
<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [x] My changes look good in both light AND dark mode
-   [x] The change is not hardcoded to a single network, but has multi-asset in mind
-   [x] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [x] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
