### PR TITLE
fix: make secondary navbar in `PluginManager` sticky

### DIFF
--- a/src/domains/plugin/pages/PluginManager/PluginManager.tsx
+++ b/src/domains/plugin/pages/PluginManager/PluginManager.tsx
@@ -271,18 +271,16 @@ export const PluginManager = ({ paths }: PluginManagerProps) => {
 					/>
 				</Section>
 
-				<div className="-mb-5">
-					<PluginManagerNavigationBar
-						selected={currentView}
-						onChange={setCurrentView}
-						selectedViewType={viewType}
-						onSelectGridView={() => setViewType("grid")}
-						onSelectListView={() => setViewType("list")}
-						installedPluginsCount={installedPlugins.length}
-					/>
-				</div>
+				<PluginManagerNavigationBar
+					selected={currentView}
+					onChange={setCurrentView}
+					selectedViewType={viewType}
+					onSelectGridView={() => setViewType("grid")}
+					onSelectListView={() => setViewType("list")}
+					installedPluginsCount={installedPlugins.length}
+				/>
 
-				<Section>
+				<Section marginTop={false}>
 					<div data-testid={`PluginManager__container--${currentView}`}>
 						<div className="flex justify-between items-center" />
 

--- a/src/domains/plugin/pages/PluginManager/__snapshots__/PluginManager.test.tsx.snap
+++ b/src/domains/plugin/pages/PluginManager/__snapshots__/PluginManager.test.tsx.snap
@@ -3583,193 +3583,189 @@ exports[`PluginManager should disable plugin on my-plugins 1`] = `
             </div>
           </div>
         </div>
-        <div
-          class="-mb-5"
+        <nav
+          class="PluginManagerNavigationBar__NavWrapper-sc-1x1q7te-0 ggmsTH sticky top-20 md:top-24 bg-theme-secondary-100 dark:bg-theme-secondary-800"
+          data-testid="PluginManagerNavigationBar"
         >
-          <nav
-            class="PluginManagerNavigationBar__NavWrapper-sc-1x1q7te-0 ggmsTH sticky top-20 md:top-24 bg-theme-secondary-100 dark:bg-theme-secondary-800"
-            data-testid="PluginManagerNavigationBar"
+          <div
+            class="container flex justify-between items-center px-14 mx-auto"
           >
-            <div
-              class="container flex justify-between items-center px-14 mx-auto"
-            >
-              <div>
-                <ul
-                  class="flex h-24"
-                >
-                  <li
-                    class="flex"
-                  >
-                    <button
-                      class="PluginManagerNavigationBar__item px-1 focus:outline-none lex items-center font-semibold text-md text-theme-secondary-text hover:text-theme-text transition-colors duration-200 cursor-pointer "
-                      data-testid="PluginManagerNavigationBar__home"
-                      title="Home"
-                    >
-                      <span>
-                        Home
-                      </span>
-                      <span
-                        class="ml-1 text-theme-secondary-500 dark:text-theme-secondary-700"
-                      >
-                        1
-                      </span>
-                    </button>
-                    <div
-                      class="my-auto mx-6 w-px h-4 border-r PluginManagerNavigationBar__menu-divider border-theme-secondary-300 dark:border-theme-secondary-800"
-                    />
-                  </li>
-                  <li
-                    class="flex"
-                  >
-                    <button
-                      class="PluginManagerNavigationBar__item px-1 focus:outline-none lex items-center font-semibold text-md text-theme-secondary-text hover:text-theme-text transition-colors duration-200 cursor-pointer "
-                      data-testid="PluginManagerNavigationBar__gaming"
-                      title="Gaming"
-                    >
-                      <span>
-                        Gaming
-                      </span>
-                      <span
-                        class="ml-1 text-theme-secondary-500 dark:text-theme-secondary-700"
-                      >
-                        0
-                      </span>
-                    </button>
-                    <div
-                      class="my-auto mx-6 w-px h-4 border-r PluginManagerNavigationBar__menu-divider border-theme-secondary-300 dark:border-theme-secondary-800"
-                    />
-                  </li>
-                  <li
-                    class="flex"
-                  >
-                    <button
-                      class="PluginManagerNavigationBar__item px-1 focus:outline-none lex items-center font-semibold text-md text-theme-secondary-text hover:text-theme-text transition-colors duration-200 cursor-pointer "
-                      data-testid="PluginManagerNavigationBar__utility"
-                      title="Utility"
-                    >
-                      <span>
-                        Utility
-                      </span>
-                      <span
-                        class="ml-1 text-theme-secondary-500 dark:text-theme-secondary-700"
-                      >
-                        0
-                      </span>
-                    </button>
-                    <div
-                      class="my-auto mx-6 w-px h-4 border-r PluginManagerNavigationBar__menu-divider border-theme-secondary-300 dark:border-theme-secondary-800"
-                    />
-                  </li>
-                  <li
-                    class="flex"
-                  >
-                    <button
-                      class="PluginManagerNavigationBar__item px-1 focus:outline-none lex items-center font-semibold text-md text-theme-secondary-text hover:text-theme-text transition-colors duration-200 cursor-pointer "
-                      data-testid="PluginManagerNavigationBar__theme"
-                      title="Theme"
-                    >
-                      <span>
-                        Theme
-                      </span>
-                      <span
-                        class="ml-1 text-theme-secondary-500 dark:text-theme-secondary-700"
-                      >
-                        0
-                      </span>
-                    </button>
-                    <div
-                      class="my-auto mx-6 w-px h-4 border-r PluginManagerNavigationBar__menu-divider border-theme-secondary-300 dark:border-theme-secondary-800"
-                    />
-                  </li>
-                  <li
-                    class="flex"
-                  >
-                    <button
-                      class="PluginManagerNavigationBar__item px-1 focus:outline-none lex items-center font-semibold text-md text-theme-secondary-text hover:text-theme-text transition-colors duration-200 cursor-pointer "
-                      data-testid="PluginManagerNavigationBar__other"
-                      title="Other"
-                    >
-                      <span>
-                        Other
-                      </span>
-                      <span
-                        class="ml-1 text-theme-secondary-500 dark:text-theme-secondary-700"
-                      >
-                        1
-                      </span>
-                    </button>
-                  </li>
-                </ul>
-              </div>
-              <div
+            <div>
+              <ul
                 class="flex h-24"
               >
-                <button
-                  class="PluginManagerNavigationBar__item px-1 focus:outline-none flex items-center font-semibold text-md text-theme-secondary-text hover:text-theme-text transition-colors duration-200 cursor-pointer active"
-                  data-testid="PluginManagerNavigationBar__my-plugins"
-                  title="My Plugins"
+                <li
+                  class="flex"
                 >
-                  <span>
-                    My Plugins
-                  </span>
-                  <span
-                    class="ml-1 text-theme-secondary-500 dark:text-theme-secondary-700"
-                    data-testid="PluginManagerNavigationBar__my-plugins__count"
+                  <button
+                    class="PluginManagerNavigationBar__item px-1 focus:outline-none lex items-center font-semibold text-md text-theme-secondary-text hover:text-theme-text transition-colors duration-200 cursor-pointer "
+                    data-testid="PluginManagerNavigationBar__home"
+                    title="Home"
                   >
-                    1
-                  </span>
-                </button>
+                    <span>
+                      Home
+                    </span>
+                    <span
+                      class="ml-1 text-theme-secondary-500 dark:text-theme-secondary-700"
+                    >
+                      1
+                    </span>
+                  </button>
+                  <div
+                    class="my-auto mx-6 w-px h-4 border-r PluginManagerNavigationBar__menu-divider border-theme-secondary-300 dark:border-theme-secondary-800"
+                  />
+                </li>
+                <li
+                  class="flex"
+                >
+                  <button
+                    class="PluginManagerNavigationBar__item px-1 focus:outline-none lex items-center font-semibold text-md text-theme-secondary-text hover:text-theme-text transition-colors duration-200 cursor-pointer "
+                    data-testid="PluginManagerNavigationBar__gaming"
+                    title="Gaming"
+                  >
+                    <span>
+                      Gaming
+                    </span>
+                    <span
+                      class="ml-1 text-theme-secondary-500 dark:text-theme-secondary-700"
+                    >
+                      0
+                    </span>
+                  </button>
+                  <div
+                    class="my-auto mx-6 w-px h-4 border-r PluginManagerNavigationBar__menu-divider border-theme-secondary-300 dark:border-theme-secondary-800"
+                  />
+                </li>
+                <li
+                  class="flex"
+                >
+                  <button
+                    class="PluginManagerNavigationBar__item px-1 focus:outline-none lex items-center font-semibold text-md text-theme-secondary-text hover:text-theme-text transition-colors duration-200 cursor-pointer "
+                    data-testid="PluginManagerNavigationBar__utility"
+                    title="Utility"
+                  >
+                    <span>
+                      Utility
+                    </span>
+                    <span
+                      class="ml-1 text-theme-secondary-500 dark:text-theme-secondary-700"
+                    >
+                      0
+                    </span>
+                  </button>
+                  <div
+                    class="my-auto mx-6 w-px h-4 border-r PluginManagerNavigationBar__menu-divider border-theme-secondary-300 dark:border-theme-secondary-800"
+                  />
+                </li>
+                <li
+                  class="flex"
+                >
+                  <button
+                    class="PluginManagerNavigationBar__item px-1 focus:outline-none lex items-center font-semibold text-md text-theme-secondary-text hover:text-theme-text transition-colors duration-200 cursor-pointer "
+                    data-testid="PluginManagerNavigationBar__theme"
+                    title="Theme"
+                  >
+                    <span>
+                      Theme
+                    </span>
+                    <span
+                      class="ml-1 text-theme-secondary-500 dark:text-theme-secondary-700"
+                    >
+                      0
+                    </span>
+                  </button>
+                  <div
+                    class="my-auto mx-6 w-px h-4 border-r PluginManagerNavigationBar__menu-divider border-theme-secondary-300 dark:border-theme-secondary-800"
+                  />
+                </li>
+                <li
+                  class="flex"
+                >
+                  <button
+                    class="PluginManagerNavigationBar__item px-1 focus:outline-none lex items-center font-semibold text-md text-theme-secondary-text hover:text-theme-text transition-colors duration-200 cursor-pointer "
+                    data-testid="PluginManagerNavigationBar__other"
+                    title="Other"
+                  >
+                    <span>
+                      Other
+                    </span>
+                    <span
+                      class="ml-1 text-theme-secondary-500 dark:text-theme-secondary-700"
+                    >
+                      1
+                    </span>
+                  </button>
+                </li>
+              </ul>
+            </div>
+            <div
+              class="flex h-24"
+            >
+              <button
+                class="PluginManagerNavigationBar__item px-1 focus:outline-none flex items-center font-semibold text-md text-theme-secondary-text hover:text-theme-text transition-colors duration-200 cursor-pointer active"
+                data-testid="PluginManagerNavigationBar__my-plugins"
+                title="My Plugins"
+              >
+                <span>
+                  My Plugins
+                </span>
+                <span
+                  class="ml-1 text-theme-secondary-500 dark:text-theme-secondary-700"
+                  data-testid="PluginManagerNavigationBar__my-plugins__count"
+                >
+                  1
+                </span>
+              </button>
+              <div
+                class="my-auto mx-8 w-px h-10 border-r border-theme-secondary-300 dark:border-theme-secondary-800"
+              />
+              <div
+                class="flex items-center space-x-1"
+              >
                 <div
-                  class="my-auto mx-8 w-px h-10 border-r border-theme-secondary-300 dark:border-theme-secondary-800"
-                />
-                <div
-                  class="flex items-center space-x-1"
+                  class="group"
+                  data-testid="LayoutControls__grid"
                 >
                   <div
-                    class="group"
-                    data-testid="LayoutControls__grid"
+                    class="LayoutControls__ControlButton-j2iwgi-0 hcJMgX"
+                    data-testid="LayoutControls__grid--icon"
                   >
                     <div
-                      class="LayoutControls__ControlButton-j2iwgi-0 hcJMgX"
-                      data-testid="LayoutControls__grid--icon"
+                      class="sc-gsTCUz fHxsLl"
+                      height="20"
+                      width="20"
                     >
-                      <div
-                        class="sc-gsTCUz fHxsLl"
-                        height="20"
-                        width="20"
-                      >
-                        <svg>
-                          grid-view.svg
-                        </svg>
-                      </div>
+                      <svg>
+                        grid-view.svg
+                      </svg>
                     </div>
                   </div>
+                </div>
+                <div
+                  class="group"
+                  data-testid="LayoutControls__list"
+                >
                   <div
-                    class="group"
-                    data-testid="LayoutControls__list"
+                    class="LayoutControls__ControlButton-j2iwgi-0 jQrgSV"
+                    data-testid="LayoutControls__list--icon"
                   >
                     <div
-                      class="LayoutControls__ControlButton-j2iwgi-0 jQrgSV"
-                      data-testid="LayoutControls__list--icon"
+                      class="sc-gsTCUz fHxsLl"
+                      height="20"
+                      width="20"
                     >
-                      <div
-                        class="sc-gsTCUz fHxsLl"
-                        height="20"
-                        width="20"
-                      >
-                        <svg>
-                          list-view.svg
-                        </svg>
-                      </div>
+                      <svg>
+                        list-view.svg
+                      </svg>
                     </div>
                   </div>
                 </div>
               </div>
             </div>
-          </nav>
-        </div>
+          </div>
+        </nav>
         <div
-          class="Section__SectionWrapper-sc-8cjvre-0 Aphxw"
+          class="Section__SectionWrapper-sc-8cjvre-0 gFwrwb"
         >
           <div
             class="container py-16 px-14 mx-auto "
@@ -6281,193 +6277,189 @@ exports[`PluginManager should enable plugin on my-plugins 1`] = `
             </div>
           </div>
         </div>
-        <div
-          class="-mb-5"
+        <nav
+          class="PluginManagerNavigationBar__NavWrapper-sc-1x1q7te-0 ggmsTH sticky top-20 md:top-24 bg-theme-secondary-100 dark:bg-theme-secondary-800"
+          data-testid="PluginManagerNavigationBar"
         >
-          <nav
-            class="PluginManagerNavigationBar__NavWrapper-sc-1x1q7te-0 ggmsTH sticky top-20 md:top-24 bg-theme-secondary-100 dark:bg-theme-secondary-800"
-            data-testid="PluginManagerNavigationBar"
+          <div
+            class="container flex justify-between items-center px-14 mx-auto"
           >
-            <div
-              class="container flex justify-between items-center px-14 mx-auto"
-            >
-              <div>
-                <ul
-                  class="flex h-24"
-                >
-                  <li
-                    class="flex"
-                  >
-                    <button
-                      class="PluginManagerNavigationBar__item px-1 focus:outline-none lex items-center font-semibold text-md text-theme-secondary-text hover:text-theme-text transition-colors duration-200 cursor-pointer "
-                      data-testid="PluginManagerNavigationBar__home"
-                      title="Home"
-                    >
-                      <span>
-                        Home
-                      </span>
-                      <span
-                        class="ml-1 text-theme-secondary-500 dark:text-theme-secondary-700"
-                      >
-                        1
-                      </span>
-                    </button>
-                    <div
-                      class="my-auto mx-6 w-px h-4 border-r PluginManagerNavigationBar__menu-divider border-theme-secondary-300 dark:border-theme-secondary-800"
-                    />
-                  </li>
-                  <li
-                    class="flex"
-                  >
-                    <button
-                      class="PluginManagerNavigationBar__item px-1 focus:outline-none lex items-center font-semibold text-md text-theme-secondary-text hover:text-theme-text transition-colors duration-200 cursor-pointer "
-                      data-testid="PluginManagerNavigationBar__gaming"
-                      title="Gaming"
-                    >
-                      <span>
-                        Gaming
-                      </span>
-                      <span
-                        class="ml-1 text-theme-secondary-500 dark:text-theme-secondary-700"
-                      >
-                        0
-                      </span>
-                    </button>
-                    <div
-                      class="my-auto mx-6 w-px h-4 border-r PluginManagerNavigationBar__menu-divider border-theme-secondary-300 dark:border-theme-secondary-800"
-                    />
-                  </li>
-                  <li
-                    class="flex"
-                  >
-                    <button
-                      class="PluginManagerNavigationBar__item px-1 focus:outline-none lex items-center font-semibold text-md text-theme-secondary-text hover:text-theme-text transition-colors duration-200 cursor-pointer "
-                      data-testid="PluginManagerNavigationBar__utility"
-                      title="Utility"
-                    >
-                      <span>
-                        Utility
-                      </span>
-                      <span
-                        class="ml-1 text-theme-secondary-500 dark:text-theme-secondary-700"
-                      >
-                        0
-                      </span>
-                    </button>
-                    <div
-                      class="my-auto mx-6 w-px h-4 border-r PluginManagerNavigationBar__menu-divider border-theme-secondary-300 dark:border-theme-secondary-800"
-                    />
-                  </li>
-                  <li
-                    class="flex"
-                  >
-                    <button
-                      class="PluginManagerNavigationBar__item px-1 focus:outline-none lex items-center font-semibold text-md text-theme-secondary-text hover:text-theme-text transition-colors duration-200 cursor-pointer "
-                      data-testid="PluginManagerNavigationBar__theme"
-                      title="Theme"
-                    >
-                      <span>
-                        Theme
-                      </span>
-                      <span
-                        class="ml-1 text-theme-secondary-500 dark:text-theme-secondary-700"
-                      >
-                        0
-                      </span>
-                    </button>
-                    <div
-                      class="my-auto mx-6 w-px h-4 border-r PluginManagerNavigationBar__menu-divider border-theme-secondary-300 dark:border-theme-secondary-800"
-                    />
-                  </li>
-                  <li
-                    class="flex"
-                  >
-                    <button
-                      class="PluginManagerNavigationBar__item px-1 focus:outline-none lex items-center font-semibold text-md text-theme-secondary-text hover:text-theme-text transition-colors duration-200 cursor-pointer "
-                      data-testid="PluginManagerNavigationBar__other"
-                      title="Other"
-                    >
-                      <span>
-                        Other
-                      </span>
-                      <span
-                        class="ml-1 text-theme-secondary-500 dark:text-theme-secondary-700"
-                      >
-                        1
-                      </span>
-                    </button>
-                  </li>
-                </ul>
-              </div>
-              <div
+            <div>
+              <ul
                 class="flex h-24"
               >
-                <button
-                  class="PluginManagerNavigationBar__item px-1 focus:outline-none flex items-center font-semibold text-md text-theme-secondary-text hover:text-theme-text transition-colors duration-200 cursor-pointer active"
-                  data-testid="PluginManagerNavigationBar__my-plugins"
-                  title="My Plugins"
+                <li
+                  class="flex"
                 >
-                  <span>
-                    My Plugins
-                  </span>
-                  <span
-                    class="ml-1 text-theme-secondary-500 dark:text-theme-secondary-700"
-                    data-testid="PluginManagerNavigationBar__my-plugins__count"
+                  <button
+                    class="PluginManagerNavigationBar__item px-1 focus:outline-none lex items-center font-semibold text-md text-theme-secondary-text hover:text-theme-text transition-colors duration-200 cursor-pointer "
+                    data-testid="PluginManagerNavigationBar__home"
+                    title="Home"
                   >
-                    1
-                  </span>
-                </button>
+                    <span>
+                      Home
+                    </span>
+                    <span
+                      class="ml-1 text-theme-secondary-500 dark:text-theme-secondary-700"
+                    >
+                      1
+                    </span>
+                  </button>
+                  <div
+                    class="my-auto mx-6 w-px h-4 border-r PluginManagerNavigationBar__menu-divider border-theme-secondary-300 dark:border-theme-secondary-800"
+                  />
+                </li>
+                <li
+                  class="flex"
+                >
+                  <button
+                    class="PluginManagerNavigationBar__item px-1 focus:outline-none lex items-center font-semibold text-md text-theme-secondary-text hover:text-theme-text transition-colors duration-200 cursor-pointer "
+                    data-testid="PluginManagerNavigationBar__gaming"
+                    title="Gaming"
+                  >
+                    <span>
+                      Gaming
+                    </span>
+                    <span
+                      class="ml-1 text-theme-secondary-500 dark:text-theme-secondary-700"
+                    >
+                      0
+                    </span>
+                  </button>
+                  <div
+                    class="my-auto mx-6 w-px h-4 border-r PluginManagerNavigationBar__menu-divider border-theme-secondary-300 dark:border-theme-secondary-800"
+                  />
+                </li>
+                <li
+                  class="flex"
+                >
+                  <button
+                    class="PluginManagerNavigationBar__item px-1 focus:outline-none lex items-center font-semibold text-md text-theme-secondary-text hover:text-theme-text transition-colors duration-200 cursor-pointer "
+                    data-testid="PluginManagerNavigationBar__utility"
+                    title="Utility"
+                  >
+                    <span>
+                      Utility
+                    </span>
+                    <span
+                      class="ml-1 text-theme-secondary-500 dark:text-theme-secondary-700"
+                    >
+                      0
+                    </span>
+                  </button>
+                  <div
+                    class="my-auto mx-6 w-px h-4 border-r PluginManagerNavigationBar__menu-divider border-theme-secondary-300 dark:border-theme-secondary-800"
+                  />
+                </li>
+                <li
+                  class="flex"
+                >
+                  <button
+                    class="PluginManagerNavigationBar__item px-1 focus:outline-none lex items-center font-semibold text-md text-theme-secondary-text hover:text-theme-text transition-colors duration-200 cursor-pointer "
+                    data-testid="PluginManagerNavigationBar__theme"
+                    title="Theme"
+                  >
+                    <span>
+                      Theme
+                    </span>
+                    <span
+                      class="ml-1 text-theme-secondary-500 dark:text-theme-secondary-700"
+                    >
+                      0
+                    </span>
+                  </button>
+                  <div
+                    class="my-auto mx-6 w-px h-4 border-r PluginManagerNavigationBar__menu-divider border-theme-secondary-300 dark:border-theme-secondary-800"
+                  />
+                </li>
+                <li
+                  class="flex"
+                >
+                  <button
+                    class="PluginManagerNavigationBar__item px-1 focus:outline-none lex items-center font-semibold text-md text-theme-secondary-text hover:text-theme-text transition-colors duration-200 cursor-pointer "
+                    data-testid="PluginManagerNavigationBar__other"
+                    title="Other"
+                  >
+                    <span>
+                      Other
+                    </span>
+                    <span
+                      class="ml-1 text-theme-secondary-500 dark:text-theme-secondary-700"
+                    >
+                      1
+                    </span>
+                  </button>
+                </li>
+              </ul>
+            </div>
+            <div
+              class="flex h-24"
+            >
+              <button
+                class="PluginManagerNavigationBar__item px-1 focus:outline-none flex items-center font-semibold text-md text-theme-secondary-text hover:text-theme-text transition-colors duration-200 cursor-pointer active"
+                data-testid="PluginManagerNavigationBar__my-plugins"
+                title="My Plugins"
+              >
+                <span>
+                  My Plugins
+                </span>
+                <span
+                  class="ml-1 text-theme-secondary-500 dark:text-theme-secondary-700"
+                  data-testid="PluginManagerNavigationBar__my-plugins__count"
+                >
+                  1
+                </span>
+              </button>
+              <div
+                class="my-auto mx-8 w-px h-10 border-r border-theme-secondary-300 dark:border-theme-secondary-800"
+              />
+              <div
+                class="flex items-center space-x-1"
+              >
                 <div
-                  class="my-auto mx-8 w-px h-10 border-r border-theme-secondary-300 dark:border-theme-secondary-800"
-                />
-                <div
-                  class="flex items-center space-x-1"
+                  class="group"
+                  data-testid="LayoutControls__grid"
                 >
                   <div
-                    class="group"
-                    data-testid="LayoutControls__grid"
+                    class="LayoutControls__ControlButton-j2iwgi-0 hcJMgX"
+                    data-testid="LayoutControls__grid--icon"
                   >
                     <div
-                      class="LayoutControls__ControlButton-j2iwgi-0 hcJMgX"
-                      data-testid="LayoutControls__grid--icon"
+                      class="sc-gsTCUz fHxsLl"
+                      height="20"
+                      width="20"
                     >
-                      <div
-                        class="sc-gsTCUz fHxsLl"
-                        height="20"
-                        width="20"
-                      >
-                        <svg>
-                          grid-view.svg
-                        </svg>
-                      </div>
+                      <svg>
+                        grid-view.svg
+                      </svg>
                     </div>
                   </div>
+                </div>
+                <div
+                  class="group"
+                  data-testid="LayoutControls__list"
+                >
                   <div
-                    class="group"
-                    data-testid="LayoutControls__list"
+                    class="LayoutControls__ControlButton-j2iwgi-0 jQrgSV"
+                    data-testid="LayoutControls__list--icon"
                   >
                     <div
-                      class="LayoutControls__ControlButton-j2iwgi-0 jQrgSV"
-                      data-testid="LayoutControls__list--icon"
+                      class="sc-gsTCUz fHxsLl"
+                      height="20"
+                      width="20"
                     >
-                      <div
-                        class="sc-gsTCUz fHxsLl"
-                        height="20"
-                        width="20"
-                      >
-                        <svg>
-                          list-view.svg
-                        </svg>
-                      </div>
+                      <svg>
+                        list-view.svg
+                      </svg>
                     </div>
                   </div>
                 </div>
               </div>
             </div>
-          </nav>
-        </div>
+          </div>
+        </nav>
         <div
-          class="Section__SectionWrapper-sc-8cjvre-0 Aphxw"
+          class="Section__SectionWrapper-sc-8cjvre-0 gFwrwb"
         >
           <div
             class="container py-16 px-14 mx-auto "
@@ -9311,187 +9303,183 @@ exports[`PluginManager should render 1`] = `
             </div>
           </div>
         </div>
-        <div
-          class="-mb-5"
+        <nav
+          class="PluginManagerNavigationBar__NavWrapper-sc-1x1q7te-0 ggmsTH sticky top-20 md:top-24 bg-theme-secondary-100 dark:bg-theme-secondary-800"
+          data-testid="PluginManagerNavigationBar"
         >
-          <nav
-            class="PluginManagerNavigationBar__NavWrapper-sc-1x1q7te-0 ggmsTH sticky top-20 md:top-24 bg-theme-secondary-100 dark:bg-theme-secondary-800"
-            data-testid="PluginManagerNavigationBar"
+          <div
+            class="container flex justify-between items-center px-14 mx-auto"
           >
-            <div
-              class="container flex justify-between items-center px-14 mx-auto"
-            >
-              <div>
-                <ul
-                  class="flex h-24"
-                >
-                  <li
-                    class="flex"
-                  >
-                    <button
-                      class="PluginManagerNavigationBar__item px-1 focus:outline-none lex items-center font-semibold text-md text-theme-secondary-text hover:text-theme-text transition-colors duration-200 cursor-pointer active"
-                      data-testid="PluginManagerNavigationBar__home"
-                      title="Home"
-                    >
-                      <span>
-                        Home
-                      </span>
-                      <span
-                        class="ml-1 text-theme-secondary-500 dark:text-theme-secondary-700"
-                      >
-                        1
-                      </span>
-                    </button>
-                    <div
-                      class="my-auto mx-6 w-px h-4 border-r PluginManagerNavigationBar__menu-divider border-theme-secondary-300 dark:border-theme-secondary-800"
-                    />
-                  </li>
-                  <li
-                    class="flex"
-                  >
-                    <button
-                      class="PluginManagerNavigationBar__item px-1 focus:outline-none lex items-center font-semibold text-md text-theme-secondary-text hover:text-theme-text transition-colors duration-200 cursor-pointer "
-                      data-testid="PluginManagerNavigationBar__gaming"
-                      title="Gaming"
-                    >
-                      <span>
-                        Gaming
-                      </span>
-                      <span
-                        class="ml-1 text-theme-secondary-500 dark:text-theme-secondary-700"
-                      >
-                        0
-                      </span>
-                    </button>
-                    <div
-                      class="my-auto mx-6 w-px h-4 border-r PluginManagerNavigationBar__menu-divider border-theme-secondary-300 dark:border-theme-secondary-800"
-                    />
-                  </li>
-                  <li
-                    class="flex"
-                  >
-                    <button
-                      class="PluginManagerNavigationBar__item px-1 focus:outline-none lex items-center font-semibold text-md text-theme-secondary-text hover:text-theme-text transition-colors duration-200 cursor-pointer "
-                      data-testid="PluginManagerNavigationBar__utility"
-                      title="Utility"
-                    >
-                      <span>
-                        Utility
-                      </span>
-                      <span
-                        class="ml-1 text-theme-secondary-500 dark:text-theme-secondary-700"
-                      >
-                        0
-                      </span>
-                    </button>
-                    <div
-                      class="my-auto mx-6 w-px h-4 border-r PluginManagerNavigationBar__menu-divider border-theme-secondary-300 dark:border-theme-secondary-800"
-                    />
-                  </li>
-                  <li
-                    class="flex"
-                  >
-                    <button
-                      class="PluginManagerNavigationBar__item px-1 focus:outline-none lex items-center font-semibold text-md text-theme-secondary-text hover:text-theme-text transition-colors duration-200 cursor-pointer "
-                      data-testid="PluginManagerNavigationBar__theme"
-                      title="Theme"
-                    >
-                      <span>
-                        Theme
-                      </span>
-                      <span
-                        class="ml-1 text-theme-secondary-500 dark:text-theme-secondary-700"
-                      >
-                        0
-                      </span>
-                    </button>
-                    <div
-                      class="my-auto mx-6 w-px h-4 border-r PluginManagerNavigationBar__menu-divider border-theme-secondary-300 dark:border-theme-secondary-800"
-                    />
-                  </li>
-                  <li
-                    class="flex"
-                  >
-                    <button
-                      class="PluginManagerNavigationBar__item px-1 focus:outline-none lex items-center font-semibold text-md text-theme-secondary-text hover:text-theme-text transition-colors duration-200 cursor-pointer "
-                      data-testid="PluginManagerNavigationBar__other"
-                      title="Other"
-                    >
-                      <span>
-                        Other
-                      </span>
-                      <span
-                        class="ml-1 text-theme-secondary-500 dark:text-theme-secondary-700"
-                      >
-                        1
-                      </span>
-                    </button>
-                  </li>
-                </ul>
-              </div>
-              <div
+            <div>
+              <ul
                 class="flex h-24"
               >
-                <button
-                  class="PluginManagerNavigationBar__item px-1 focus:outline-none flex items-center font-semibold text-md text-theme-secondary-text hover:text-theme-text transition-colors duration-200 cursor-pointer "
-                  data-testid="PluginManagerNavigationBar__my-plugins"
-                  title="My Plugins"
+                <li
+                  class="flex"
                 >
-                  <span>
-                    My Plugins
-                  </span>
-                </button>
+                  <button
+                    class="PluginManagerNavigationBar__item px-1 focus:outline-none lex items-center font-semibold text-md text-theme-secondary-text hover:text-theme-text transition-colors duration-200 cursor-pointer active"
+                    data-testid="PluginManagerNavigationBar__home"
+                    title="Home"
+                  >
+                    <span>
+                      Home
+                    </span>
+                    <span
+                      class="ml-1 text-theme-secondary-500 dark:text-theme-secondary-700"
+                    >
+                      1
+                    </span>
+                  </button>
+                  <div
+                    class="my-auto mx-6 w-px h-4 border-r PluginManagerNavigationBar__menu-divider border-theme-secondary-300 dark:border-theme-secondary-800"
+                  />
+                </li>
+                <li
+                  class="flex"
+                >
+                  <button
+                    class="PluginManagerNavigationBar__item px-1 focus:outline-none lex items-center font-semibold text-md text-theme-secondary-text hover:text-theme-text transition-colors duration-200 cursor-pointer "
+                    data-testid="PluginManagerNavigationBar__gaming"
+                    title="Gaming"
+                  >
+                    <span>
+                      Gaming
+                    </span>
+                    <span
+                      class="ml-1 text-theme-secondary-500 dark:text-theme-secondary-700"
+                    >
+                      0
+                    </span>
+                  </button>
+                  <div
+                    class="my-auto mx-6 w-px h-4 border-r PluginManagerNavigationBar__menu-divider border-theme-secondary-300 dark:border-theme-secondary-800"
+                  />
+                </li>
+                <li
+                  class="flex"
+                >
+                  <button
+                    class="PluginManagerNavigationBar__item px-1 focus:outline-none lex items-center font-semibold text-md text-theme-secondary-text hover:text-theme-text transition-colors duration-200 cursor-pointer "
+                    data-testid="PluginManagerNavigationBar__utility"
+                    title="Utility"
+                  >
+                    <span>
+                      Utility
+                    </span>
+                    <span
+                      class="ml-1 text-theme-secondary-500 dark:text-theme-secondary-700"
+                    >
+                      0
+                    </span>
+                  </button>
+                  <div
+                    class="my-auto mx-6 w-px h-4 border-r PluginManagerNavigationBar__menu-divider border-theme-secondary-300 dark:border-theme-secondary-800"
+                  />
+                </li>
+                <li
+                  class="flex"
+                >
+                  <button
+                    class="PluginManagerNavigationBar__item px-1 focus:outline-none lex items-center font-semibold text-md text-theme-secondary-text hover:text-theme-text transition-colors duration-200 cursor-pointer "
+                    data-testid="PluginManagerNavigationBar__theme"
+                    title="Theme"
+                  >
+                    <span>
+                      Theme
+                    </span>
+                    <span
+                      class="ml-1 text-theme-secondary-500 dark:text-theme-secondary-700"
+                    >
+                      0
+                    </span>
+                  </button>
+                  <div
+                    class="my-auto mx-6 w-px h-4 border-r PluginManagerNavigationBar__menu-divider border-theme-secondary-300 dark:border-theme-secondary-800"
+                  />
+                </li>
+                <li
+                  class="flex"
+                >
+                  <button
+                    class="PluginManagerNavigationBar__item px-1 focus:outline-none lex items-center font-semibold text-md text-theme-secondary-text hover:text-theme-text transition-colors duration-200 cursor-pointer "
+                    data-testid="PluginManagerNavigationBar__other"
+                    title="Other"
+                  >
+                    <span>
+                      Other
+                    </span>
+                    <span
+                      class="ml-1 text-theme-secondary-500 dark:text-theme-secondary-700"
+                    >
+                      1
+                    </span>
+                  </button>
+                </li>
+              </ul>
+            </div>
+            <div
+              class="flex h-24"
+            >
+              <button
+                class="PluginManagerNavigationBar__item px-1 focus:outline-none flex items-center font-semibold text-md text-theme-secondary-text hover:text-theme-text transition-colors duration-200 cursor-pointer "
+                data-testid="PluginManagerNavigationBar__my-plugins"
+                title="My Plugins"
+              >
+                <span>
+                  My Plugins
+                </span>
+              </button>
+              <div
+                class="my-auto mx-8 w-px h-10 border-r border-theme-secondary-300 dark:border-theme-secondary-800"
+              />
+              <div
+                class="flex items-center space-x-1"
+              >
                 <div
-                  class="my-auto mx-8 w-px h-10 border-r border-theme-secondary-300 dark:border-theme-secondary-800"
-                />
-                <div
-                  class="flex items-center space-x-1"
+                  class="group"
+                  data-testid="LayoutControls__grid"
                 >
                   <div
-                    class="group"
-                    data-testid="LayoutControls__grid"
+                    class="LayoutControls__ControlButton-j2iwgi-0 jQrgSV"
+                    data-testid="LayoutControls__grid--icon"
                   >
                     <div
-                      class="LayoutControls__ControlButton-j2iwgi-0 jQrgSV"
-                      data-testid="LayoutControls__grid--icon"
+                      class="sc-gsTCUz fHxsLl"
+                      height="20"
+                      width="20"
                     >
-                      <div
-                        class="sc-gsTCUz fHxsLl"
-                        height="20"
-                        width="20"
-                      >
-                        <svg>
-                          grid-view.svg
-                        </svg>
-                      </div>
+                      <svg>
+                        grid-view.svg
+                      </svg>
                     </div>
                   </div>
+                </div>
+                <div
+                  class="group"
+                  data-testid="LayoutControls__list"
+                >
                   <div
-                    class="group"
-                    data-testid="LayoutControls__list"
+                    class="LayoutControls__ControlButton-j2iwgi-0 hcJMgX"
+                    data-testid="LayoutControls__list--icon"
                   >
                     <div
-                      class="LayoutControls__ControlButton-j2iwgi-0 hcJMgX"
-                      data-testid="LayoutControls__list--icon"
+                      class="sc-gsTCUz fHxsLl"
+                      height="20"
+                      width="20"
                     >
-                      <div
-                        class="sc-gsTCUz fHxsLl"
-                        height="20"
-                        width="20"
-                      >
-                        <svg>
-                          list-view.svg
-                        </svg>
-                      </div>
+                      <svg>
+                        list-view.svg
+                      </svg>
                     </div>
                   </div>
                 </div>
               </div>
             </div>
-          </nav>
-        </div>
+          </div>
+        </nav>
         <div
-          class="Section__SectionWrapper-sc-8cjvre-0 Aphxw"
+          class="Section__SectionWrapper-sc-8cjvre-0 gFwrwb"
         >
           <div
             class="container py-16 px-14 mx-auto "
@@ -10237,187 +10225,183 @@ exports[`PluginManager should search for plugin 1`] = `
             </div>
           </div>
         </div>
-        <div
-          class="-mb-5"
+        <nav
+          class="PluginManagerNavigationBar__NavWrapper-sc-1x1q7te-0 ggmsTH sticky top-20 md:top-24 bg-theme-secondary-100 dark:bg-theme-secondary-800"
+          data-testid="PluginManagerNavigationBar"
         >
-          <nav
-            class="PluginManagerNavigationBar__NavWrapper-sc-1x1q7te-0 ggmsTH sticky top-20 md:top-24 bg-theme-secondary-100 dark:bg-theme-secondary-800"
-            data-testid="PluginManagerNavigationBar"
+          <div
+            class="container flex justify-between items-center px-14 mx-auto"
           >
-            <div
-              class="container flex justify-between items-center px-14 mx-auto"
-            >
-              <div>
-                <ul
-                  class="flex h-24"
-                >
-                  <li
-                    class="flex"
-                  >
-                    <button
-                      class="PluginManagerNavigationBar__item px-1 focus:outline-none lex items-center font-semibold text-md text-theme-secondary-text hover:text-theme-text transition-colors duration-200 cursor-pointer active"
-                      data-testid="PluginManagerNavigationBar__home"
-                      title="Home"
-                    >
-                      <span>
-                        Home
-                      </span>
-                      <span
-                        class="ml-1 text-theme-secondary-500 dark:text-theme-secondary-700"
-                      >
-                        1
-                      </span>
-                    </button>
-                    <div
-                      class="my-auto mx-6 w-px h-4 border-r PluginManagerNavigationBar__menu-divider border-theme-secondary-300 dark:border-theme-secondary-800"
-                    />
-                  </li>
-                  <li
-                    class="flex"
-                  >
-                    <button
-                      class="PluginManagerNavigationBar__item px-1 focus:outline-none lex items-center font-semibold text-md text-theme-secondary-text hover:text-theme-text transition-colors duration-200 cursor-pointer "
-                      data-testid="PluginManagerNavigationBar__gaming"
-                      title="Gaming"
-                    >
-                      <span>
-                        Gaming
-                      </span>
-                      <span
-                        class="ml-1 text-theme-secondary-500 dark:text-theme-secondary-700"
-                      >
-                        0
-                      </span>
-                    </button>
-                    <div
-                      class="my-auto mx-6 w-px h-4 border-r PluginManagerNavigationBar__menu-divider border-theme-secondary-300 dark:border-theme-secondary-800"
-                    />
-                  </li>
-                  <li
-                    class="flex"
-                  >
-                    <button
-                      class="PluginManagerNavigationBar__item px-1 focus:outline-none lex items-center font-semibold text-md text-theme-secondary-text hover:text-theme-text transition-colors duration-200 cursor-pointer "
-                      data-testid="PluginManagerNavigationBar__utility"
-                      title="Utility"
-                    >
-                      <span>
-                        Utility
-                      </span>
-                      <span
-                        class="ml-1 text-theme-secondary-500 dark:text-theme-secondary-700"
-                      >
-                        0
-                      </span>
-                    </button>
-                    <div
-                      class="my-auto mx-6 w-px h-4 border-r PluginManagerNavigationBar__menu-divider border-theme-secondary-300 dark:border-theme-secondary-800"
-                    />
-                  </li>
-                  <li
-                    class="flex"
-                  >
-                    <button
-                      class="PluginManagerNavigationBar__item px-1 focus:outline-none lex items-center font-semibold text-md text-theme-secondary-text hover:text-theme-text transition-colors duration-200 cursor-pointer "
-                      data-testid="PluginManagerNavigationBar__theme"
-                      title="Theme"
-                    >
-                      <span>
-                        Theme
-                      </span>
-                      <span
-                        class="ml-1 text-theme-secondary-500 dark:text-theme-secondary-700"
-                      >
-                        0
-                      </span>
-                    </button>
-                    <div
-                      class="my-auto mx-6 w-px h-4 border-r PluginManagerNavigationBar__menu-divider border-theme-secondary-300 dark:border-theme-secondary-800"
-                    />
-                  </li>
-                  <li
-                    class="flex"
-                  >
-                    <button
-                      class="PluginManagerNavigationBar__item px-1 focus:outline-none lex items-center font-semibold text-md text-theme-secondary-text hover:text-theme-text transition-colors duration-200 cursor-pointer "
-                      data-testid="PluginManagerNavigationBar__other"
-                      title="Other"
-                    >
-                      <span>
-                        Other
-                      </span>
-                      <span
-                        class="ml-1 text-theme-secondary-500 dark:text-theme-secondary-700"
-                      >
-                        1
-                      </span>
-                    </button>
-                  </li>
-                </ul>
-              </div>
-              <div
+            <div>
+              <ul
                 class="flex h-24"
               >
-                <button
-                  class="PluginManagerNavigationBar__item px-1 focus:outline-none flex items-center font-semibold text-md text-theme-secondary-text hover:text-theme-text transition-colors duration-200 cursor-pointer "
-                  data-testid="PluginManagerNavigationBar__my-plugins"
-                  title="My Plugins"
+                <li
+                  class="flex"
                 >
-                  <span>
-                    My Plugins
-                  </span>
-                </button>
+                  <button
+                    class="PluginManagerNavigationBar__item px-1 focus:outline-none lex items-center font-semibold text-md text-theme-secondary-text hover:text-theme-text transition-colors duration-200 cursor-pointer active"
+                    data-testid="PluginManagerNavigationBar__home"
+                    title="Home"
+                  >
+                    <span>
+                      Home
+                    </span>
+                    <span
+                      class="ml-1 text-theme-secondary-500 dark:text-theme-secondary-700"
+                    >
+                      1
+                    </span>
+                  </button>
+                  <div
+                    class="my-auto mx-6 w-px h-4 border-r PluginManagerNavigationBar__menu-divider border-theme-secondary-300 dark:border-theme-secondary-800"
+                  />
+                </li>
+                <li
+                  class="flex"
+                >
+                  <button
+                    class="PluginManagerNavigationBar__item px-1 focus:outline-none lex items-center font-semibold text-md text-theme-secondary-text hover:text-theme-text transition-colors duration-200 cursor-pointer "
+                    data-testid="PluginManagerNavigationBar__gaming"
+                    title="Gaming"
+                  >
+                    <span>
+                      Gaming
+                    </span>
+                    <span
+                      class="ml-1 text-theme-secondary-500 dark:text-theme-secondary-700"
+                    >
+                      0
+                    </span>
+                  </button>
+                  <div
+                    class="my-auto mx-6 w-px h-4 border-r PluginManagerNavigationBar__menu-divider border-theme-secondary-300 dark:border-theme-secondary-800"
+                  />
+                </li>
+                <li
+                  class="flex"
+                >
+                  <button
+                    class="PluginManagerNavigationBar__item px-1 focus:outline-none lex items-center font-semibold text-md text-theme-secondary-text hover:text-theme-text transition-colors duration-200 cursor-pointer "
+                    data-testid="PluginManagerNavigationBar__utility"
+                    title="Utility"
+                  >
+                    <span>
+                      Utility
+                    </span>
+                    <span
+                      class="ml-1 text-theme-secondary-500 dark:text-theme-secondary-700"
+                    >
+                      0
+                    </span>
+                  </button>
+                  <div
+                    class="my-auto mx-6 w-px h-4 border-r PluginManagerNavigationBar__menu-divider border-theme-secondary-300 dark:border-theme-secondary-800"
+                  />
+                </li>
+                <li
+                  class="flex"
+                >
+                  <button
+                    class="PluginManagerNavigationBar__item px-1 focus:outline-none lex items-center font-semibold text-md text-theme-secondary-text hover:text-theme-text transition-colors duration-200 cursor-pointer "
+                    data-testid="PluginManagerNavigationBar__theme"
+                    title="Theme"
+                  >
+                    <span>
+                      Theme
+                    </span>
+                    <span
+                      class="ml-1 text-theme-secondary-500 dark:text-theme-secondary-700"
+                    >
+                      0
+                    </span>
+                  </button>
+                  <div
+                    class="my-auto mx-6 w-px h-4 border-r PluginManagerNavigationBar__menu-divider border-theme-secondary-300 dark:border-theme-secondary-800"
+                  />
+                </li>
+                <li
+                  class="flex"
+                >
+                  <button
+                    class="PluginManagerNavigationBar__item px-1 focus:outline-none lex items-center font-semibold text-md text-theme-secondary-text hover:text-theme-text transition-colors duration-200 cursor-pointer "
+                    data-testid="PluginManagerNavigationBar__other"
+                    title="Other"
+                  >
+                    <span>
+                      Other
+                    </span>
+                    <span
+                      class="ml-1 text-theme-secondary-500 dark:text-theme-secondary-700"
+                    >
+                      1
+                    </span>
+                  </button>
+                </li>
+              </ul>
+            </div>
+            <div
+              class="flex h-24"
+            >
+              <button
+                class="PluginManagerNavigationBar__item px-1 focus:outline-none flex items-center font-semibold text-md text-theme-secondary-text hover:text-theme-text transition-colors duration-200 cursor-pointer "
+                data-testid="PluginManagerNavigationBar__my-plugins"
+                title="My Plugins"
+              >
+                <span>
+                  My Plugins
+                </span>
+              </button>
+              <div
+                class="my-auto mx-8 w-px h-10 border-r border-theme-secondary-300 dark:border-theme-secondary-800"
+              />
+              <div
+                class="flex items-center space-x-1"
+              >
                 <div
-                  class="my-auto mx-8 w-px h-10 border-r border-theme-secondary-300 dark:border-theme-secondary-800"
-                />
-                <div
-                  class="flex items-center space-x-1"
+                  class="group"
+                  data-testid="LayoutControls__grid"
                 >
                   <div
-                    class="group"
-                    data-testid="LayoutControls__grid"
+                    class="LayoutControls__ControlButton-j2iwgi-0 jQrgSV"
+                    data-testid="LayoutControls__grid--icon"
                   >
                     <div
-                      class="LayoutControls__ControlButton-j2iwgi-0 jQrgSV"
-                      data-testid="LayoutControls__grid--icon"
+                      class="sc-gsTCUz fHxsLl"
+                      height="20"
+                      width="20"
                     >
-                      <div
-                        class="sc-gsTCUz fHxsLl"
-                        height="20"
-                        width="20"
-                      >
-                        <svg>
-                          grid-view.svg
-                        </svg>
-                      </div>
+                      <svg>
+                        grid-view.svg
+                      </svg>
                     </div>
                   </div>
+                </div>
+                <div
+                  class="group"
+                  data-testid="LayoutControls__list"
+                >
                   <div
-                    class="group"
-                    data-testid="LayoutControls__list"
+                    class="LayoutControls__ControlButton-j2iwgi-0 hcJMgX"
+                    data-testid="LayoutControls__list--icon"
                   >
                     <div
-                      class="LayoutControls__ControlButton-j2iwgi-0 hcJMgX"
-                      data-testid="LayoutControls__list--icon"
+                      class="sc-gsTCUz fHxsLl"
+                      height="20"
+                      width="20"
                     >
-                      <div
-                        class="sc-gsTCUz fHxsLl"
-                        height="20"
-                        width="20"
-                      >
-                        <svg>
-                          list-view.svg
-                        </svg>
-                      </div>
+                      <svg>
+                        list-view.svg
+                      </svg>
                     </div>
                   </div>
                 </div>
               </div>
             </div>
-          </nav>
-        </div>
+          </div>
+        </nav>
         <div
-          class="Section__SectionWrapper-sc-8cjvre-0 Aphxw"
+          class="Section__SectionWrapper-sc-8cjvre-0 gFwrwb"
         >
           <div
             class="container py-16 px-14 mx-auto "
@@ -11110,187 +11094,183 @@ exports[`PluginManager should toggle between list and grid on game 1`] = `
             </div>
           </div>
         </div>
-        <div
-          class="-mb-5"
+        <nav
+          class="PluginManagerNavigationBar__NavWrapper-sc-1x1q7te-0 ggmsTH sticky top-20 md:top-24 bg-theme-secondary-100 dark:bg-theme-secondary-800"
+          data-testid="PluginManagerNavigationBar"
         >
-          <nav
-            class="PluginManagerNavigationBar__NavWrapper-sc-1x1q7te-0 ggmsTH sticky top-20 md:top-24 bg-theme-secondary-100 dark:bg-theme-secondary-800"
-            data-testid="PluginManagerNavigationBar"
+          <div
+            class="container flex justify-between items-center px-14 mx-auto"
           >
-            <div
-              class="container flex justify-between items-center px-14 mx-auto"
-            >
-              <div>
-                <ul
-                  class="flex h-24"
-                >
-                  <li
-                    class="flex"
-                  >
-                    <button
-                      class="PluginManagerNavigationBar__item px-1 focus:outline-none lex items-center font-semibold text-md text-theme-secondary-text hover:text-theme-text transition-colors duration-200 cursor-pointer "
-                      data-testid="PluginManagerNavigationBar__home"
-                      title="Home"
-                    >
-                      <span>
-                        Home
-                      </span>
-                      <span
-                        class="ml-1 text-theme-secondary-500 dark:text-theme-secondary-700"
-                      >
-                        1
-                      </span>
-                    </button>
-                    <div
-                      class="my-auto mx-6 w-px h-4 border-r PluginManagerNavigationBar__menu-divider border-theme-secondary-300 dark:border-theme-secondary-800"
-                    />
-                  </li>
-                  <li
-                    class="flex"
-                  >
-                    <button
-                      class="PluginManagerNavigationBar__item px-1 focus:outline-none lex items-center font-semibold text-md text-theme-secondary-text hover:text-theme-text transition-colors duration-200 cursor-pointer active"
-                      data-testid="PluginManagerNavigationBar__gaming"
-                      title="Gaming"
-                    >
-                      <span>
-                        Gaming
-                      </span>
-                      <span
-                        class="ml-1 text-theme-secondary-500 dark:text-theme-secondary-700"
-                      >
-                        0
-                      </span>
-                    </button>
-                    <div
-                      class="my-auto mx-6 w-px h-4 border-r PluginManagerNavigationBar__menu-divider border-theme-secondary-300 dark:border-theme-secondary-800"
-                    />
-                  </li>
-                  <li
-                    class="flex"
-                  >
-                    <button
-                      class="PluginManagerNavigationBar__item px-1 focus:outline-none lex items-center font-semibold text-md text-theme-secondary-text hover:text-theme-text transition-colors duration-200 cursor-pointer "
-                      data-testid="PluginManagerNavigationBar__utility"
-                      title="Utility"
-                    >
-                      <span>
-                        Utility
-                      </span>
-                      <span
-                        class="ml-1 text-theme-secondary-500 dark:text-theme-secondary-700"
-                      >
-                        0
-                      </span>
-                    </button>
-                    <div
-                      class="my-auto mx-6 w-px h-4 border-r PluginManagerNavigationBar__menu-divider border-theme-secondary-300 dark:border-theme-secondary-800"
-                    />
-                  </li>
-                  <li
-                    class="flex"
-                  >
-                    <button
-                      class="PluginManagerNavigationBar__item px-1 focus:outline-none lex items-center font-semibold text-md text-theme-secondary-text hover:text-theme-text transition-colors duration-200 cursor-pointer "
-                      data-testid="PluginManagerNavigationBar__theme"
-                      title="Theme"
-                    >
-                      <span>
-                        Theme
-                      </span>
-                      <span
-                        class="ml-1 text-theme-secondary-500 dark:text-theme-secondary-700"
-                      >
-                        0
-                      </span>
-                    </button>
-                    <div
-                      class="my-auto mx-6 w-px h-4 border-r PluginManagerNavigationBar__menu-divider border-theme-secondary-300 dark:border-theme-secondary-800"
-                    />
-                  </li>
-                  <li
-                    class="flex"
-                  >
-                    <button
-                      class="PluginManagerNavigationBar__item px-1 focus:outline-none lex items-center font-semibold text-md text-theme-secondary-text hover:text-theme-text transition-colors duration-200 cursor-pointer "
-                      data-testid="PluginManagerNavigationBar__other"
-                      title="Other"
-                    >
-                      <span>
-                        Other
-                      </span>
-                      <span
-                        class="ml-1 text-theme-secondary-500 dark:text-theme-secondary-700"
-                      >
-                        1
-                      </span>
-                    </button>
-                  </li>
-                </ul>
-              </div>
-              <div
+            <div>
+              <ul
                 class="flex h-24"
               >
-                <button
-                  class="PluginManagerNavigationBar__item px-1 focus:outline-none flex items-center font-semibold text-md text-theme-secondary-text hover:text-theme-text transition-colors duration-200 cursor-pointer "
-                  data-testid="PluginManagerNavigationBar__my-plugins"
-                  title="My Plugins"
+                <li
+                  class="flex"
                 >
-                  <span>
-                    My Plugins
-                  </span>
-                </button>
+                  <button
+                    class="PluginManagerNavigationBar__item px-1 focus:outline-none lex items-center font-semibold text-md text-theme-secondary-text hover:text-theme-text transition-colors duration-200 cursor-pointer "
+                    data-testid="PluginManagerNavigationBar__home"
+                    title="Home"
+                  >
+                    <span>
+                      Home
+                    </span>
+                    <span
+                      class="ml-1 text-theme-secondary-500 dark:text-theme-secondary-700"
+                    >
+                      1
+                    </span>
+                  </button>
+                  <div
+                    class="my-auto mx-6 w-px h-4 border-r PluginManagerNavigationBar__menu-divider border-theme-secondary-300 dark:border-theme-secondary-800"
+                  />
+                </li>
+                <li
+                  class="flex"
+                >
+                  <button
+                    class="PluginManagerNavigationBar__item px-1 focus:outline-none lex items-center font-semibold text-md text-theme-secondary-text hover:text-theme-text transition-colors duration-200 cursor-pointer active"
+                    data-testid="PluginManagerNavigationBar__gaming"
+                    title="Gaming"
+                  >
+                    <span>
+                      Gaming
+                    </span>
+                    <span
+                      class="ml-1 text-theme-secondary-500 dark:text-theme-secondary-700"
+                    >
+                      0
+                    </span>
+                  </button>
+                  <div
+                    class="my-auto mx-6 w-px h-4 border-r PluginManagerNavigationBar__menu-divider border-theme-secondary-300 dark:border-theme-secondary-800"
+                  />
+                </li>
+                <li
+                  class="flex"
+                >
+                  <button
+                    class="PluginManagerNavigationBar__item px-1 focus:outline-none lex items-center font-semibold text-md text-theme-secondary-text hover:text-theme-text transition-colors duration-200 cursor-pointer "
+                    data-testid="PluginManagerNavigationBar__utility"
+                    title="Utility"
+                  >
+                    <span>
+                      Utility
+                    </span>
+                    <span
+                      class="ml-1 text-theme-secondary-500 dark:text-theme-secondary-700"
+                    >
+                      0
+                    </span>
+                  </button>
+                  <div
+                    class="my-auto mx-6 w-px h-4 border-r PluginManagerNavigationBar__menu-divider border-theme-secondary-300 dark:border-theme-secondary-800"
+                  />
+                </li>
+                <li
+                  class="flex"
+                >
+                  <button
+                    class="PluginManagerNavigationBar__item px-1 focus:outline-none lex items-center font-semibold text-md text-theme-secondary-text hover:text-theme-text transition-colors duration-200 cursor-pointer "
+                    data-testid="PluginManagerNavigationBar__theme"
+                    title="Theme"
+                  >
+                    <span>
+                      Theme
+                    </span>
+                    <span
+                      class="ml-1 text-theme-secondary-500 dark:text-theme-secondary-700"
+                    >
+                      0
+                    </span>
+                  </button>
+                  <div
+                    class="my-auto mx-6 w-px h-4 border-r PluginManagerNavigationBar__menu-divider border-theme-secondary-300 dark:border-theme-secondary-800"
+                  />
+                </li>
+                <li
+                  class="flex"
+                >
+                  <button
+                    class="PluginManagerNavigationBar__item px-1 focus:outline-none lex items-center font-semibold text-md text-theme-secondary-text hover:text-theme-text transition-colors duration-200 cursor-pointer "
+                    data-testid="PluginManagerNavigationBar__other"
+                    title="Other"
+                  >
+                    <span>
+                      Other
+                    </span>
+                    <span
+                      class="ml-1 text-theme-secondary-500 dark:text-theme-secondary-700"
+                    >
+                      1
+                    </span>
+                  </button>
+                </li>
+              </ul>
+            </div>
+            <div
+              class="flex h-24"
+            >
+              <button
+                class="PluginManagerNavigationBar__item px-1 focus:outline-none flex items-center font-semibold text-md text-theme-secondary-text hover:text-theme-text transition-colors duration-200 cursor-pointer "
+                data-testid="PluginManagerNavigationBar__my-plugins"
+                title="My Plugins"
+              >
+                <span>
+                  My Plugins
+                </span>
+              </button>
+              <div
+                class="my-auto mx-8 w-px h-10 border-r border-theme-secondary-300 dark:border-theme-secondary-800"
+              />
+              <div
+                class="flex items-center space-x-1"
+              >
                 <div
-                  class="my-auto mx-8 w-px h-10 border-r border-theme-secondary-300 dark:border-theme-secondary-800"
-                />
-                <div
-                  class="flex items-center space-x-1"
+                  class="group"
+                  data-testid="LayoutControls__grid"
                 >
                   <div
-                    class="group"
-                    data-testid="LayoutControls__grid"
+                    class="LayoutControls__ControlButton-j2iwgi-0 jQrgSV"
+                    data-testid="LayoutControls__grid--icon"
                   >
                     <div
-                      class="LayoutControls__ControlButton-j2iwgi-0 jQrgSV"
-                      data-testid="LayoutControls__grid--icon"
+                      class="sc-gsTCUz fHxsLl"
+                      height="20"
+                      width="20"
                     >
-                      <div
-                        class="sc-gsTCUz fHxsLl"
-                        height="20"
-                        width="20"
-                      >
-                        <svg>
-                          grid-view.svg
-                        </svg>
-                      </div>
+                      <svg>
+                        grid-view.svg
+                      </svg>
                     </div>
                   </div>
+                </div>
+                <div
+                  class="group"
+                  data-testid="LayoutControls__list"
+                >
                   <div
-                    class="group"
-                    data-testid="LayoutControls__list"
+                    class="LayoutControls__ControlButton-j2iwgi-0 hcJMgX"
+                    data-testid="LayoutControls__list--icon"
                   >
                     <div
-                      class="LayoutControls__ControlButton-j2iwgi-0 hcJMgX"
-                      data-testid="LayoutControls__list--icon"
+                      class="sc-gsTCUz fHxsLl"
+                      height="20"
+                      width="20"
                     >
-                      <div
-                        class="sc-gsTCUz fHxsLl"
-                        height="20"
-                        width="20"
-                      >
-                        <svg>
-                          list-view.svg
-                        </svg>
-                      </div>
+                      <svg>
+                        list-view.svg
+                      </svg>
                     </div>
                   </div>
                 </div>
               </div>
             </div>
-          </nav>
-        </div>
+          </div>
+        </nav>
         <div
-          class="Section__SectionWrapper-sc-8cjvre-0 Aphxw"
+          class="Section__SectionWrapper-sc-8cjvre-0 gFwrwb"
         >
           <div
             class="container py-16 px-14 mx-auto "
@@ -11691,187 +11671,183 @@ exports[`PluginManager should toggle between list and grid on home 1`] = `
             </div>
           </div>
         </div>
-        <div
-          class="-mb-5"
+        <nav
+          class="PluginManagerNavigationBar__NavWrapper-sc-1x1q7te-0 ggmsTH sticky top-20 md:top-24 bg-theme-secondary-100 dark:bg-theme-secondary-800"
+          data-testid="PluginManagerNavigationBar"
         >
-          <nav
-            class="PluginManagerNavigationBar__NavWrapper-sc-1x1q7te-0 ggmsTH sticky top-20 md:top-24 bg-theme-secondary-100 dark:bg-theme-secondary-800"
-            data-testid="PluginManagerNavigationBar"
+          <div
+            class="container flex justify-between items-center px-14 mx-auto"
           >
-            <div
-              class="container flex justify-between items-center px-14 mx-auto"
-            >
-              <div>
-                <ul
-                  class="flex h-24"
-                >
-                  <li
-                    class="flex"
-                  >
-                    <button
-                      class="PluginManagerNavigationBar__item px-1 focus:outline-none lex items-center font-semibold text-md text-theme-secondary-text hover:text-theme-text transition-colors duration-200 cursor-pointer active"
-                      data-testid="PluginManagerNavigationBar__home"
-                      title="Home"
-                    >
-                      <span>
-                        Home
-                      </span>
-                      <span
-                        class="ml-1 text-theme-secondary-500 dark:text-theme-secondary-700"
-                      >
-                        1
-                      </span>
-                    </button>
-                    <div
-                      class="my-auto mx-6 w-px h-4 border-r PluginManagerNavigationBar__menu-divider border-theme-secondary-300 dark:border-theme-secondary-800"
-                    />
-                  </li>
-                  <li
-                    class="flex"
-                  >
-                    <button
-                      class="PluginManagerNavigationBar__item px-1 focus:outline-none lex items-center font-semibold text-md text-theme-secondary-text hover:text-theme-text transition-colors duration-200 cursor-pointer "
-                      data-testid="PluginManagerNavigationBar__gaming"
-                      title="Gaming"
-                    >
-                      <span>
-                        Gaming
-                      </span>
-                      <span
-                        class="ml-1 text-theme-secondary-500 dark:text-theme-secondary-700"
-                      >
-                        0
-                      </span>
-                    </button>
-                    <div
-                      class="my-auto mx-6 w-px h-4 border-r PluginManagerNavigationBar__menu-divider border-theme-secondary-300 dark:border-theme-secondary-800"
-                    />
-                  </li>
-                  <li
-                    class="flex"
-                  >
-                    <button
-                      class="PluginManagerNavigationBar__item px-1 focus:outline-none lex items-center font-semibold text-md text-theme-secondary-text hover:text-theme-text transition-colors duration-200 cursor-pointer "
-                      data-testid="PluginManagerNavigationBar__utility"
-                      title="Utility"
-                    >
-                      <span>
-                        Utility
-                      </span>
-                      <span
-                        class="ml-1 text-theme-secondary-500 dark:text-theme-secondary-700"
-                      >
-                        0
-                      </span>
-                    </button>
-                    <div
-                      class="my-auto mx-6 w-px h-4 border-r PluginManagerNavigationBar__menu-divider border-theme-secondary-300 dark:border-theme-secondary-800"
-                    />
-                  </li>
-                  <li
-                    class="flex"
-                  >
-                    <button
-                      class="PluginManagerNavigationBar__item px-1 focus:outline-none lex items-center font-semibold text-md text-theme-secondary-text hover:text-theme-text transition-colors duration-200 cursor-pointer "
-                      data-testid="PluginManagerNavigationBar__theme"
-                      title="Theme"
-                    >
-                      <span>
-                        Theme
-                      </span>
-                      <span
-                        class="ml-1 text-theme-secondary-500 dark:text-theme-secondary-700"
-                      >
-                        0
-                      </span>
-                    </button>
-                    <div
-                      class="my-auto mx-6 w-px h-4 border-r PluginManagerNavigationBar__menu-divider border-theme-secondary-300 dark:border-theme-secondary-800"
-                    />
-                  </li>
-                  <li
-                    class="flex"
-                  >
-                    <button
-                      class="PluginManagerNavigationBar__item px-1 focus:outline-none lex items-center font-semibold text-md text-theme-secondary-text hover:text-theme-text transition-colors duration-200 cursor-pointer "
-                      data-testid="PluginManagerNavigationBar__other"
-                      title="Other"
-                    >
-                      <span>
-                        Other
-                      </span>
-                      <span
-                        class="ml-1 text-theme-secondary-500 dark:text-theme-secondary-700"
-                      >
-                        1
-                      </span>
-                    </button>
-                  </li>
-                </ul>
-              </div>
-              <div
+            <div>
+              <ul
                 class="flex h-24"
               >
-                <button
-                  class="PluginManagerNavigationBar__item px-1 focus:outline-none flex items-center font-semibold text-md text-theme-secondary-text hover:text-theme-text transition-colors duration-200 cursor-pointer "
-                  data-testid="PluginManagerNavigationBar__my-plugins"
-                  title="My Plugins"
+                <li
+                  class="flex"
                 >
-                  <span>
-                    My Plugins
-                  </span>
-                </button>
+                  <button
+                    class="PluginManagerNavigationBar__item px-1 focus:outline-none lex items-center font-semibold text-md text-theme-secondary-text hover:text-theme-text transition-colors duration-200 cursor-pointer active"
+                    data-testid="PluginManagerNavigationBar__home"
+                    title="Home"
+                  >
+                    <span>
+                      Home
+                    </span>
+                    <span
+                      class="ml-1 text-theme-secondary-500 dark:text-theme-secondary-700"
+                    >
+                      1
+                    </span>
+                  </button>
+                  <div
+                    class="my-auto mx-6 w-px h-4 border-r PluginManagerNavigationBar__menu-divider border-theme-secondary-300 dark:border-theme-secondary-800"
+                  />
+                </li>
+                <li
+                  class="flex"
+                >
+                  <button
+                    class="PluginManagerNavigationBar__item px-1 focus:outline-none lex items-center font-semibold text-md text-theme-secondary-text hover:text-theme-text transition-colors duration-200 cursor-pointer "
+                    data-testid="PluginManagerNavigationBar__gaming"
+                    title="Gaming"
+                  >
+                    <span>
+                      Gaming
+                    </span>
+                    <span
+                      class="ml-1 text-theme-secondary-500 dark:text-theme-secondary-700"
+                    >
+                      0
+                    </span>
+                  </button>
+                  <div
+                    class="my-auto mx-6 w-px h-4 border-r PluginManagerNavigationBar__menu-divider border-theme-secondary-300 dark:border-theme-secondary-800"
+                  />
+                </li>
+                <li
+                  class="flex"
+                >
+                  <button
+                    class="PluginManagerNavigationBar__item px-1 focus:outline-none lex items-center font-semibold text-md text-theme-secondary-text hover:text-theme-text transition-colors duration-200 cursor-pointer "
+                    data-testid="PluginManagerNavigationBar__utility"
+                    title="Utility"
+                  >
+                    <span>
+                      Utility
+                    </span>
+                    <span
+                      class="ml-1 text-theme-secondary-500 dark:text-theme-secondary-700"
+                    >
+                      0
+                    </span>
+                  </button>
+                  <div
+                    class="my-auto mx-6 w-px h-4 border-r PluginManagerNavigationBar__menu-divider border-theme-secondary-300 dark:border-theme-secondary-800"
+                  />
+                </li>
+                <li
+                  class="flex"
+                >
+                  <button
+                    class="PluginManagerNavigationBar__item px-1 focus:outline-none lex items-center font-semibold text-md text-theme-secondary-text hover:text-theme-text transition-colors duration-200 cursor-pointer "
+                    data-testid="PluginManagerNavigationBar__theme"
+                    title="Theme"
+                  >
+                    <span>
+                      Theme
+                    </span>
+                    <span
+                      class="ml-1 text-theme-secondary-500 dark:text-theme-secondary-700"
+                    >
+                      0
+                    </span>
+                  </button>
+                  <div
+                    class="my-auto mx-6 w-px h-4 border-r PluginManagerNavigationBar__menu-divider border-theme-secondary-300 dark:border-theme-secondary-800"
+                  />
+                </li>
+                <li
+                  class="flex"
+                >
+                  <button
+                    class="PluginManagerNavigationBar__item px-1 focus:outline-none lex items-center font-semibold text-md text-theme-secondary-text hover:text-theme-text transition-colors duration-200 cursor-pointer "
+                    data-testid="PluginManagerNavigationBar__other"
+                    title="Other"
+                  >
+                    <span>
+                      Other
+                    </span>
+                    <span
+                      class="ml-1 text-theme-secondary-500 dark:text-theme-secondary-700"
+                    >
+                      1
+                    </span>
+                  </button>
+                </li>
+              </ul>
+            </div>
+            <div
+              class="flex h-24"
+            >
+              <button
+                class="PluginManagerNavigationBar__item px-1 focus:outline-none flex items-center font-semibold text-md text-theme-secondary-text hover:text-theme-text transition-colors duration-200 cursor-pointer "
+                data-testid="PluginManagerNavigationBar__my-plugins"
+                title="My Plugins"
+              >
+                <span>
+                  My Plugins
+                </span>
+              </button>
+              <div
+                class="my-auto mx-8 w-px h-10 border-r border-theme-secondary-300 dark:border-theme-secondary-800"
+              />
+              <div
+                class="flex items-center space-x-1"
+              >
                 <div
-                  class="my-auto mx-8 w-px h-10 border-r border-theme-secondary-300 dark:border-theme-secondary-800"
-                />
-                <div
-                  class="flex items-center space-x-1"
+                  class="group"
+                  data-testid="LayoutControls__grid"
                 >
                   <div
-                    class="group"
-                    data-testid="LayoutControls__grid"
+                    class="LayoutControls__ControlButton-j2iwgi-0 jQrgSV"
+                    data-testid="LayoutControls__grid--icon"
                   >
                     <div
-                      class="LayoutControls__ControlButton-j2iwgi-0 jQrgSV"
-                      data-testid="LayoutControls__grid--icon"
+                      class="sc-gsTCUz fHxsLl"
+                      height="20"
+                      width="20"
                     >
-                      <div
-                        class="sc-gsTCUz fHxsLl"
-                        height="20"
-                        width="20"
-                      >
-                        <svg>
-                          grid-view.svg
-                        </svg>
-                      </div>
+                      <svg>
+                        grid-view.svg
+                      </svg>
                     </div>
                   </div>
+                </div>
+                <div
+                  class="group"
+                  data-testid="LayoutControls__list"
+                >
                   <div
-                    class="group"
-                    data-testid="LayoutControls__list"
+                    class="LayoutControls__ControlButton-j2iwgi-0 hcJMgX"
+                    data-testid="LayoutControls__list--icon"
                   >
                     <div
-                      class="LayoutControls__ControlButton-j2iwgi-0 hcJMgX"
-                      data-testid="LayoutControls__list--icon"
+                      class="sc-gsTCUz fHxsLl"
+                      height="20"
+                      width="20"
                     >
-                      <div
-                        class="sc-gsTCUz fHxsLl"
-                        height="20"
-                        width="20"
-                      >
-                        <svg>
-                          list-view.svg
-                        </svg>
-                      </div>
+                      <svg>
+                        list-view.svg
+                      </svg>
                     </div>
                   </div>
                 </div>
               </div>
             </div>
-          </nav>
-        </div>
+          </div>
+        </nav>
         <div
-          class="Section__SectionWrapper-sc-8cjvre-0 Aphxw"
+          class="Section__SectionWrapper-sc-8cjvre-0 gFwrwb"
         >
           <div
             class="container py-16 px-14 mx-auto "


### PR DESCRIPTION

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
![image (7)](https://user-images.githubusercontent.com/22020168/106756617-1adfac00-6638-11eb-8d05-212695aa0551.png)

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [x] My changes look good in both light AND dark mode
-   [x] The change is not hardcoded to a single network, but has multi-asset in mind
-   [x] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [x] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
