### PR TITLE
refactor: use send-all functionality only on single recipient transaction

### DIFF
--- a/src/domains/transaction/components/AddRecipient/AddRecipient.tsx
+++ b/src/domains/transaction/components/AddRecipient/AddRecipient.tsx
@@ -81,7 +81,7 @@ export const AddRecipient = ({
 		clearErrors,
 		formState: { errors },
 	} = useFormContext();
-	const { network, senderAddress, fee, recipientAddress, amount, isSendAllSelected } = watch();
+	const { network, senderAddress, fee, recipientAddress, amount } = watch();
 	const { sendTransfer } = useValidation();
 
 	const remainingBalance = useMemo(() => {

--- a/src/domains/transaction/components/AddRecipient/AddRecipient.tsx
+++ b/src/domains/transaction/components/AddRecipient/AddRecipient.tsx
@@ -81,7 +81,7 @@ export const AddRecipient = ({
 		clearErrors,
 		formState: { errors },
 	} = useFormContext();
-	const { network, senderAddress, fee, recipientAddress, amount } = watch();
+	const { network, senderAddress, fee, recipientAddress, amount, isSendAllSelected } = watch();
 	const { sendTransfer } = useValidation();
 
 	const remainingBalance = useMemo(() => {
@@ -149,6 +149,10 @@ export const AddRecipient = ({
 			clearFields();
 		}
 	}, [isSingle, clearErrors, clearFields, addedRecipients, setValue]);
+
+	useEffect(() => {
+		setValue("isSendAllSelected", isSingle);
+	}, [isSingle, setValue]);
 
 	const singleRecipientOnChange = (amountValue: string, recipientAddressValue: string) => {
 		if (!isSingle) {
@@ -245,30 +249,32 @@ export const AddRecipient = ({
 									setValue("isSendAllSelected", false);
 								}}
 							/>
-							<InputAddonEnd>
-								<button
-									type="button"
-									data-testid="AddRecipient__send-all"
-									onClick={() => {
-										const remaining = remainingBalance.isGreaterThan(fee)
-											? remainingBalance.minus(fee)
-											: remainingBalance;
+							{isSingle && (
+								<InputAddonEnd>
+									<button
+										type="button"
+										data-testid="AddRecipient__send-all"
+										onClick={() => {
+											const remaining = remainingBalance.isGreaterThan(fee)
+												? remainingBalance.minus(fee)
+												: remainingBalance;
 
-										setValue("displayAmount", remaining.toHuman());
+											setValue("displayAmount", remaining.toHuman());
 
-										setValue("amount", remaining.toString(), {
-											shouldValidate: true,
-											shouldDirty: true,
-										});
+											setValue("amount", remaining.toString(), {
+												shouldValidate: true,
+												shouldDirty: true,
+											});
 
-										singleRecipientOnChange(remaining.toString(), recipientAddress);
-										setValue("isSendAllSelected", true);
-									}}
-									className="pr-3 pl-6 mr-1 h-12 font-medium text-theme-primary-600 focus:outline-none"
-								>
-									{t("TRANSACTION.SEND_ALL")}
-								</button>
-							</InputAddonEnd>
+											singleRecipientOnChange(remaining.toString(), recipientAddress);
+											setValue("isSendAllSelected", true);
+										}}
+										className="pr-3 pl-6 mr-1 h-12 font-medium text-theme-primary-600 focus:outline-none"
+									>
+										{t("TRANSACTION.SEND_ALL")}
+									</button>
+								</InputAddonEnd>
+							)}
 						</InputGroup>
 						<FormHelperText />
 					</FormField>

--- a/src/domains/transaction/components/AddRecipient/__snapshots__/AddRecipient.test.tsx.snap
+++ b/src/domains/transaction/components/AddRecipient/__snapshots__/AddRecipient.test.tsx.snap
@@ -295,17 +295,6 @@ exports[`AddRecipient should render with multiple recipients tab 1`] = `
               placeholder="Amount"
               value=""
             />
-            <div
-              class="InputGroup__InputAddon-sc-1obbdqe-0 InputGroup__InputAddonEnd-sc-1obbdqe-2 bsvVEG isvHuV"
-            >
-              <button
-                class="pr-3 pl-6 mr-1 h-12 font-medium text-theme-primary-600 focus:outline-none"
-                data-testid="AddRecipient__send-all"
-                type="button"
-              >
-                Send All
-              </button>
-            </div>
           </div>
         </fieldset>
       </div>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [x] My changes look good in both light AND dark mode
-   [x] The change is not hardcoded to a single network, but has multi-asset in mind
-   [x] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [x] Tests _(if necessary)_
-   [x] Ready to be merged



<!-- Feel free to add additional comments. -->
