### PR TITLE
chore: update contribution guidelines url

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 <!--
 Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!
 
-Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).
+Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).
 
 Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
 -->


### PR DESCRIPTION
## Summary

Your current GitHub PR template links to `learn.ark.dev` which redirects `/*` to `ark.dev`. I Googled the new URL for your contribution guidelines and updated it. 

## Checklist

<!-- Have you done all of these things?  -->

-   [x] My changes look good in both light AND dark mode
-   [x] The change is not hardcoded to a single network, but has multi-asset in mind
-   [x] I checked my changes for obvious issues, debug statements and commented code
-   [x] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
