### PR TITLE
fix: do not render empty dropdown option group

### DIFF
--- a/src/app/components/Dropdown/Dropdown.tsx
+++ b/src/app/components/Dropdown/Dropdown.tsx
@@ -40,26 +40,27 @@ export const Wrapper = styled.div<{ position?: string; variant: string }>(getSty
 const isOptionGroup = (options: DropdownOption | DropdownOptionGroup) =>
 	(options as DropdownOptionGroup).key !== undefined;
 
-const renderOptionGroup = ({ key, hasDivider, title, options }: DropdownOptionGroup, onSelect: any) => (
-	<div key={key} className="mt-4 first:mt-0">
-		{hasDivider && (
-			<div className="mx-8 -my-2">
-				<Divider dashed />
-			</div>
-		)}
-		<ul>
-			{title && (
-				<li className="block px-8 text-xs font-bold text-left uppercase whitespace-nowrap cursor-pointer text-theme-secondary-500">
-					{title}
-				</li>
+const renderOptionGroup = ({ key, hasDivider, title, options }: DropdownOptionGroup, onSelect: any) =>
+	options.length ? (
+		<div key={key} className="mt-4 first:mt-0">
+			{hasDivider && (
+				<div className="mx-8 -my-2">
+					<Divider dashed />
+				</div>
 			)}
-			{renderOptions(options, onSelect, key)}
-		</ul>
-	</div>
-);
+			<ul>
+				{title && (
+					<li className="block px-8 text-xs font-bold text-left uppercase whitespace-nowrap text-theme-secondary-500">
+						{title}
+					</li>
+				)}
+				{renderOptions(options, onSelect, key)}
+			</ul>
+		</div>
+	) : null;
 
 const renderOptions = (options: DropdownOption[] | DropdownOptionGroup[], onSelect: any, key?: string) => {
-	if (options[0] && isOptionGroup(options[0])) {
+	if (options.length && isOptionGroup(options[0])) {
 		return (
 			<div className="pt-5 pb-1">
 				{(options as DropdownOptionGroup[]).map((optionGroup: DropdownOptionGroup) =>

--- a/src/domains/transaction/components/FilterTransactions/__snapshots__/FilterTransactions.test.tsx.snap
+++ b/src/domains/transaction/components/FilterTransactions/__snapshots__/FilterTransactions.test.tsx.snap
@@ -87,7 +87,7 @@ exports[`FilterTransactions should open dropdown list with all transaction types
             </div>
             <ul>
               <li
-                class="block px-8 text-xs font-bold text-left uppercase whitespace-nowrap cursor-pointer text-theme-secondary-500"
+                class="block px-8 text-xs font-bold text-left uppercase whitespace-nowrap text-theme-secondary-500"
               >
                 CORE
               </li>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/ed0q0c

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [x] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
