### PR TITLE
chore: update homebrew install mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ pamac build ark-desktop
 Install via [Homebrew](https://brew.sh/):
 
 ```shell
-brew cask install ark-desktop-wallet
+brew install --cask ark-desktop-wallet
 ```
 
 ## Translations


### PR DESCRIPTION
## Summary

Homebrew removed the `cask` subcommand in 2.6.0 [[release notes](https://brew.sh/2020/12/01/homebrew-2.6.0/)] ([detailed explanation](https://github.com/ansible-collections/community.general/issues/1524#issuecomment-749945392). This updates your README to have the proper flag to still install from cask. 

Tested with Homebrew 2.7.7 on Catalina, new command works, old one does not.

## Checklist

<!-- Have you done all of these things?  -->

-   [x] My changes look good in both light AND dark mode
-   [x] The change is not hardcoded to a single network, but has multi-asset in mind
-   [x] I checked my changes for obvious issues, debug statements and commented code
-   [x] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

