### PR TITLE
fix: buttons focus only in tabbing no onclick

### DIFF
--- a/package.json
+++ b/package.json
@@ -155,6 +155,7 @@
 		"electron-window-state": "^5.0.3",
 		"enhanced-resolve": "^5.6.0",
 		"extract-domain": "^2.2.1",
+		"focus-visible": "^5.2.0",
 		"framer-motion": "^2.1.2",
 		"fs-extra": "^9.0.1",
 		"glob": "^7.1.6",

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,4 +1,6 @@
 // import { ADA } from "@arkecosystem/platform-sdk-ada";
+import "focus-visible";
+
 import { ARK } from "@arkecosystem/platform-sdk-ark";
 // import { ATOM } from "@arkecosystem/platform-sdk-atom";
 // import { BTC } from "@arkecosystem/platform-sdk-btc";

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -13,3 +13,4 @@
 @import "./tooltips.css";
 
 @import "./coins.css";
+@import "./focus-visible.css";

--- a/src/styles/focus-visible.css
+++ b/src/styles/focus-visible.css
@@ -1,0 +1,4 @@
+[data-js-focus-visible] :focus:not([data-focus-visible-added]) {
+	outline: none;
+	box-shadow: none;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -10562,6 +10562,11 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
+focus-visible@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/focus-visible/-/focus-visible-5.2.0.tgz#3a9e41fccf587bd25dcc2ef045508284f0a4d6b3"
+  integrity sha512-Rwix9pBtC1Nuy5wysTmKy+UjbDJpIfg8eHjw0rjZ1mX4GNLz1Bmd16uDpI3Gk1i70Fgcs8Csg2lPm8HULFg9DQ==
+
 follow-redirects@1.5.10:
   version "1.5.10"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
Fix setting focus on button only on tabbing no click

<!-- Why are these changes necessary? -->
These changes are important for UI

<!-- How were these changes implemented? -->
Added focus-visible polyfill and added some styles for focus only on tabbing

## Checklist

<!-- Have you done all of these things?  -->

-   [x] My changes look good in both light AND dark mode
-   [x] The change is not hardcoded to a single network, but has multi-asset in mind
-   [x] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
