### PR TITLE
build: remove the E2E flag for production build

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 	"main": "build/electron/index.js",
 	"scripts": {
 		"build": "yarn compile && react-app-rewired build",
-		"build:ci": "cross-env REACT_APP_IS_E2E=1 GENERATE_SOURCEMAP=false yarn build",
+		"build:ci": "cross-env GENERATE_SOURCEMAP=false yarn build",
 		"build:e2e": "cross-env REACT_APP_IS_E2E=1 GENERATE_SOURCEMAP=false yarn build",
 		"build:linux": "yarn build:ci && electron-builder --linux --publish never",
 		"build:mac": "yarn build:ci && electron-builder --mac --publish never",


### PR DESCRIPTION
## Summary

The generated artifact contains John and Jane profiles since the `build:mac` relays on this script.

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
