### PR TITLE
fix: increase z-index in `HeaderSearchBar`

### DIFF
--- a/src/app/components/Header/HeaderSearchBar/HeaderSearchBar.tsx
+++ b/src/app/components/Header/HeaderSearchBar/HeaderSearchBar.tsx
@@ -71,7 +71,7 @@ export const HeaderSearchBar = ({
 				<SearchBarInputWrapper
 					data-testid="header-search-bar__input"
 					ref={ref}
-					className={`absolute flex items-center text-base px-10 py-6 rounded-md shadow-xl bg-theme-background -right-4 ${
+					className={`absolute z-20 flex items-center text-base px-10 py-6 rounded-md shadow-xl bg-theme-background -right-4 ${
 						offsetClassName || "top-1/2 transform -translate-y-1/2"
 					}`}
 				>

--- a/src/domains/plugin/pages/PluginManager/__snapshots__/PluginManager.test.tsx.snap
+++ b/src/domains/plugin/pages/PluginManager/__snapshots__/PluginManager.test.tsx.snap
@@ -10129,7 +10129,7 @@ exports[`PluginManager should search for plugin 1`] = `
                     class="relative"
                   >
                     <div
-                      class="HeaderSearchBar__SearchBarInputWrapper-sc-124mt80-0 foBMUQ absolute flex items-center text-base px-10 py-6 rounded-md shadow-xl bg-theme-background -right-4 top-1/2 transform -translate-y-1/2"
+                      class="HeaderSearchBar__SearchBarInputWrapper-sc-124mt80-0 foBMUQ absolute z-20 flex items-center text-base px-10 py-6 rounded-md shadow-xl bg-theme-background -right-4 top-1/2 transform -translate-y-1/2"
                       data-testid="header-search-bar__input"
                     >
                       <div

--- a/src/domains/plugin/pages/PluginsCategory/__snapshots__/PluginsCategory.test.tsx.snap
+++ b/src/domains/plugin/pages/PluginsCategory/__snapshots__/PluginsCategory.test.tsx.snap
@@ -8490,7 +8490,7 @@ exports[`PluginsCategory should search for plugin 1`] = `
                   class="relative"
                 >
                   <div
-                    class="HeaderSearchBar__SearchBarInputWrapper-sc-124mt80-0 foBMUQ absolute flex items-center text-base px-10 py-6 rounded-md shadow-xl bg-theme-background -right-4 top-1/2 transform -translate-y-1/2"
+                    class="HeaderSearchBar__SearchBarInputWrapper-sc-124mt80-0 foBMUQ absolute z-20 flex items-center text-base px-10 py-6 rounded-md shadow-xl bg-theme-background -right-4 top-1/2 transform -translate-y-1/2"
                     data-testid="header-search-bar__input"
                   >
                     <div


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Fixes overlapping issue in Plugin Manager
![image (8)](https://user-images.githubusercontent.com/22020168/106760088-187f5100-663c-11eb-80e5-32836bbf8a01.png)

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [x] My changes look good in both light AND dark mode
-   [x] The change is not hardcoded to a single network, but has multi-asset in mind
-   [x] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [x] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
