### PR TITLE
fix: adjust label color of transaction history setting

### DIFF
--- a/src/domains/setting/pages/Settings/__snapshots__/Settings.test.tsx.snap
+++ b/src/domains/setting/pages/Settings/__snapshots__/Settings.test.tsx.snap
@@ -1904,7 +1904,7 @@ exports[`Settings should not update the uploaded avatar when removing focus from
                               class="flex justify-between items-center space-x-5"
                             >
                               <span
-                                class="text-lg font-semibold text-theme-secondary-text"
+                                class="text-lg font-semibold text-theme-secondary-700 dark:text-theme-secondary-200"
                                 data-testid="list-divided-item__label"
                               >
                                 Portfolio Transaction History
@@ -3341,7 +3341,7 @@ exports[`Settings should render 1`] = `
                               class="flex justify-between items-center space-x-5"
                             >
                               <span
-                                class="text-lg font-semibold text-theme-secondary-text"
+                                class="text-lg font-semibold text-theme-secondary-700 dark:text-theme-secondary-200"
                                 data-testid="list-divided-item__label"
                               >
                                 Portfolio Transaction History
@@ -8323,7 +8323,7 @@ exports[`Settings should update profile 1`] = `
                               class="flex justify-between items-center space-x-5"
                             >
                               <span
-                                class="text-lg font-semibold text-theme-secondary-text"
+                                class="text-lg font-semibold text-theme-secondary-700 dark:text-theme-secondary-200"
                                 data-testid="list-divided-item__label"
                               >
                                 Portfolio Transaction History
@@ -9760,7 +9760,7 @@ exports[`Settings should update the avatar when removing focus from name input 1
                               class="flex justify-between items-center space-x-5"
                             >
                               <span
-                                class="text-lg font-semibold text-theme-secondary-text"
+                                class="text-lg font-semibold text-theme-secondary-700 dark:text-theme-secondary-200"
                                 data-testid="list-divided-item__label"
                               >
                                 Portfolio Transaction History
@@ -11210,7 +11210,7 @@ exports[`Settings should update the avatar when removing focus from name input 2
                               class="flex justify-between items-center space-x-5"
                             >
                               <span
-                                class="text-lg font-semibold text-theme-secondary-text"
+                                class="text-lg font-semibold text-theme-secondary-700 dark:text-theme-secondary-200"
                                 data-testid="list-divided-item__label"
                               >
                                 Portfolio Transaction History

--- a/src/domains/setting/pages/Settings/available-settings/General.tsx
+++ b/src/domains/setting/pages/Settings/available-settings/General.tsx
@@ -177,7 +177,6 @@ export const General = ({ formConfig, onSuccess }: SettingsProps) => {
 		},
 		{
 			label: t("SETTINGS.GENERAL.OTHER.TRANSACTION_HISTORY.TITLE"),
-			labelClass: "text-lg font-semibold text-theme-secondary-text",
 			labelDescription: t("SETTINGS.GENERAL.OTHER.TRANSACTION_HISTORY.DESCRIPTION"),
 			labelAddon: (
 				<Toggle


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/fd58ne

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
