### PR TITLE
test: increase `src/domains/splash` coverage to 100%

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -427,7 +427,7 @@ jobs:
                   src/domains/splash --forceExit --maxWorkers=50%
                   --logHeapUsage--watchAll=false --coverage
                   --collectCoverageFrom='["src/domains/splash/**/*.{js,jsx,ts,tsx}","!<rootDir>/build/*","!<rootDir>/dist/*","!jest.setup.js","!src/**/e2e/*.ts","!src/**/*.e2e.ts","!src/**/*.models.{js,jsx,ts,tsx}","!src/**/*.stories.{js,jsx,ts,tsx}","!src/**/*.styles.{js,jsx,ts,tsx}","!src/electron/**/*","!src/i18n/**/*","!src/tests/**/*","!src/tailwind.config.js","!src/utils/e2e-utils.ts","!src/polyfill/**/*"]'
-                  --coverageThreshold='{"./src/domains/splash/":{"branches":50,"functions":50,"lines":60,"statements":60}}'
+                  --coverageThreshold='{"./src/domains/splash/":{"branches":100,"functions":100,"lines":100,"statements":100}}'
     domains-transaction:
         runs-on: ubuntu-latest
         strategy:

--- a/scripts/generate-test-workflow.js
+++ b/scripts/generate-test-workflow.js
@@ -78,10 +78,10 @@ const directories = {
 		statements: 100,
 	},
 	"domains/splash": {
-		branches: 50,
-		functions: 50,
-		lines: 60,
-		statements: 60,
+		branches: 100,
+		functions: 100,
+		lines: 100,
+		statements: 100,
 	},
 	"domains/transaction": {
 		branches: 99.5,

--- a/src/domains/splash/pages/Splash/Splash.test.tsx
+++ b/src/domains/splash/pages/Splash/Splash.test.tsx
@@ -1,11 +1,14 @@
+import { DateTime } from "@arkecosystem/platform-sdk-intl";
 import React from "react";
 import { render } from "testing-library";
 
+import * as utils from "../../../../utils/electron-utils";
 import { translations } from "../../i18n";
 import { Splash } from "./Splash";
 
 describe("Splash", () => {
-	it("should render", () => {
+	it.each(["light", "dark"])("should  render  %s theme", (theme) => {
+		jest.spyOn(utils, "shouldUseDarkColors").mockImplementation(() => theme === "dark");
 		const { container, asFragment, getByTestId } = render(<Splash year="2020" />);
 
 		expect(container).toBeTruthy();
@@ -16,6 +19,22 @@ describe("Splash", () => {
 		expect(getByTestId("Splash__footer")).toHaveTextContent(translations.RIGHTS);
 		expect(getByTestId("Splash__footer")).toHaveTextContent(translations.PRODUCT);
 		expect(getByTestId("Splash__footer")).toHaveTextContent("2020");
+		expect(getByTestId("Splash__footer")).toHaveTextContent(translations.VERSION);
+
+		expect(asFragment()).toMatchSnapshot();
+	});
+
+	it("should render without year", () => {
+		const { container, asFragment, getByTestId } = render(<Splash />);
+
+		expect(container).toBeTruthy();
+		expect(getByTestId("Splash__text")).toHaveTextContent(translations.BRAND);
+		expect(getByTestId("Splash__text")).toHaveTextContent(translations.LOADING);
+
+		expect(getByTestId("Splash__footer")).toHaveTextContent(translations.COPYRIGHT);
+		expect(getByTestId("Splash__footer")).toHaveTextContent(translations.RIGHTS);
+		expect(getByTestId("Splash__footer")).toHaveTextContent(translations.PRODUCT);
+		expect(getByTestId("Splash__footer")).toHaveTextContent(DateTime.make().format("YYYY"));
 		expect(getByTestId("Splash__footer")).toHaveTextContent(translations.VERSION);
 
 		expect(asFragment()).toMatchSnapshot();

--- a/src/domains/splash/pages/Splash/__snapshots__/Splash.test.tsx.snap
+++ b/src/domains/splash/pages/Splash/__snapshots__/Splash.test.tsx.snap
@@ -1,6 +1,290 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Splash should render 1`] = `
+exports[`Splash should  render  dark theme 1`] = `
+<DocumentFragment>
+  <div
+    class="flex relative flex-col min-h-screen bg-theme-secondary-background"
+  >
+    <nav
+      aria-labelledby="main menu"
+      class="NavigationBar__NavWrapper-sc-1qsoskw-0 bPGMtQ"
+    >
+      <div
+        class="px-4 sm:px-6 lg:px-10"
+      >
+        <div
+          class="flex relative justify-between h-20 md:h-24"
+        >
+          <div
+            class="flex items-center my-auto"
+          >
+            <div
+              class="NavigationBar__LogoContainer-sc-1qsoskw-2 dCvhsI"
+            >
+              <svg
+                width="48"
+              >
+                ark-logo.svg
+              </svg>
+            </div>
+          </div>
+        </div>
+      </div>
+    </nav>
+    <div
+      class="flex flex-col flex-1 "
+    >
+      <div
+        class="Section__SectionWrapper-sc-8cjvre-0 Aphxw flex flex-col flex-1 justify-center text-center select-none"
+      >
+        <div
+          class="container py-16 px-14 mx-auto "
+        >
+          <div
+            class="mx-auto w-64 lg:w-96"
+          >
+            <svg>
+              welcome-banner.svg
+            </svg>
+          </div>
+          <div
+            class="mt-8"
+            data-testid="Splash__text"
+          >
+            <h1
+              class="text-4xl font-extrabold"
+            >
+              ARK Desktop Wallet
+            </h1>
+            <p
+              class="animate-pulse text-theme-secondary-text"
+            >
+              Initializing...
+            </p>
+            <div
+              class="flex justify-center mt-4"
+            >
+              <div
+                class="animate-spin"
+              >
+                <svg
+                  height="40"
+                  viewBox="0 0 40 40"
+                  width="40"
+                >
+                  <circle
+                    cx="20"
+                    cy="20"
+                    fill="transparent"
+                    r="19"
+                    stroke="var(--theme-color-secondary-800)"
+                    stroke-width="2"
+                  />
+                  <circle
+                    cx="20"
+                    cy="20"
+                    fill="transparent"
+                    r="19"
+                    stroke="var(--theme-color-primary-600)"
+                    stroke-dasharray="119.38052083641213"
+                    stroke-dashoffset="95.50441666912971"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    transform="rotate(-90 20 20)"
+                  />
+                </svg>
+              </div>
+            </div>
+          </div>
+          <div
+            class="flex fixed right-0 left-0 bottom-5 justify-center items-center text-xs font-semibold text-theme-secondary-500 dark:text-theme-secondary-700"
+            data-testid="Splash__footer"
+          >
+            <div>
+              2020 © ARK.io
+            </div>
+            <div
+              class="Divider-sc-19q4mlo-0 gSJoMw border-theme-secondary-300 dark:border-theme-secondary-800"
+              type="vertical"
+            />
+            <div>
+              All Rights Reserved
+            </div>
+            <div
+              class="Divider-sc-19q4mlo-0 gSJoMw border-theme-secondary-300 dark:border-theme-secondary-800"
+              type="vertical"
+            />
+            <div
+              class="Splash__LogoContainer-sc-1ulyvw-0 hJYohG"
+            >
+              <svg
+                width="18"
+              >
+                ark-logo.svg
+              </svg>
+            </div>
+            <div>
+              An ARK.io Product
+            </div>
+            <div
+              class="Divider-sc-19q4mlo-0 gSJoMw border-theme-secondary-300 dark:border-theme-secondary-800"
+              type="vertical"
+            />
+            <div>
+              Version 3.0.0
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`Splash should  render  light theme 1`] = `
+<DocumentFragment>
+  <div
+    class="flex relative flex-col min-h-screen bg-theme-secondary-background"
+  >
+    <nav
+      aria-labelledby="main menu"
+      class="NavigationBar__NavWrapper-sc-1qsoskw-0 bPGMtQ"
+    >
+      <div
+        class="px-4 sm:px-6 lg:px-10"
+      >
+        <div
+          class="flex relative justify-between h-20 md:h-24"
+        >
+          <div
+            class="flex items-center my-auto"
+          >
+            <div
+              class="NavigationBar__LogoContainer-sc-1qsoskw-2 dCvhsI"
+            >
+              <svg
+                width="48"
+              >
+                ark-logo.svg
+              </svg>
+            </div>
+          </div>
+        </div>
+      </div>
+    </nav>
+    <div
+      class="flex flex-col flex-1 "
+    >
+      <div
+        class="Section__SectionWrapper-sc-8cjvre-0 Aphxw flex flex-col flex-1 justify-center text-center select-none"
+      >
+        <div
+          class="container py-16 px-14 mx-auto "
+        >
+          <div
+            class="mx-auto w-64 lg:w-96"
+          >
+            <svg>
+              welcome-banner.svg
+            </svg>
+          </div>
+          <div
+            class="mt-8"
+            data-testid="Splash__text"
+          >
+            <h1
+              class="text-4xl font-extrabold"
+            >
+              ARK Desktop Wallet
+            </h1>
+            <p
+              class="animate-pulse text-theme-secondary-text"
+            >
+              Initializing...
+            </p>
+            <div
+              class="flex justify-center mt-4"
+            >
+              <div
+                class="animate-spin"
+              >
+                <svg
+                  height="40"
+                  viewBox="0 0 40 40"
+                  width="40"
+                >
+                  <circle
+                    cx="20"
+                    cy="20"
+                    fill="transparent"
+                    r="19"
+                    stroke="var(--theme-color-success-200)"
+                    stroke-width="2"
+                  />
+                  <circle
+                    cx="20"
+                    cy="20"
+                    fill="transparent"
+                    r="19"
+                    stroke="var(--theme-color-primary-600)"
+                    stroke-dasharray="119.38052083641213"
+                    stroke-dashoffset="95.50441666912971"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    transform="rotate(-90 20 20)"
+                  />
+                </svg>
+              </div>
+            </div>
+          </div>
+          <div
+            class="flex fixed right-0 left-0 bottom-5 justify-center items-center text-xs font-semibold text-theme-secondary-500 dark:text-theme-secondary-700"
+            data-testid="Splash__footer"
+          >
+            <div>
+              2020 © ARK.io
+            </div>
+            <div
+              class="Divider-sc-19q4mlo-0 gSJoMw border-theme-secondary-300 dark:border-theme-secondary-800"
+              type="vertical"
+            />
+            <div>
+              All Rights Reserved
+            </div>
+            <div
+              class="Divider-sc-19q4mlo-0 gSJoMw border-theme-secondary-300 dark:border-theme-secondary-800"
+              type="vertical"
+            />
+            <div
+              class="Splash__LogoContainer-sc-1ulyvw-0 hJYohG"
+            >
+              <svg
+                width="18"
+              >
+                ark-logo.svg
+              </svg>
+            </div>
+            <div>
+              An ARK.io Product
+            </div>
+            <div
+              class="Divider-sc-19q4mlo-0 gSJoMw border-theme-secondary-300 dark:border-theme-secondary-800"
+              type="vertical"
+            />
+            <div>
+              Version 3.0.0
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`Splash should render without year 1`] = `
 <DocumentFragment>
   <div
     class="flex relative flex-col min-h-screen bg-theme-secondary-background"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
Covered src/domains/splash to 100%

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->
Added more test cases for missed lines and branches. Changed test.yml and generate-test-workflow.js for src/domains/splash to 100

## Checklist

<!-- Have you done all of these things?  -->

-   [x] My changes look good in both light AND dark mode
-   [x] The change is not hardcoded to a single network, but has multi-asset in mind
-   [x] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
